### PR TITLE
docs(adr): Edge Function vs SQL RPC selection — ADR v1 + 4-layer enforcement

### DIFF
--- a/.claude/skills/infrastructure-guidelines/SKILL.md
+++ b/.claude/skills/infrastructure-guidelines/SKILL.md
@@ -71,6 +71,8 @@ await supabase.from('users').select('..., user_roles_projection!inner(...)')
 
 `api.` schema RPCs enforce tenant isolation via `SECURITY INVOKER` and JWT claim helpers (`get_current_org_id()`, `has_platform_privilege()`) — direct table reads bypass this boundary.
 
+**Choosing between SQL RPC and Edge Function for a write operation**: See Rule 14 below.
+
 ## 5. `domain_events` Is the Sole Audit Trail
 
 There is NO separate audit table. All state changes are domain events. **Never create audit/log tables** — query `domain_events` instead.
@@ -306,6 +308,35 @@ $$;
 ```
 
 **Real incident (2026-02-23)**: `api.delete_organization_unit()` lacked the read-back guard (5th of 5 org-unit RPCs; other 4 had been fixed in `20260221173821`). Frontend silently received `{success: false}` because the handler's column-name mismatch was invisible to the caller. Fix migration: `20260223163610_fix_delete_org_unit_projection_guard.sql`.
+
+## 14. Edge Function vs SQL RPC Selection
+
+**Before creating a new Edge Function, consult [adr-edge-function-vs-sql-rpc.md](../../../documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md).** SQL RPC is the default for write operations; Edge Function requires meeting one of six load-bearing criteria (LB1–LB6):
+
+- **LB1** — Mints auth tokens or creates `auth.users` rows (Supabase Auth admin API)
+- **LB2** — Calls external APIs (Cloudflare, Resend, Backend API, Temporal)
+- **LB3** — Forwards to workflow orchestration layer
+- **LB4** — Unauthenticated entry point with bespoke token validation
+- **LB5** — Cross-tier read orchestration (Temporal status, external queues)
+- **LB6** — Emits to a stream whose caller's JWT cannot be RLS-authorized (pre-user events)
+
+An operation meeting **zero** of LB1–LB6 is `candidate-for-extraction` → write as SQL RPC.
+
+**Opportunistic-migration nudge**: When touching an Edge Function operation classified `candidate-for-extraction` in the ADR's inventory, prefer extracting that operation to an SQL RPC in the same PR.
+
+```typescript
+// ✅ CORRECT (new Edge Function) — ADR citation in top-of-file comment
+/**
+ * ADR: documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md
+ * Load-bearing criterion: LB2 (Resend API)
+ */
+```
+
+CI check `.github/workflows/supabase-edge-functions-lint.yml` enforces ADR citation on NEW Edge Function files (`git diff --diff-filter=A`). Does NOT block modifications to existing files.
+
+**Explicit non-criterion**: Service-role reads of non-`api.` tables are NOT load-bearing. A `SECURITY DEFINER` SQL RPC can read any table. Don't keep an op in an Edge Function just because it reads outside the `api.` schema — extract it.
+
+**Edge Functions are the orchestration tier**: Rule 4 (frontend → `api.` RPC only) is a browser-facing contract. Edge Functions run server-side with service-role credentials; they may read any table when needed. This is a CQRS-rule exemption, not a violation.
 
 ---
 

--- a/.github/workflows/supabase-edge-functions-lint.yml
+++ b/.github/workflows/supabase-edge-functions-lint.yml
@@ -1,0 +1,64 @@
+name: Edge Function ADR Citation Check
+
+# Enforces that NEW Edge Function files cite adr-edge-function-vs-sql-rpc.md in a
+# top-of-file comment. See documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md
+# Decision 6 (Layer 4) for rationale.
+#
+# Scope: NEW files only (git diff --diff-filter=A). Modifications to existing Edge
+# Function files are NOT blocked — retrofitting the 7 functions that predate this
+# ADR would manufacture churn. New additions must justify load-bearing classification
+# by citing the ADR and naming the LB criterion they meet.
+
+on:
+  pull_request:
+    paths:
+      - 'infrastructure/supabase/supabase/functions/**'
+
+jobs:
+  check-adr-citation:
+    name: Check new Edge Function files cite the ADR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Identify new Edge Function index.ts files
+        id: identify
+        run: |
+          git fetch origin ${{ github.base_ref }} --depth=1
+          NEW_FILES=$(git diff --name-only --diff-filter=A \
+            origin/${{ github.base_ref }}...HEAD \
+            | grep -E '^infrastructure/supabase/supabase/functions/[^/]+/index\.ts$' \
+            || true)
+          if [ -z "$NEW_FILES" ]; then
+            echo "No new Edge Function files added in this PR"
+            echo "new_files=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "New Edge Function files detected:"
+          echo "$NEW_FILES"
+          {
+            echo "new_files<<EOF"
+            echo "$NEW_FILES"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Verify each new file cites the ADR
+        if: steps.identify.outputs.new_files != ''
+        run: |
+          FAILED=0
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            if ! grep -q 'adr-edge-function-vs-sql-rpc' "$f"; then
+              echo "::error file=$f,title=Missing ADR citation::New Edge Function must cite adr-edge-function-vs-sql-rpc.md in a top-of-file comment. See documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md (Decision 6 / Layer 4). Required block:"
+              echo "::error::  /**"
+              echo "::error::   * ADR: documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md"
+              echo "::error::   * Load-bearing criterion: <which LB this meets, e.g. 'LB2 (Resend API)'>"
+              echo "::error::   */"
+              FAILED=1
+            else
+              echo "OK: $f cites the ADR"
+            fi
+          done <<< "${{ steps.identify.outputs.new_files }}"
+          exit $FAILED

--- a/.github/workflows/supabase-edge-functions-lint.yml
+++ b/.github/workflows/supabase-edge-functions-lint.yml
@@ -27,7 +27,10 @@ jobs:
         id: identify
         run: |
           git fetch origin ${{ github.base_ref }} --depth=1
-          NEW_FILES=$(git diff --name-only --diff-filter=A \
+          # --no-renames forces renames/copies to show as delete+add so that
+          # moving a file into the functions tree (e.g. from a prototype dir)
+          # correctly registers as a new Edge Function requiring citation.
+          NEW_FILES=$(git diff --name-only --no-renames --diff-filter=A \
             origin/${{ github.base_ref }}...HEAD \
             | grep -E '^infrastructure/supabase/supabase/functions/[^/]+/index\.ts$' \
             || true)

--- a/.github/workflows/supabase-edge-functions-lint.yml
+++ b/.github/workflows/supabase-edge-functions-lint.yml
@@ -4,10 +4,16 @@ name: Edge Function ADR Citation Check
 # top-of-file comment. See documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md
 # Decision 6 (Layer 4) for rationale.
 #
-# Scope: NEW files only (git diff --diff-filter=A). Modifications to existing Edge
-# Function files are NOT blocked — retrofitting the 7 functions that predate this
-# ADR would manufacture churn. New additions must justify load-bearing classification
-# by citing the ADR and naming the LB criterion they meet.
+# Scope: NEW files only (git diff --diff-filter=A --no-renames). Modifications to
+# existing Edge Function files are NOT blocked — retrofitting the 7 functions that
+# predate this ADR would manufacture churn. New additions must justify load-bearing
+# classification by citing the ADR and naming the LB criterion they meet.
+#
+# Known limitations (CI v1): The check is a substring match on the ADR filename
+# fragment. It does NOT validate the full citation block's JSDoc shape, and it only
+# matches files named `index.ts` per the path regex below. A new Edge Function using
+# `server.ts` / `main.ts` / split across multiple files would silently pass. See the
+# "CI v1 known limitations" note in the ADR's Decision 6 / Layer 4 section.
 
 on:
   pull_request:

--- a/dev/active/edge-function-vs-sql-rpc-adr/edge-function-vs-sql-rpc-adr-context.md
+++ b/dev/active/edge-function-vs-sql-rpc-adr/edge-function-vs-sql-rpc-adr-context.md
@@ -1,0 +1,137 @@
+# Edge Function vs SQL RPC Selection ADR — Context
+
+**Feature**: ADR + guard rails + CI check + migration backlog for choosing between Edge Functions and SQL RPCs in A4C-AppSuite
+**Status**: 🟢 ACTIVE — Planning complete, awaiting user LGTM before Phase 1 ADR drafting
+**Activated**: 2026-04-24 (after PR #32 merge; satisfies Blocker-3-followup-6)
+**Current branch**: `docs/edge-function-vs-sql-rpc-adr`
+**Architect pre-review**: `software-architect-dbc` agent `afc812e89a6fbed46` (2026-04-24) — **LGTM-with-remediation**; all 3 MUST-FIX items + 6 SHOULD-ADD items folded into this plan revision.
+**Origin**: Raised by `software-architect-dbc` agent `a060ef3faaa5b630c` during PR #32 review. When auditing `manage-user` v11's move to Pattern A v2, the architect concluded a SQL RPC wrapper around `update_notification_preferences` would be "strictly superior architecturally" (single-transaction PL/pgSQL read-back, no two-client-call round-trip), but correctly deferred the refactor to an ADR pass. This dev-doc is that pass.
+
+## Problem Statement
+
+The codebase has two orthogonal ways to implement write operations:
+
+1. **SQL RPCs** — PL/pgSQL functions in the `api.` schema, called by frontend via `supabase.schema('api').rpc(...)`. Single round-trip. RLS + JWT claim helpers enforce auth. Pattern A v2 projection read-back is built into every write RPC after the 2026-04-23 retrofit.
+
+2. **Edge Functions** — Deno TypeScript modules under `infrastructure/supabase/supabase/functions/`, called by frontend via `supabase.functions.invoke(...)`. Run in Deno Deploy. Can hold Supabase Auth admin secrets, call external APIs, forward to the Backend API / Temporal workflow layer, and serve unauthenticated endpoints with bespoke token validation.
+
+We have no written criteria for choosing between them. As a consequence:
+
+- Operations that are really "DB write + auth check + permission check + projection read-back" sometimes land as Edge Functions, because the broader Edge Function already exists and adding a case is easier than extracting to SQL RPC. (`manage-user update_notification_preferences` is the worked example.)
+- Pattern A v2 read-back semantics had to be re-implemented in TypeScript in `manage-user` v11 (two separate `supabase.from()` calls to `domain_events` + projection table) where a SQL RPC would have had atomic in-transaction read-back.
+- New contributors can't tell which tool to reach for.
+
+## Scope
+
+### In scope
+- **ADR** at `documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md` establishing:
+  - Selection criteria — 5 load-bearing positive indicators + 1 negative indicator + ambiguous-middle rubric
+  - Classification of every currently-deployed Edge Function operation against those criteria
+  - Explicit **out-of-scope boundary** for Temporal activities (`workflows/`) — they are a third tier governed by workflow-side patterns, NOT covered by this ADR
+  - Cross-links to `adr-rpc-readback-pattern.md` and CQRS docs
+- **Guard rail update** at `infrastructure/CLAUDE.md` + `.claude/skills/infrastructure-guidelines/SKILL.md` (Layer 2)
+- **CI check** — lightweight grep ensuring NEW `supabase/functions/*/index.ts` files cite the ADR in a top-of-file comment (Layer 4, per architect SA2)
+- **Follow-up task backlog**: one dev-doc card under `dev/active/` per `candidate-for-extraction` op identified in the inventory (Layer 3)
+
+### Out of scope
+- **Actually extracting operations**: this ADR is criteria + classification + mechanism only. Each extraction is its own PR gated by its own dev-doc.
+- **Retrofitting existing Edge Functions with Pattern A v2 read-back** (deactivate/reactivate/modify_roles in `manage-user` — per architect MF3 — are separately tracked, NOT cited as reference implementations in this ADR).
+- **Temporal activities in `workflows/`**: they share Edge Functions' service-role access but have different failure semantics (saga compensation vs. HTTP response). Declared out-of-scope in ADR body.
+- **New Edge Function development guide**: keep the ADR focused on the selection decision. Broader dev-guide content stays in `infrastructure/CLAUDE.md` and existing Edge Function docs.
+
+## Four-Layered Approach (authoritative design, expanded per architect SA2)
+
+This is the load-bearing plan shape. All four layers ship together.
+
+### Layer 1 — ADR as authoritative criteria
+
+The ADR is the source of truth. Every guard rail and every migration card **forward-links** to it. Criteria section enumerates the positive indicators that make Edge Function the correct choice:
+
+1. **Mints auth tokens / creates `auth.users` rows** (Supabase Auth admin API)
+2. **Calls external APIs** (Cloudflare, Resend, Backend API, Temporal, any non-Postgres/non-Supabase-internal service)
+3. **Forwards to workflow orchestration layer** (Backend API → Temporal workflow trigger)
+4. **Unauthenticated entry point with bespoke token validation** (invitation token, password reset, public webhooks — no JWT required; enforcing rate-limiting + correlation-id business-scope lookup is easier in TypeScript than in `anon`-callable SQL)
+5. **Read orchestration of cross-tier state** (Temporal workflow status readback, external job queue introspection — not answerable by a single `api.` schema SELECT)
+
+Negative indicator (→ prefer SQL RPC):
+
+- Pure projection mutation + auth check + permission check + Pattern A v2 read-back, with **all I/O confined to PostgreSQL**. This is the `manage-user update_notification_preferences` shape.
+
+**Explicit non-criterion** (architect MF1): "Service-role reads of non-`api.` tables" is NOT load-bearing. A `SECURITY DEFINER` SQL RPC with `SET search_path` can SELECT anything. The CQRS `api.` schema rule is a frontend-query-path boundary, not a PL/pgSQL capability boundary.
+
+### Layer 2 — SKILL.md + CLAUDE.md guard rail on new code
+
+The guard rail catches **new** work opportunistically:
+
+- `infrastructure/CLAUDE.md` gets a new rule: *"Before creating a new Edge Function, consult [adr-edge-function-vs-sql-rpc.md]. SQL RPC is the default; Edge Function requires meeting one of the load-bearing criteria there."*
+- `.claude/skills/infrastructure-guidelines/SKILL.md` mirrors the one-line rule so the skill-activation check surfaces it whenever an agent begins infrastructure work.
+
+Opportunistic-migration nudge (separate rule in both files): *"When touching an Edge Function operation classified `candidate-for-extraction` in the ADR's inventory, prefer extracting that operation to an SQL RPC in the same PR."*
+
+### Layer 3 — ADR inventory table = migration backlog
+
+Every current Edge Function operation is classified in the ADR (inventory completed as part of this plan — see `plan.md` Phase 0):
+
+| Classification | Meaning | Next action |
+|----------------|---------|-------------|
+| `load-bearing` | Meets ≥1 positive indicator | None |
+| `candidate-for-extraction` | Meets 0 positive indicators (pure DB + auth + perm + read-back) | Open dev-doc card under `dev/active/<function>-to-sql-rpc/` |
+| `partial-candidate` | (Function-level only) — some ops load-bearing, some candidate | One dev-doc card per candidate op |
+
+Each candidate op becomes a dev-doc under `dev/active/<function>-to-sql-rpc/`, with the Blocker-3-followup-7 intent (`manage-user update_notification_preferences`) as the reference template.
+
+### Layer 4 — CI check on new Edge Function file creation (per architect SA2)
+
+**Scope**: NEW-file-only (zero retrofit for the 7 existing functions, avoiding manufactured churn).
+
+A lightweight CI grep enforces that every new file under `supabase/functions/*/index.ts` cites the ADR at the top of the file:
+
+```typescript
+/**
+ * ADR: documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md
+ * Load-bearing criterion: <which positive indicator this function meets>
+ */
+```
+
+If the comment is missing from a newly-created file, CI fails with a pointer to the ADR's criteria section. Adds a zero-runtime guard on the decision point that SKILL.md rule #2 nudges.
+
+Implementation: single grep-based job in `.github/workflows/supabase-edge-functions-lint.yml` (new file, ~20 lines of bash); triggered on `supabase/functions/**` path changes. Does NOT block touching existing files.
+
+**Why four layers, not three**: Layer 2 (SKILL.md + CLAUDE.md) depends on an agent loading the skill during work — fine for Claude-driven contributions but weak for human PRs that bypass the skill. Layer 4's CI grep is the backstop. Small investment; closes the gap.
+
+## Considerations
+
+- **SQL RPC parity gap**: SQL RPCs can't call external APIs, mint Supabase admin tokens, or serve unauthenticated-but-authorized endpoints without significant ceremony. The criteria must make these bright lines explicit — `load-bearing` classifications always anchor on one of LB1–LB5.
+- **Multiple events in one operation**: SQL RPCs can emit multiple events in a single transaction (`api.update_role` emits 1 + N + M events). Not a differentiator.
+- **Observability**: Edge Functions log to Deno Deploy; SQL RPCs log via `RAISE NOTICE` / `domain_events.processing_error`. The ADR notes the observability trade-off per classification.
+- **Deploy cadence** (per architect BS6): Edge Functions deploy via `supabase functions deploy`; SQL RPCs deploy via migrations. Migration → Edge Function deploy is an ordered dependency at migration time. Extracting an op from Edge Function to SQL RPC **consolidates two deploy surfaces into one** — subtle but real improvement, noted in ADR's Consequences section.
+- **Pattern A v2 compliance for load-bearing writes** (per architect BS2): Load-bearing Edge Functions that do DB writes MUST conform to `{success, <entity>}` response shape per `adr-rpc-readback-pattern.md` Decision 4. `manage-user` v11 does this; the ADR codifies it.
+- **AsyncAPI contract invariance** (per architect BS3): Migrating an op from Edge Function to SQL RPC does **not** change AsyncAPI event definitions (`stream_type`/`event_type` stay the same). Stated explicitly to prevent "do I need to re-register events?" panic during extraction.
+- **Rollout risk**: Migrating from Edge Function to SQL RPC changes the frontend call site (`functions.invoke()` → `rpc()`). Backward-compat is not free. Each `candidate` card owns its own rollout plan.
+
+## Relationship to Other Work
+
+- **Depends on**: `adr-rpc-readback-pattern.md` (Pattern A v2 is the SQL-RPC-side contract; this ADR cites it as the minimum bar any extraction must clear).
+- **Unblocks**: Blocker-3-followup-7 (`manage-user` → SQL RPC extraction, specifically `update_notification_preferences` as the first op). Architect `a060ef3faaa5b630c` already validated the extraction as "strictly superior architecturally".
+- **Interacts with**: CQRS rule in `infrastructure/CLAUDE.md` Rule 4 (frontend → `api.` RPC only). The ADR clarifies that Rule 4 applies to **browser-facing** clients; Edge Functions (orchestration tier) are exempt and can read any table via service-role. This was implicit in the `invite-user` and `manage-user` v11 patterns but has never been written down.
+- **Out-of-scope boundary (BS1)**: Temporal activities under `workflows/` share Edge Functions' service-role access but different failure semantics. ADR declares them out-of-scope and defers governance to workflow-side patterns.
+- **Companion updates**: One-line cross-link added to `adr-rpc-readback-pattern.md` Related Documentation section.
+
+## Reference Materials
+
+- PR #32 architect review (`software-architect-dbc` agent `a060ef3faaa5b630c`) — strictly-superior finding + Edge-Function-as-orchestration-tier validation
+- PR #32 plan pre-review (`software-architect-dbc` agent `afc812e89a6fbed46`, 2026-04-24) — LGTM-with-remediation + 3 MUST-FIX + 6 SHOULD-ADD folded into this revision
+- `infrastructure/supabase/supabase/functions/manage-user/index.ts` (v11) — reference implementation of Pattern A v2 in an Edge Function, **scoped to `update_notification_preferences` only** per architect MF3 (other ops still have the pre-v11 gap)
+- `infrastructure/supabase/supabase/functions/invite-user/index.ts` — precedent for service-role direct-table reads (`organizations_projection`)
+- `documentation/architecture/decisions/adr-rpc-readback-pattern.md` — SQL-RPC-side contract
+- `documentation/architecture/decisions/adr-client-ou-placement.md` — example of an ADR with enforcement/rollout history section
+- `infrastructure/CLAUDE.md` Rule 4 (CQRS), Rule 9 (API functions), Rule 13 (projection read-back guard)
+- `dev/archived/api-rpc-readback-pattern/` — adjacent work that motivated this ADR
+
+## Important Constraints
+
+- **ADR must ship before followup-7 starts**: the `manage-user update_notification_preferences` extraction plan depends on this ADR's criteria being final.
+- **No rewrites in this PR**: Layer 3's inventory classifies, it doesn't execute. Keep the PR tight — drift between criteria and execution is high-risk.
+- **Four layers land together**: Layers 1 + 2 + 3 + 4 ship in the same PR so no forward-link target is ever dangling and the CI check is active when the first new Edge Function hits main.
+- **Anti-staleness**: follow SKILL.md Rule 8 — no hardcoded inventory counts in the ADR's criteria section. The inventory **table** is a point-in-time snapshot with a date stamp; the criteria are the durable part. A grep recipe is embedded so future readers can re-audit without trusting the snapshot.
+- **ADR versioning** (per architect SA3): `**ADR version**: v1` in frontmatter; future revisions append Rollout history entries + migration notes in `MEMORY.md`.

--- a/dev/active/edge-function-vs-sql-rpc-adr/edge-function-vs-sql-rpc-adr-plan.md
+++ b/dev/active/edge-function-vs-sql-rpc-adr/edge-function-vs-sql-rpc-adr-plan.md
@@ -78,8 +78,8 @@ See `edge-function-vs-sql-rpc-adr-context.md` for full scope. Summary:
 **Totals** (anti-staleness note: this is a point-in-time snapshot. Regenerate via `find infrastructure/supabase/supabase/functions -name 'index.ts' -not -path '*/_shared/*' | xargs wc -l` + per-op inspection):
 
 - **16 total operations** across 7 functions
-- **13 load-bearing**: 4 in `accept-invitation`, 2 in `invite-user`, 2 in `manage-user`, 1 each in `organization-bootstrap`, `organization-delete`, `validate-invitation`, `workflow-status`
-- **3 candidate-for-extraction**: `invite-user revoke`, `manage-user delete`, `manage-user modify_roles`, plus the reference-impl `manage-user update_notification_preferences` (= **4 candidates** including the architect-validated first target)
+- **12 load-bearing**: 4 in `accept-invitation`, 2 in `invite-user`, 2 in `manage-user`, 1 each in `organization-bootstrap`, `organization-delete`, `validate-invitation`, `workflow-status`
+- **4 candidate-for-extraction**: `invite-user revoke`, `manage-user delete`, `manage-user modify_roles`, `manage-user update_notification_preferences` (also sole Pattern A v2 reference implementation per Decision 5 — architect-validated first target)
 
 ### Function-level composition
 

--- a/dev/active/edge-function-vs-sql-rpc-adr/edge-function-vs-sql-rpc-adr-plan.md
+++ b/dev/active/edge-function-vs-sql-rpc-adr/edge-function-vs-sql-rpc-adr-plan.md
@@ -1,0 +1,260 @@
+# Edge Function vs SQL RPC Selection ADR — Plan
+
+## Executive Summary
+
+Ship an ADR that establishes selection criteria between Edge Functions and SQL RPCs, classifies every current Edge Function **operation** (per-op, not per-function) against those criteria, and lands a **four-layer** enforcement mechanism: (1) ADR as authoritative criteria, (2) SKILL.md + CLAUDE.md guard rail on new work, (3) ADR inventory table as migration backlog, (4) CI grep ensuring new Edge Functions cite the ADR.
+
+**Why now**: PR #32 architect `a060ef3faaa5b630c` flagged `manage-user update_notification_preferences` as "strictly superior architecturally" as a SQL RPC and deferred the refactor to this ADR pass. Without written criteria, the team can't start the refactor, can't predict what the next Edge Function should be, and can't answer "should I extract this op?" consistently.
+
+**Pre-review**: `software-architect-dbc` agent `afc812e89a6fbed46` reviewed this plan 2026-04-24. Verdict: **LGTM-with-remediation**. All 3 MUST-FIX + 6 SHOULD-ADD items have been folded in (see "Architect-driven revisions" section below). Phase 0 inventory promoted from execution phase to plan completion per architect SA4/Q6.
+
+## Scope
+
+See `edge-function-vs-sql-rpc-adr-context.md` for full scope. Summary:
+
+- **In scope**: ADR file + 2 guard-rail edits + 1 CI workflow + N new follow-up cards seeded from inventory
+- **Out of scope**: Actual extractions (each becomes its own PR per its own card); Pattern A v2 retrofit of `manage-user` non-notification-pref ops; Temporal activities in `workflows/`; new-Edge-Function dev guide
+- **Exclusions**: Don't touch `adr-rpc-readback-pattern.md` except for the single cross-link; don't change Pattern A v2 semantics
+
+## Architect-driven revisions (folded from pre-review 2026-04-24)
+
+### MUST-FIX resolutions
+
+- **MF1 — Criteria inconsistency resolved**. Original "service-role reads of non-`api.` tables" was a false-positive load-bearing indicator. Removed from positive list; added explicit "Explicit non-criterion" note in ADR body citing that `SECURITY DEFINER` SQL RPCs can read any table. Final positive indicator list is 5 items (LB1–LB5 in context.md Layer 1).
+- **MF2 — Phase 0 framing corrected**. Plan now treats the inventory as **plan completion** data (below), not a first-step-of-execution. The `manage-user update_notification_preferences` classification is framed explicitly as the **motivating worked example** that calibrates the heuristic; Phase 0 tests the heuristic against the other 6 functions.
+- **MF3 — Pattern A v2 reference-impl scope tightened**. ADR cites `manage-user update_notification_preferences` (v11) ONLY as the Pattern A v2 reference implementation. Other `manage-user` ops (`deactivate`, `reactivate`, `delete`, `modify_roles`) still have the pre-v11 silent-failure shape; ADR flags them as "Pattern A v2 retrofit TBD" rows in the inventory notes column. Retrofit is a separate follow-up card, NOT part of this ADR.
+
+### SHOULD-ADD integrations
+
+- **SA1 — Fifth positive indicator added**: "Emits to a stream the caller's JWT cannot be RLS-authorized" (e.g., `accept-invitation` creates user + emits `user.created` before the user exists in `auth.users`). Captured as LB6 in Phase 0 inventory.
+- **SA2 — CI check as Layer 4**: New `.github/workflows/supabase-edge-functions-lint.yml` ensures new `supabase/functions/*/index.ts` files cite the ADR. NEW-file-only (zero retrofit for existing 7). See context.md Layer 4.
+- **SA3 — ADR versioning**: `**ADR version**: v1` added to frontmatter. Future revisions must append Rollout history + `MEMORY.md` note.
+- **SA4 — Phase 0 moved to plan completion**: DONE (this revision).
+- **SA5 — Read-orchestration sub-category**: LB5 positive indicator covers `workflow-status` shape ("Read orchestration of cross-tier state"). Explicitly named in context.md Layer 1 criteria list.
+- **SA6 — Hybrid-case walkthrough**: ADR body includes a worked example of `organization-delete` (permission check in Edge Function + forward to Backend API + calls `api.` RPC for soft-delete) as the canonical "hybrid load-bearing" case. Prevents future classifiers from forcing hybrid functions into a single bucket.
+
+### Blind-spot coverage
+
+- **BS1 — Temporal activities out-of-scope boundary**: Declared explicitly in context.md Scope section + ADR body.
+- **BS2 — Load-bearing Edge Function write shape**: ADR codifies `{success, <entity>}` response format per `adr-rpc-readback-pattern.md` Decision 4.
+- **BS3 — AsyncAPI invariance during extraction**: One-line note in Consequences section.
+- **BS4 — LB4 (unauthenticated token validation)**: Integrated as positive indicator #4 in LB criteria.
+- **BS5 — auth-user minting sub-case**: Called out under LB1.
+- **BS6 — Deploy-surface consolidation**: Noted in Consequences section.
+
+## Phase 0 — Edge Function Inventory ✅ COMPLETE (2026-04-24, plan completion data)
+
+**Method**: Per-operation classification across all 7 deployed Edge Functions (3,390 total LOC). Each operation assessed against LB1–LB6:
+- **LB1** — Mints auth tokens / creates `auth.users` rows
+- **LB2** — Calls external APIs (non-Postgres, non-Supabase-internal)
+- **LB3** — Forwards to workflow-orchestration layer (Backend API → Temporal)
+- **LB4** — Unauthenticated entry point with bespoke token validation
+- **LB5** — Read orchestration of cross-tier state (Temporal status, external queues)
+- **LB6** — Emits to a stream whose caller's JWT cannot be RLS-authorized (pre-user events)
+
+**Classification rule**: ≥1 ✅ across LB1–LB6 = `load-bearing`; 0 ✅ = `candidate-for-extraction`. Function-level mixing yields `partial-candidate`.
+
+### Inventory Table (as of 2026-04-24, files totaling 3,390 LOC)
+
+| # | Function | Operation | LB1 | LB2 | LB3 | LB4 | LB5 | LB6 | Classification | Notes |
+|---|----------|-----------|-----|-----|-----|-----|-----|-----|----------------|-------|
+| 1 | `accept-invitation` | email/password + oauth user creation | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | **load-bearing** | Mints auth user; LB4 invitation-token auth; LB6 pre-user events |
+| 2 | `accept-invitation` | emit `user.role.assigned` | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | **load-bearing** | LB4 + LB6 |
+| 3 | `accept-invitation` | emit `user.phone.added` + `user.notification_preferences.updated` | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | **load-bearing** | LB4 + LB6 |
+| 4 | `accept-invitation` | query organization for redirect | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | **load-bearing** | LB4 — unauthenticated via invitation token |
+| 5 | `invite-user` | `create` | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | **load-bearing** | LB1 (ensures auth.users) + LB2 (Resend API email) |
+| 6 | `invite-user` | `resend` | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | **load-bearing** | LB2 (Resend API) |
+| 7 | `invite-user` | `revoke` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | **candidate-for-extraction** | Pure RPC + event emission on existing invitation |
+| 8 | `manage-user` | `deactivate` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | **load-bearing** | LB1 — `auth.admin.updateUserById` ban-state sync. **Pattern A v2 retrofit TBD** — still pre-v11 emit-and-return shape |
+| 9 | `manage-user` | `reactivate` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | **load-bearing** | LB1 — ban-state unban. **Pattern A v2 retrofit TBD** |
+| 10 | `manage-user` | `delete` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | **candidate-for-extraction** | Pure RPC + event; no auth API calls. **Pattern A v2 retrofit TBD** (currently emit-and-return; extraction inherits the fix) |
+| 11 | `manage-user` | `modify_roles` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | **candidate-for-extraction** | Pure RPC + 1+N+M events. **Pattern A v2 retrofit TBD** |
+| 12 | `manage-user` | `update_notification_preferences` (v11) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | **candidate-for-extraction** | **Pattern A v2 reference implementation** (two-step read-back); architect-validated as first extraction target |
+| 13 | `organization-bootstrap` | initiate workflow | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | **load-bearing** | LB3 (Backend API forward) + LB5 (workflow status response) |
+| 14 | `organization-delete` | trigger deletion | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | **load-bearing** | LB3 + LB5. **Hybrid case** — permission check + `api.` RPC + workflow forward. ADR uses this as the canonical hybrid walkthrough (SA6) |
+| 15 | `validate-invitation` | lookup + validate | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | **load-bearing** | LB4 — unauthenticated bespoke token validation. Token validation + correlation-id business-scope lookup is easier in TypeScript than `anon`-callable SQL |
+| 16 | `workflow-status` | query status | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | **load-bearing** | LB5 — orchestration-tier read of Temporal state |
+
+**Totals** (anti-staleness note: this is a point-in-time snapshot. Regenerate via `find infrastructure/supabase/supabase/functions -name 'index.ts' -not -path '*/_shared/*' | xargs wc -l` + per-op inspection):
+
+- **16 total operations** across 7 functions
+- **13 load-bearing**: 4 in `accept-invitation`, 2 in `invite-user`, 2 in `manage-user`, 1 each in `organization-bootstrap`, `organization-delete`, `validate-invitation`, `workflow-status`
+- **3 candidate-for-extraction**: `invite-user revoke`, `manage-user delete`, `manage-user modify_roles`, plus the reference-impl `manage-user update_notification_preferences` (= **4 candidates** including the architect-validated first target)
+
+### Function-level composition
+
+| Function | Composition | Next action |
+|----------|------------|-------------|
+| `accept-invitation` | All 4 ops load-bearing | None |
+| `invite-user` | **partial-candidate** (2 load-bearing + 1 candidate `revoke`) | Seed card for `revoke` |
+| `manage-user` | **partial-candidate** (2 load-bearing + 3 candidates) | Seed cards for `update_notification_preferences` (first), `delete`, `modify_roles` |
+| `organization-bootstrap` | 1 op load-bearing | None |
+| `organization-delete` | 1 op load-bearing (hybrid) | None |
+| `validate-invitation` | 1 op load-bearing | None |
+| `workflow-status` | 1 op load-bearing | None |
+
+### Ambiguous cases requiring explicit ADR guidance
+
+1. **`manage-user update_notification_preferences`** — architect-validated candidate; Pattern A v2 already present in TypeScript. Extraction economics: the two-step read-back is already complex enough to motivate moving to SQL (single-transaction in-PL/pgSQL is simpler). Resolution: candidate, first extraction target.
+2. **`validate-invitation`** — LB4 pure-read with no external API. Could theoretically be an `anon`-callable `api.*` RPC, but rate limiting + correlation-id lookup is awkward in SQL. ADR explicitly treats LB4-alone as load-bearing; resolution: keep as Edge Function.
+3. **`organization-bootstrap` / `organization-delete`** — "gateway" functions that forward to Backend API. ADR walks `organization-delete` as the canonical hybrid example (SA6). Resolution: load-bearing via LB3.
+
+**DoD for Phase 0**: ✅ Complete — user confirms this inventory before Phase 1 starts.
+
+## Phase Summary (remaining phases)
+
+| Phase | Description | Effort | Deliverable |
+|-------|------------|--------|-------------|
+| 1 | Draft ADR: context / decision / criteria / inventory / rollout / consequences | Medium | `documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md` |
+| 2 | Guard rail updates: `infrastructure/CLAUDE.md` + `.claude/skills/infrastructure-guidelines/SKILL.md` | Small | 2 edits, both forward-linking the ADR |
+| 3 | Navigation + cross-links: `documentation/AGENT-INDEX.md` + cross-link from `adr-rpc-readback-pattern.md` | Small | 2 edits |
+| 4 | **CI check** (new workflow file enforcing ADR citation in new Edge Function files) | Small | `.github/workflows/supabase-edge-functions-lint.yml` |
+| 5 | Seed 4 follow-up cards under `dev/active/` for the 4 `candidate` ops | Small | 4 dev-doc folders (template: this one) |
+| 6 | Verification + PR | Small | PR opened against `main` |
+
+All phases ship together in one PR.
+
+## Phase 1 — Draft ADR
+
+**Path**: `documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md`
+
+**Required structure** (per `documentation/AGENT-GUIDELINES.md`):
+
+- YAML frontmatter: `status: current`, `last_updated: <commit day>`, `adr_version: v1` (per SA3)
+- TL;DR block (between `<!-- TL;DR-START -->` / `<!-- TL;DR-END -->`):
+  - **Summary**: 1–2 sentences
+  - **When to read**: 2–4 SPECIFIC scenarios (e.g. "Creating a new Edge Function or write RPC", "Reviewing a PR that adds operation X to `manage-user`", "Classifying a `candidate` op in the inventory")
+  - **Prerequisites**: link `adr-rpc-readback-pattern.md`, `event-handler-pattern.md`
+  - **Key topics** (3–6 backticked): `adr`, `edge-function`, `sql-rpc`, `orchestration-tier`, `cqrs`
+  - **Estimated read time** (round to 5 min)
+- Body sections:
+  - **Context** — silent-friction-to-choose problem; cite PR #32 architect report (`a060ef3faaa5b630c`) + pre-review (`afc812e89a6fbed46`)
+  - **Decision** — SQL RPC is the default; Edge Function requires meeting ≥1 load-bearing criterion (LB1–LB6)
+  - **Selection criteria** — 6 LB indicators (LB1 auth mint, LB2 external API, LB3 workflow fwd, LB4 noauth token, LB5 read-orch, LB6 pre-user-emit); 1 negative indicator (pure DB + auth + perm + read-back); explicit non-criterion (service-role reads ≠ load-bearing); ambiguous-middle rubric with 3 worked cases from Phase 0
+  - **Edge Functions as orchestration tier** (elevated to its own section per architect N1) — frontend CQRS Rule 4 does NOT apply; Edge Functions may use service-role reads of any table. Cite `invite-user` + `manage-user` v11 as precedent.
+  - **Pattern A v2 compatibility** — Edge Functions that remain load-bearing AND do DB writes MUST implement two-step read-back; `manage-user update_notification_preferences` (v11) is the SOLE reference implementation (per MF3). Other v11 ops have the pre-v11 gap; flagged in inventory notes.
+  - **Hybrid case walkthrough** (per SA6) — `organization-delete` pattern: permission check in Edge Function + `api.` RPC call for soft-delete + workflow-layer forward. Classified load-bearing via LB3.
+  - **Out-of-scope boundary** (per BS1) — Temporal activities under `workflows/` are NOT governed by this ADR; saga compensation has different failure semantics.
+  - **Inventory (as of 2026-04-24)** — Phase 0's table, date-stamped, with grep-recipe footnote per anti-staleness Rule 8
+  - **Rollout history** — initial publication (this PR). Future `candidate` extractions append rows.
+  - **Consequences** — predictability for new authors; easier review; migration burden on `candidate` functions; frontend-call-site churn during migrations; **deploy-surface consolidation (BS6)** — extraction turns two deploy surfaces into one; **AsyncAPI invariance (BS3)** — extraction does not change event contracts.
+  - **Alternatives considered** — status quo (rejected: evidence is `manage-user update_notification_preferences`); all-Edge-Functions (rejected: violates Pattern A v2 atomicity); all-SQL-RPCs (rejected: LB1/LB2/LB3/LB4/LB5 force Edge Functions)
+- **Related Documentation** section: `adr-rpc-readback-pattern.md`, `infrastructure/CLAUDE.md` (Rules 4, 9, 13), `event-handler-pattern.md`, `documentation/architecture/data/event-sourcing-overview.md`
+
+**DoD**: Frontmatter + TL;DR + all body sections present; 5+ keyword tags; all relative links resolve.
+
+## Phase 2 — Guard Rail Updates
+
+### 2a — `infrastructure/CLAUDE.md`
+
+- Add new rule (likely in the "Edge Function Deployment" block): *"Before creating a new Edge Function, consult [adr-edge-function-vs-sql-rpc.md]. SQL RPC is the default; Edge Function requires meeting one of the load-bearing criteria there (LB1–LB6)."*
+- Add companion opportunistic-migration nudge: *"When touching an Edge Function operation classified `candidate-for-extraction` in the ADR's inventory, prefer extracting that operation to an SQL RPC in the same PR."*
+- Bump `last_updated` if the file has frontmatter.
+
+### 2b — `.claude/skills/infrastructure-guidelines/SKILL.md`
+
+- Mirror both rules from 2a
+- Place adjacent to existing Rule 4 (Frontend Queries via `api.` Schema RPC ONLY) — shared "which tool for which operation" theme
+- No version bump unless explicit version field exists
+
+**DoD**: `grep -rn 'adr-edge-function-vs-sql-rpc' infrastructure/CLAUDE.md .claude/skills/infrastructure-guidelines/SKILL.md` returns ≥1 match per file.
+
+## Phase 3 — Navigation + Cross-links
+
+### 3a — `documentation/AGENT-INDEX.md`
+
+- Add keyword rows: `edge-function`, `sql-rpc`, `orchestration-tier`
+- Document Catalog entry (path | summary | keywords | token estimate = line count × 10)
+- Cross-ref updates on existing `api-contract` / `rpc-readback` / `cqrs` rows
+
+### 3b — Cross-link from `adr-rpc-readback-pattern.md`
+
+- One-line Related-Documentation entry pointing at new ADR
+- Bump `last_updated`
+
+**DoD**: all cross-links resolve (manual grep walk); AGENT-INDEX keyword rows match ADR's TL;DR `Key topics` exactly.
+
+## Phase 4 — CI Check (SA2)
+
+**Path**: `.github/workflows/supabase-edge-functions-lint.yml` (new file)
+
+**Shape** (approx. 20 lines):
+
+```yaml
+name: Edge Function ADR Citation Check
+on:
+  pull_request:
+    paths:
+      - 'infrastructure/supabase/supabase/functions/**'
+jobs:
+  check-adr-citation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Identify new Edge Function files
+        run: |
+          git fetch origin main
+          NEW_FILES=$(git diff --name-only --diff-filter=A origin/main...HEAD \
+            | grep -E 'infrastructure/supabase/supabase/functions/[^/]+/index\.ts$' || true)
+          for f in $NEW_FILES; do
+            if ! grep -q 'adr-edge-function-vs-sql-rpc' "$f"; then
+              echo "::error file=$f::New Edge Function must cite the ADR in a top-of-file comment. See documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md"
+              exit 1
+            fi
+          done
+```
+
+**Scope**:
+- **NEW files only** (`--diff-filter=A`) — zero retrofit for the 7 existing functions. Per architect: retrofitting would manufacture churn.
+- Grep is case-sensitive and anchored on the ADR filename fragment, so casual references in other doc files don't accidentally pass it.
+- CI failure message points directly at the ADR path.
+
+**DoD**: Workflow file lands; triggered on `supabase/functions/**` PR changes; a dry-run branch confirms it would catch a hypothetical new function file missing the citation.
+
+## Phase 5 — Seed Follow-up Cards (4 candidates)
+
+For each `candidate-for-extraction` row in Phase 0:
+
+| # | Card folder | Source op | Priority | Notes |
+|---|-------------|-----------|----------|-------|
+| 1 | `dev/active/manage-user-to-sql-rpc/` | `update_notification_preferences` | **High** | Architect-validated first target. Supersedes Blocker-3-followup-7. Card scope = this one op only (per architect Q4 — start narrow). |
+| 2 | `dev/active/invite-user-revoke-to-sql-rpc/` | `invite-user revoke` | Medium | Pure RPC wrapper; no rollout complexity. |
+| 3 | `dev/active/manage-user-delete-to-sql-rpc/` | `manage-user delete` | Medium | Couples with Pattern A v2 retrofit opportunity. |
+| 4 | `dev/active/manage-user-modify-roles-to-sql-rpc/` | `manage-user modify_roles` | Low | 1+N+M event emission; more rollout complexity. Revisit after (1) ships. |
+
+**Template** (minimum content per card):
+- `context.md` — motivation (cite this ADR + Phase 0 classification), related work, constraints
+- `plan.md` — migration-recipe outline (dual-deploy? direct cutover? backward-compat shim?), rollout gate (e.g., N days of zero Edge Function calls)
+- `tasks.md` — checkbox breakdown
+
+**DoD**: 4 folders exist under `dev/active/`; each has valid 3-file structure; `manage-user-to-sql-rpc/` explicitly supersedes Blocker-3-followup-7 and references this ADR as activation trigger.
+
+## Phase 6 — Verification + PR
+
+- Manual link walk: every `[text](path)` in new ADR resolves (`grep -oE '\]\([^)]+\)' <file>` + `[ -f $path ]`)
+- AGENT-INDEX keyword rows match ADR's TL;DR `Key topics` exactly (AGENT-GUIDELINES Rule 3)
+- `npm run docs:check` (frontend validator) remains green — only pre-existing trailing-slash warning acceptable
+- No anti-staleness violations (hardcoded counts, stale dates, dangling forward-links)
+- Commit on `docs/edge-function-vs-sql-rpc-adr` branch; push; open PR against `main`
+- PR body: summary + link to PR #32 architect report + link to this plan
+
+**Post-merge**:
+- Archive `dev/active/edge-function-vs-sql-rpc-adr/` → `dev/archived/edge-function-vs-sql-rpc-adr/`
+- 4 new `dev/active/<function>-to-sql-rpc/` folders remain in-flight per their priorities
+- Update `MEMORY.md` with ADR ship note (per SA3 versioning protocol)
+
+## Risks & Open Questions
+
+- **R1 — Classification disagreement in practice**: The LB6 pre-user-emit criterion is narrow but real (`accept-invitation` only). If future features introduce more pre-user event emission, the criterion may need expansion. Noted but not mitigated in v1.
+- **R2 — 4-card backlog load**: 4 `candidate` cards is manageable — no splitting/parking needed. If priorities shift, the low-priority cards can sit in `dev/active/` without causing attention drain (user confirmed 2026-04-24).
+- **R3 — Criteria drift**: Durable criteria vs. aging inventory. Inventory has explicit date stamp + grep recipe; criteria section is durable-by-design. Inventory-refresh cadence noted in ADR body ("Walk the inventory every 6 months or when adding a new Edge Function").
+- **O1 — `accept-invitation` / `validate-invitation` unification**: Tangent; not this ADR's problem. Noted as "not in scope" in ADR body to preempt future confusion.
+- **O2 — Edge Function deploy automation**: Still uses `supabase functions deploy` CLI manually. Noted in Consequences but not mitigated (orthogonal to selection criteria).
+
+## Pre-implementation Gates (all resolved)
+
+- [x] **D1** — Pre-review with `software-architect-dbc` (agent `afc812e89a6fbed46`, 2026-04-24) → LGTM-with-remediation; all items folded
+- [x] **D2** — Folder naming `<function>-to-sql-rpc/` (user, 2026-04-24)
+- [x] **D3** — All candidate cards seed under `dev/active/` regardless of priority (user, 2026-04-24)
+
+**Ready-to-execute signal**: After user reviews this revised plan and confirms, begin Phase 1 (ADR drafting).

--- a/dev/active/edge-function-vs-sql-rpc-adr/edge-function-vs-sql-rpc-adr-tasks.md
+++ b/dev/active/edge-function-vs-sql-rpc-adr/edge-function-vs-sql-rpc-adr-tasks.md
@@ -59,7 +59,7 @@ Activated 2026-04-24. Conditions met:
 - [x] Identified 3 ambiguous cases (`update_notification_preferences`, `validate-invitation`, `organization-bootstrap`/`organization-delete`) with explicit rationale
 - [x] Corrected sub-agent rule-violation: `validate-invitation` and `accept-invitation.query-org-for-redirect` reclassified as load-bearing per LB4
 
-**Totals**: 13 load-bearing, 3 candidate + 1 reference-impl candidate = **4 candidate ops** for Phase 5 seed cards.
+**Totals**: **12 load-bearing** + **4 candidate-for-extraction** (one also serves as Pattern A v2 reference implementation). 4 seed cards land in Phase 5.
 
 ## Phase 1 — Draft ADR ✅ COMPLETE (2026-04-24)
 

--- a/dev/active/edge-function-vs-sql-rpc-adr/edge-function-vs-sql-rpc-adr-tasks.md
+++ b/dev/active/edge-function-vs-sql-rpc-adr/edge-function-vs-sql-rpc-adr-tasks.md
@@ -1,0 +1,199 @@
+# Edge Function vs SQL RPC Selection ADR — Tasks
+
+## Current Status
+
+**Phase**: Plan revised per architect pre-review — awaiting user LGTM before Phase 1 drafting
+**Status**: 🟢 ACTIVE (branch `docs/edge-function-vs-sql-rpc-adr`; Phase 0 inventory folded in)
+**Last Updated**: 2026-04-24
+**Branch**: `docs/edge-function-vs-sql-rpc-adr` (no PR yet; no commits yet)
+**Next step**: User reviews revised `context.md` + `plan.md` + this file; confirms → Phase 1 ADR drafting begins.
+
+---
+
+## Activation Trigger
+
+Activated 2026-04-24. Conditions met:
+- ✅ PR #32 merged (commit `6b4a2fe5`) — `manage-user` v11 Pattern A v2 surfaced the "strictly superior architecturally" finding
+- ✅ `api-rpc-readback-pattern` archived — the SQL-RPC-side contract this ADR cites is stable
+- ✅ Four-layered approach confirmed (user + architect, 2026-04-24)
+- ✅ Architect pre-review complete (agent `afc812e89a6fbed46`, verdict LGTM-with-remediation; 3 MUST-FIX + 6 SHOULD-ADD folded into this revision)
+
+## Pre-implementation Gates (all resolved)
+
+- [x] **D1** — Pre-review plan with `software-architect-dbc` (agent `afc812e89a6fbed46`, 2026-04-24) — LGTM-with-remediation
+- [x] **D2** — Follow-up card folder naming: `<function>-to-sql-rpc/` (user, 2026-04-24)
+- [x] **D3** — New seed cards land under `dev/active/` regardless of priority (user, 2026-04-24)
+
+## Architect Remediation Tracking
+
+### MUST-FIX items (all folded before Phase 1)
+
+- [x] **MF1** — Remove "service-role reads of non-`api.` tables" as positive indicator; add explicit non-criterion note
+- [x] **MF2** — Reframe Phase 0 as plan-completion motivating-example calibration (not conclusion-first execution)
+- [x] **MF3** — Scope Pattern A v2 reference-impl citation to `manage-user update_notification_preferences` only; flag other manage-user ops as "Pattern A v2 retrofit TBD"
+
+### SHOULD-ADD items (all folded before Phase 1)
+
+- [x] **SA1** — 5th positive indicator added (LB6 — pre-user-emit)
+- [x] **SA2** — CI check added as Layer 4 (new workflow `supabase-edge-functions-lint.yml`)
+- [x] **SA3** — ADR version field (`adr_version: v1`) added to frontmatter spec
+- [x] **SA4** — Phase 0 moved to plan-completion data (done)
+- [x] **SA5** — LB5 (read-orchestration of cross-tier state) added to criteria list
+- [x] **SA6** — `organization-delete` hybrid case walkthrough added to Phase 1 ADR body spec
+
+### Blind-spot coverage (all folded)
+
+- [x] **BS1** — Temporal activities declared out-of-scope in context.md + ADR body
+- [x] **BS2** — `{success, <entity>}` conformance requirement for load-bearing Edge Function writes
+- [x] **BS3** — AsyncAPI invariance during extraction noted in Consequences
+- [x] **BS4** — LB4 (unauthenticated token validation) integrated as positive indicator
+- [x] **BS5** — auth-user minting sub-case called out under LB1
+- [x] **BS6** — Deploy-surface consolidation noted in Consequences
+
+## Phase 0 — Edge Function Inventory ✅ COMPLETE (2026-04-24, plan-completion data)
+
+- [x] Inventoried all 7 Edge Functions (3,390 LOC total)
+- [x] Enumerated 16 distinct operations
+- [x] Classified each against LB1–LB6 rubric
+- [x] Populated inventory table in `plan.md` (moved from "Phase 0 execution" to "plan-completion data")
+- [x] Identified 3 ambiguous cases (`update_notification_preferences`, `validate-invitation`, `organization-bootstrap`/`organization-delete`) with explicit rationale
+- [x] Corrected sub-agent rule-violation: `validate-invitation` and `accept-invitation.query-org-for-redirect` reclassified as load-bearing per LB4
+
+**Totals**: 13 load-bearing, 3 candidate + 1 reference-impl candidate = **4 candidate ops** for Phase 5 seed cards.
+
+## Phase 1 — Draft ADR 🟡 NOT STARTED
+
+**Path**: `documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md`
+
+### 1a — Frontmatter + TL;DR
+
+- [ ] YAML frontmatter: `status: current`, `last_updated: <commit day>`, `adr_version: v1` (per SA3)
+- [ ] TL;DR block:
+  - [ ] **Summary**: 1–2 sentences
+  - [ ] **When to read**: 3+ SPECIFIC scenarios
+  - [ ] **Prerequisites**: link `adr-rpc-readback-pattern.md`, `event-handler-pattern.md`
+  - [ ] **Key topics** (3–6 backticked): `adr`, `edge-function`, `sql-rpc`, `orchestration-tier`, `cqrs`
+  - [ ] **Estimated read time**
+
+### 1b — Body
+
+- [ ] **Context** — silent-friction-to-choose; cite PR #32 reviews (both architect agents)
+- [ ] **Decision** — SQL RPC default; Edge Function requires ≥1 LB criterion
+- [ ] **Selection criteria**:
+  - [ ] 5 positive indicators LB1–LB5 (auth-mint, external-API, workflow-fwd, noauth-token, read-orch) + LB6 (pre-user-emit)
+  - [ ] 1 negative indicator (pure DB + auth + perm + read-back → SQL RPC)
+  - [ ] Explicit **non-criterion**: service-role reads of non-`api.` tables are NOT load-bearing (per MF1)
+  - [ ] Ambiguous-middle rubric with 3 worked cases from Phase 0
+- [ ] **Edge Functions as orchestration tier** (elevated section per N1) — CQRS Rule 4 exemption
+- [ ] **Pattern A v2 compatibility** — `manage-user update_notification_preferences` (v11) as SOLE reference impl (per MF3)
+- [ ] **Hybrid case walkthrough** (per SA6) — `organization-delete`
+- [ ] **Out-of-scope boundary** (per BS1) — Temporal activities
+- [ ] **Inventory (as of 2026-04-24)** — date-stamped, grep-recipe footnote, 16-row table
+- [ ] **Rollout history** — initial publication row
+- [ ] **Consequences** — predictability, review speed, migration burden, call-site churn, deploy-surface consolidation (BS6), AsyncAPI invariance (BS3)
+- [ ] **Alternatives considered** — status quo, all-EF, all-SQL-RPC
+
+### 1c — Related Documentation section
+
+- [ ] Link `adr-rpc-readback-pattern.md`
+- [ ] Link `infrastructure/CLAUDE.md` (Rules 4, 9, 13)
+- [ ] Link `event-handler-pattern.md`
+- [ ] Link `event-sourcing-overview.md`
+
+**DoD**: All sections present; frontmatter renders; manual link-walk confirms resolution.
+
+## Phase 2 — Guard Rail Updates 🟡 NOT STARTED
+
+### 2a — `infrastructure/CLAUDE.md`
+
+- [ ] Add new rule with forward-link to ADR
+- [ ] Add companion opportunistic-migration nudge
+- [ ] Bump `last_updated` if frontmatter exists
+
+### 2b — `.claude/skills/infrastructure-guidelines/SKILL.md`
+
+- [ ] Mirror both rules from 2a
+- [ ] Place adjacent to existing Rule 4
+- [ ] Verify forward-link resolves from skill base dir
+
+**DoD**: `grep -rn 'adr-edge-function-vs-sql-rpc' infrastructure/CLAUDE.md .claude/skills/infrastructure-guidelines/SKILL.md` returns ≥1 hit per file.
+
+## Phase 3 — Navigation + Cross-links 🟡 NOT STARTED
+
+### 3a — `documentation/AGENT-INDEX.md`
+
+- [ ] Add keyword rows: `edge-function`, `sql-rpc`, `orchestration-tier`
+- [ ] Document Catalog entry for new ADR
+- [ ] Cross-ref updates on `api-contract` / `rpc-readback` / `cqrs` rows
+
+### 3b — Cross-link from `adr-rpc-readback-pattern.md`
+
+- [ ] One-line Related-Documentation entry pointing at new ADR
+- [ ] Bump `last_updated`
+
+**DoD**: all cross-links resolve; keyword rows match ADR's TL;DR.
+
+## Phase 4 — CI Check 🟡 NOT STARTED (per SA2)
+
+**Path**: `.github/workflows/supabase-edge-functions-lint.yml` (new file)
+
+- [ ] Create workflow file with grep-based ADR-citation check
+- [ ] Scope: NEW files only (`git diff --diff-filter=A`)
+- [ ] Triggered on `infrastructure/supabase/supabase/functions/**` PR changes
+- [ ] Test on a throwaway branch: create a dummy new Edge Function without the citation → CI fails with clear error message pointing at ADR path
+
+**DoD**: Workflow file lands; dry-run validates catch behavior; does NOT block existing-file modifications.
+
+## Phase 5 — Seed 4 Follow-up Cards 🟡 NOT STARTED
+
+For each `candidate-for-extraction` row in Phase 0:
+
+- [ ] **Card 1** — `dev/active/manage-user-to-sql-rpc/` (scope: `update_notification_preferences` only; supersedes Blocker-3-followup-7)
+  - [ ] `context.md`
+  - [ ] `plan.md`
+  - [ ] `tasks.md`
+- [ ] **Card 2** — `dev/active/invite-user-revoke-to-sql-rpc/`
+- [ ] **Card 3** — `dev/active/manage-user-delete-to-sql-rpc/`
+- [ ] **Card 4** — `dev/active/manage-user-modify-roles-to-sql-rpc/`
+
+Each card's minimum content:
+- Motivation (cite this ADR + Phase 0 classification)
+- Operation(s) to extract
+- Backward-compat plan (dual-deploy during rollout? direct cutover?)
+- Rollout gate (N days of zero Edge Function calls? feature-flag controlled?)
+
+**DoD**: 4 folders exist under `dev/active/`; `manage-user-to-sql-rpc/` explicitly references this ADR as activation trigger.
+
+## Phase 6 — Verification + PR 🟡 NOT STARTED
+
+### 6a — Pre-PR checks
+
+- [ ] Manual link walk: every `[text](path)` in new ADR resolves
+- [ ] AGENT-INDEX keyword rows match ADR TL;DR `Key topics` exactly
+- [ ] No anti-staleness violations
+- [ ] `npm run docs:check` green (only pre-existing trailing-slash warning acceptable)
+- [ ] Dry-run CI workflow on throwaway branch confirms catch behavior
+
+### 6b — Commit + PR
+
+- [ ] Commit on `docs/edge-function-vs-sql-rpc-adr` branch
+- [ ] Push; open PR against `main`
+- [ ] PR body: summary + links to PR #32 architect reports + this dev-doc
+
+### 6c — Post-merge
+
+- [ ] Archive `dev/active/edge-function-vs-sql-rpc-adr/` → `dev/archived/edge-function-vs-sql-rpc-adr/`
+- [ ] Verify 4 seeded `<function>-to-sql-rpc/` folders remain in `dev/active/`
+- [ ] Update `MEMORY.md` with ADR v1 ship note (per SA3 versioning protocol)
+
+**Full DoD for this feature**: ADR published + guard rails in place + CI check live + 4 candidate cards seeded + Blocker-3-followup-7 explicitly unblocked.
+
+## Parked / Out-of-scope
+
+- Actual Edge Function → SQL RPC extractions (each is its own PR per its own card)
+- Pattern A v2 retrofit of `manage-user` non-notification-pref ops (separate cards, potentially coupled with Card 3 for `delete`)
+- Temporal activities under `workflows/` (BS1 boundary)
+- New Edge Function development guide (stays in `infrastructure/CLAUDE.md` + existing docs)
+- `accept-invitation` / `validate-invitation` unification (O1; noted as non-goal in ADR)
+- Inventory-refresh automation (noted cadence in ADR body; no CI check)
+- Edge Function deploy automation (O2; orthogonal)

--- a/dev/active/edge-function-vs-sql-rpc-adr/edge-function-vs-sql-rpc-adr-tasks.md
+++ b/dev/active/edge-function-vs-sql-rpc-adr/edge-function-vs-sql-rpc-adr-tasks.md
@@ -2,11 +2,11 @@
 
 ## Current Status
 
-**Phase**: Plan revised per architect pre-review — awaiting user LGTM before Phase 1 drafting
-**Status**: 🟢 ACTIVE (branch `docs/edge-function-vs-sql-rpc-adr`; Phase 0 inventory folded in)
+**Phase**: All 6 phases executed — awaiting verification pass + PR open
+**Status**: 🟢 ACTIVE (branch `docs/edge-function-vs-sql-rpc-adr`; planning checkpoint committed `0e20e045`)
 **Last Updated**: 2026-04-24
-**Branch**: `docs/edge-function-vs-sql-rpc-adr` (no PR yet; no commits yet)
-**Next step**: User reviews revised `context.md` + `plan.md` + this file; confirms → Phase 1 ADR drafting begins.
+**Branch**: `docs/edge-function-vs-sql-rpc-adr`
+**Next step**: Final commit with all Phase 1–6 artifacts; push; open PR against main.
 
 ---
 
@@ -61,100 +61,100 @@ Activated 2026-04-24. Conditions met:
 
 **Totals**: 13 load-bearing, 3 candidate + 1 reference-impl candidate = **4 candidate ops** for Phase 5 seed cards.
 
-## Phase 1 — Draft ADR 🟡 NOT STARTED
+## Phase 1 — Draft ADR ✅ COMPLETE (2026-04-24)
 
 **Path**: `documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md`
 
 ### 1a — Frontmatter + TL;DR
 
-- [ ] YAML frontmatter: `status: current`, `last_updated: <commit day>`, `adr_version: v1` (per SA3)
-- [ ] TL;DR block:
-  - [ ] **Summary**: 1–2 sentences
-  - [ ] **When to read**: 3+ SPECIFIC scenarios
-  - [ ] **Prerequisites**: link `adr-rpc-readback-pattern.md`, `event-handler-pattern.md`
-  - [ ] **Key topics** (3–6 backticked): `adr`, `edge-function`, `sql-rpc`, `orchestration-tier`, `cqrs`
-  - [ ] **Estimated read time**
+- [x] YAML frontmatter: `status: current`, `last_updated: <commit day>`, `adr_version: v1` (per SA3)
+- [x] TL;DR block:
+  - [x] **Summary**: 1–2 sentences
+  - [x] **When to read**: 3+ SPECIFIC scenarios
+  - [x] **Prerequisites**: link `adr-rpc-readback-pattern.md`, `event-handler-pattern.md`
+  - [x] **Key topics** (3–6 backticked): `adr`, `edge-function`, `sql-rpc`, `orchestration-tier`, `cqrs`
+  - [x] **Estimated read time**
 
 ### 1b — Body
 
-- [ ] **Context** — silent-friction-to-choose; cite PR #32 reviews (both architect agents)
-- [ ] **Decision** — SQL RPC default; Edge Function requires ≥1 LB criterion
-- [ ] **Selection criteria**:
-  - [ ] 5 positive indicators LB1–LB5 (auth-mint, external-API, workflow-fwd, noauth-token, read-orch) + LB6 (pre-user-emit)
-  - [ ] 1 negative indicator (pure DB + auth + perm + read-back → SQL RPC)
-  - [ ] Explicit **non-criterion**: service-role reads of non-`api.` tables are NOT load-bearing (per MF1)
-  - [ ] Ambiguous-middle rubric with 3 worked cases from Phase 0
-- [ ] **Edge Functions as orchestration tier** (elevated section per N1) — CQRS Rule 4 exemption
-- [ ] **Pattern A v2 compatibility** — `manage-user update_notification_preferences` (v11) as SOLE reference impl (per MF3)
-- [ ] **Hybrid case walkthrough** (per SA6) — `organization-delete`
-- [ ] **Out-of-scope boundary** (per BS1) — Temporal activities
-- [ ] **Inventory (as of 2026-04-24)** — date-stamped, grep-recipe footnote, 16-row table
-- [ ] **Rollout history** — initial publication row
-- [ ] **Consequences** — predictability, review speed, migration burden, call-site churn, deploy-surface consolidation (BS6), AsyncAPI invariance (BS3)
-- [ ] **Alternatives considered** — status quo, all-EF, all-SQL-RPC
+- [x] **Context** — silent-friction-to-choose; cite PR #32 reviews (both architect agents)
+- [x] **Decision** — SQL RPC default; Edge Function requires ≥1 LB criterion
+- [x] **Selection criteria**:
+  - [x] 5 positive indicators LB1–LB5 (auth-mint, external-API, workflow-fwd, noauth-token, read-orch) + LB6 (pre-user-emit)
+  - [x] 1 negative indicator (pure DB + auth + perm + read-back → SQL RPC)
+  - [x] Explicit **non-criterion**: service-role reads of non-`api.` tables are NOT load-bearing (per MF1)
+  - [x] Ambiguous-middle rubric with 3 worked cases from Phase 0
+- [x] **Edge Functions as orchestration tier** (elevated section per N1) — CQRS Rule 4 exemption
+- [x] **Pattern A v2 compatibility** — `manage-user update_notification_preferences` (v11) as SOLE reference impl (per MF3)
+- [x] **Hybrid case walkthrough** (per SA6) — `organization-delete`
+- [x] **Out-of-scope boundary** (per BS1) — Temporal activities
+- [x] **Inventory (as of 2026-04-24)** — date-stamped, grep-recipe footnote, 16-row table
+- [x] **Rollout history** — initial publication row
+- [x] **Consequences** — predictability, review speed, migration burden, call-site churn, deploy-surface consolidation (BS6), AsyncAPI invariance (BS3)
+- [x] **Alternatives considered** — status quo, all-EF, all-SQL-RPC
 
 ### 1c — Related Documentation section
 
-- [ ] Link `adr-rpc-readback-pattern.md`
-- [ ] Link `infrastructure/CLAUDE.md` (Rules 4, 9, 13)
-- [ ] Link `event-handler-pattern.md`
-- [ ] Link `event-sourcing-overview.md`
+- [x] Link `adr-rpc-readback-pattern.md`
+- [x] Link `infrastructure/CLAUDE.md` (Rules 4, 9, 13)
+- [x] Link `event-handler-pattern.md`
+- [x] Link `event-sourcing-overview.md`
 
 **DoD**: All sections present; frontmatter renders; manual link-walk confirms resolution.
 
-## Phase 2 — Guard Rail Updates 🟡 NOT STARTED
+## Phase 2 — Guard Rail Updates ✅ COMPLETE (2026-04-24)
 
 ### 2a — `infrastructure/CLAUDE.md`
 
-- [ ] Add new rule with forward-link to ADR
-- [ ] Add companion opportunistic-migration nudge
-- [ ] Bump `last_updated` if frontmatter exists
+- [x] Add new rule with forward-link to ADR
+- [x] Add companion opportunistic-migration nudge
+- [x] Bump `last_updated` if frontmatter exists
 
 ### 2b — `.claude/skills/infrastructure-guidelines/SKILL.md`
 
-- [ ] Mirror both rules from 2a
-- [ ] Place adjacent to existing Rule 4
-- [ ] Verify forward-link resolves from skill base dir
+- [x] Mirror both rules from 2a
+- [x] Place adjacent to existing Rule 4
+- [x] Verify forward-link resolves from skill base dir
 
 **DoD**: `grep -rn 'adr-edge-function-vs-sql-rpc' infrastructure/CLAUDE.md .claude/skills/infrastructure-guidelines/SKILL.md` returns ≥1 hit per file.
 
-## Phase 3 — Navigation + Cross-links 🟡 NOT STARTED
+## Phase 3 — Navigation + Cross-links ✅ COMPLETE (2026-04-24)
 
 ### 3a — `documentation/AGENT-INDEX.md`
 
-- [ ] Add keyword rows: `edge-function`, `sql-rpc`, `orchestration-tier`
-- [ ] Document Catalog entry for new ADR
-- [ ] Cross-ref updates on `api-contract` / `rpc-readback` / `cqrs` rows
+- [x] Add keyword rows: `edge-function`, `sql-rpc`, `orchestration-tier`
+- [x] Document Catalog entry for new ADR
+- [x] Cross-ref updates on `api-contract` / `rpc-readback` / `cqrs` rows
 
 ### 3b — Cross-link from `adr-rpc-readback-pattern.md`
 
-- [ ] One-line Related-Documentation entry pointing at new ADR
-- [ ] Bump `last_updated`
+- [x] One-line Related-Documentation entry pointing at new ADR
+- [x] Bump `last_updated`
 
 **DoD**: all cross-links resolve; keyword rows match ADR's TL;DR.
 
-## Phase 4 — CI Check 🟡 NOT STARTED (per SA2)
+## Phase 4 — CI Check ✅ COMPLETE (2026-04-24) (per SA2)
 
 **Path**: `.github/workflows/supabase-edge-functions-lint.yml` (new file)
 
-- [ ] Create workflow file with grep-based ADR-citation check
-- [ ] Scope: NEW files only (`git diff --diff-filter=A`)
-- [ ] Triggered on `infrastructure/supabase/supabase/functions/**` PR changes
-- [ ] Test on a throwaway branch: create a dummy new Edge Function without the citation → CI fails with clear error message pointing at ADR path
+- [x] Create workflow file with grep-based ADR-citation check
+- [x] Scope: NEW files only (`git diff --diff-filter=A`)
+- [x] Triggered on `infrastructure/supabase/supabase/functions/**` PR changes
+- [x] Test on a throwaway branch: create a dummy new Edge Function without the citation → CI fails with clear error message pointing at ADR path
 
 **DoD**: Workflow file lands; dry-run validates catch behavior; does NOT block existing-file modifications.
 
-## Phase 5 — Seed 4 Follow-up Cards 🟡 NOT STARTED
+## Phase 5 — Seed 4 Follow-up Cards ✅ COMPLETE (2026-04-24)
 
 For each `candidate-for-extraction` row in Phase 0:
 
-- [ ] **Card 1** — `dev/active/manage-user-to-sql-rpc/` (scope: `update_notification_preferences` only; supersedes Blocker-3-followup-7)
-  - [ ] `context.md`
-  - [ ] `plan.md`
-  - [ ] `tasks.md`
-- [ ] **Card 2** — `dev/active/invite-user-revoke-to-sql-rpc/`
-- [ ] **Card 3** — `dev/active/manage-user-delete-to-sql-rpc/`
-- [ ] **Card 4** — `dev/active/manage-user-modify-roles-to-sql-rpc/`
+- [x] **Card 1** — `dev/active/manage-user-to-sql-rpc/` (scope: `update_notification_preferences` only; supersedes Blocker-3-followup-7)
+  - [x] `context.md`
+  - [x] `plan.md`
+  - [x] `tasks.md`
+- [x] **Card 2** — `dev/active/invite-user-revoke-to-sql-rpc/`
+- [x] **Card 3** — `dev/active/manage-user-delete-to-sql-rpc/`
+- [x] **Card 4** — `dev/active/manage-user-modify-roles-to-sql-rpc/`
 
 Each card's minimum content:
 - Motivation (cite this ADR + Phase 0 classification)
@@ -164,7 +164,7 @@ Each card's minimum content:
 
 **DoD**: 4 folders exist under `dev/active/`; `manage-user-to-sql-rpc/` explicitly references this ADR as activation trigger.
 
-## Phase 6 — Verification + PR 🟡 NOT STARTED
+## Phase 6 — Verification + PR 🟡 IN PROGRESS (ready for PR)
 
 ### 6a — Pre-PR checks
 

--- a/dev/active/invite-user-revoke-to-sql-rpc/context.md
+++ b/dev/active/invite-user-revoke-to-sql-rpc/context.md
@@ -1,0 +1,33 @@
+# invite-user revoke → SQL RPC — Context
+
+**Feature**: Extract the `revoke` operation from the `invite-user` Edge Function into a SQL RPC
+**Status**: 🟢 ACTIVE — Seeded by `edge-function-vs-sql-rpc-adr` (2026-04-24)
+**Priority**: Medium
+**Current branch**: TBD — start from `main` after the ADR PR merges
+
+## Activation Trigger
+
+- ✅ `adr-edge-function-vs-sql-rpc.md` published (v1, 2026-04-24)
+- Classification: Phase 0 inventory row #7 — `candidate-for-extraction`; all 6 LB criteria are ❌; pure RPC + event emission on existing invitation
+
+## Scope
+
+### In scope
+- New SQL RPC wrapping the revoke operation (likely `api.revoke_invitation` — verify; `api.revoke_invitation` may already exist as the current RPC that the Edge Function's revoke case forwards to)
+- Remove the `revoke` case from `invite-user/index.ts`
+- Frontend service cutover if `invite-user.revoke` is called from frontend
+
+### Out of scope
+- `create` and `resend` operations (load-bearing via LB1/LB2 — Resend API)
+
+## Notes
+
+Per MEMORY.md entry "Invitation Resend/Revoke Fix Complete (2026-02-19)": `api.revoke_invitation` already exists as an RPC (with signature `(p_invitation_id uuid, p_reason text)`; uses `auth.uid()` internally). The `invite-user` Edge Function v15's `revoke` case may just forward to it. This extraction may be a frontend-only change (point frontend directly at the existing RPC) rather than a new RPC authoring.
+
+**Verify before planning**: inspect `invite-user/index.ts` revoke case body — if it's a pure RPC forward, this card reduces to "point frontend at existing RPC; delete Edge Function case." If it adds meaningful pre/post logic, port that logic to the RPC or a new wrapping RPC.
+
+## Reference Materials
+
+- [adr-edge-function-vs-sql-rpc.md](../../../documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md)
+- `infrastructure/supabase/supabase/functions/invite-user/index.ts` (v15)
+- MEMORY.md "Invitation Resend/Revoke Fix Complete (2026-02-19)"

--- a/dev/active/invite-user-revoke-to-sql-rpc/plan.md
+++ b/dev/active/invite-user-revoke-to-sql-rpc/plan.md
@@ -1,0 +1,24 @@
+# invite-user revoke → SQL RPC — Plan
+
+## Executive Summary
+
+Extract `revoke` operation from `invite-user` Edge Function. Investigation phase first: determine whether this reduces to a frontend-only change (pointing at the existing `api.revoke_invitation` RPC) or requires new RPC work.
+
+## Phases
+
+| Phase | Description |
+|-------|-------------|
+| 0 | Inspect `invite-user` v15 `revoke` case body; determine if it's a pure RPC forward or has additional logic |
+| 1 | (If pure forward) Frontend service cutover only — no migration needed |
+| 1' | (If wrapping logic) Migration creating `api.<wrapper>` RPC that captures the pre/post logic |
+| 2 | Remove `revoke` case from Edge Function |
+| 3 | Verification + PR |
+
+## Open Questions
+
+- **O1** — Does the Edge Function's `revoke` case add auth-token-shaped logic beyond what `api.revoke_invitation` already does?
+- **O2** — Are there non-frontend callers of the Edge Function's revoke case? (workflows/, admin scripts)
+
+## Risks
+
+- **R1** — Low. Simple extraction if Phase 0 confirms pure-forward.

--- a/dev/active/invite-user-revoke-to-sql-rpc/tasks.md
+++ b/dev/active/invite-user-revoke-to-sql-rpc/tasks.md
@@ -1,0 +1,15 @@
+# invite-user revoke → SQL RPC — Tasks
+
+## Current Status
+
+**Phase**: SEEDED — awaiting activation after `edge-function-vs-sql-rpc-adr` PR merges
+**Status**: 🟢 ACTIVE (scaffold only)
+**Priority**: Medium
+
+## Tasks
+
+- [ ] Phase 0 — Inspect v15 revoke case body (5 min)
+- [ ] Phase 1 or 1' — Frontend cutover OR migration (per Phase 0 outcome)
+- [ ] Phase 2 — Remove Edge Function case + bump DEPLOY_VERSION
+- [ ] Phase 3 — Verification + PR
+- [ ] Post-merge — Archive + append ADR Rollout history

--- a/dev/active/manage-user-delete-to-sql-rpc/context.md
+++ b/dev/active/manage-user-delete-to-sql-rpc/context.md
@@ -1,0 +1,34 @@
+# manage-user delete → SQL RPC — Context
+
+**Feature**: Extract `delete` operation from `manage-user` Edge Function into a SQL RPC
+**Status**: 🟢 ACTIVE — Seeded by `edge-function-vs-sql-rpc-adr` (2026-04-24)
+**Priority**: Medium (couples with Pattern A v2 retrofit opportunity)
+**Current branch**: TBD
+
+## Activation Trigger
+
+- ✅ `adr-edge-function-vs-sql-rpc.md` published (v1, 2026-04-24)
+- Classification: Phase 0 inventory row #10 — `candidate-for-extraction`; all 6 LB criteria are ❌; pure RPC + event emission
+- Inventory note: **"Pattern A v2 retrofit inherited on extraction"** — current Edge Function code is emit-and-return-success; the SQL RPC form includes Pattern A v2 by construction
+
+## Scope
+
+### In scope
+- New SQL RPC `api.delete_user` (verify name; soft-delete or hard-delete TBD per existing handler semantics)
+- Pattern A v2 read-back confirming `user.deleted` event processed
+- Remove `delete` case from `manage-user/index.ts`
+- Frontend service cutover
+
+### Out of scope
+- `deactivate` / `reactivate` (load-bearing via LB1 — `auth.admin.updateUserById`)
+
+## Coupling with other work
+
+**Pattern A v2 retrofit opportunity**: Since the current Edge Function path is pre-v11-style emit-and-return, extracting to SQL RPC gets Pattern A v2 read-back for free. This simultaneously closes the silent-failure gap for this operation. **Attractive scope bundle** — one extraction addresses two architectural goals.
+
+## Reference Materials
+
+- [adr-edge-function-vs-sql-rpc.md](../../../documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md)
+- [adr-rpc-readback-pattern.md](../../../documentation/architecture/decisions/adr-rpc-readback-pattern.md) — Pattern A v2 contract
+- `infrastructure/supabase/supabase/functions/manage-user/index.ts` — delete case body
+- Handler reference: `infrastructure/supabase/handlers/user/handle_user_deleted.sql` (verify exists)

--- a/dev/active/manage-user-delete-to-sql-rpc/plan.md
+++ b/dev/active/manage-user-delete-to-sql-rpc/plan.md
@@ -18,9 +18,9 @@ Extract `delete` from `manage-user` Edge Function into a new SQL RPC with Patter
 
 - **O1** — Soft-delete (`users.deleted_at`) vs hard-delete? Per Rule 13 template (SKILL.md), read-back for soft-delete matches `WHERE id = ? AND deleted_at IS NOT NULL`.
 - **O2** — Does user deletion cascade to `user_roles_projection`, `user_org_phone_overrides`, etc.? Confirm handler scope before porting.
-- **O3** — `auth.users` cleanup — does deletion also remove the auth record? If yes, LB1 applies and this becomes a `deactivate`-style flow (load-bearing). If no (soft-delete only), truly `candidate`.
+- **O3** — ~~`auth.users` cleanup — does deletion also remove the auth record?~~ **Verified 2026-04-24 — no `auth.admin` call in delete path** (confirmed by grep of `manage-user/index.ts:668–680` + full-file audit during PR #33 review). Classification stable as `candidate-for-extraction`.
 
-**If O3 reveals auth.users deletion**: reclassify as load-bearing and park this card.
+**Prerequisite**: Handler `handle_user_deleted` is missing from the repo (see `dev/active/fix-missing-user-lifecycle-handlers/`). Extraction into SQL RPC depends on the handler existing — the RPC body will call `api.emit_domain_event('user.deleted', ...)` and expect `handle_user_deleted` to do the projection write.
 
 ## Reference
 

--- a/dev/active/manage-user-delete-to-sql-rpc/plan.md
+++ b/dev/active/manage-user-delete-to-sql-rpc/plan.md
@@ -1,0 +1,27 @@
+# manage-user delete → SQL RPC — Plan
+
+## Executive Summary
+
+Extract `delete` from `manage-user` Edge Function into a new SQL RPC with Pattern A v2 read-back by construction. Closes the silent-failure gap for user deletion in the same PR as the extraction.
+
+## Phases
+
+| Phase | Description |
+|-------|-------------|
+| 0 | Inspect v11 delete case + `handle_user_deleted` handler; determine soft vs hard delete semantics |
+| 1 | Migration: create `api.delete_user` with Pattern A v2 |
+| 2 | Frontend service cutover |
+| 3 | Edge Function cleanup |
+| 4 | Verification + PR |
+
+## Open Questions
+
+- **O1** — Soft-delete (`users.deleted_at`) vs hard-delete? Per Rule 13 template (SKILL.md), read-back for soft-delete matches `WHERE id = ? AND deleted_at IS NOT NULL`.
+- **O2** — Does user deletion cascade to `user_roles_projection`, `user_org_phone_overrides`, etc.? Confirm handler scope before porting.
+- **O3** — `auth.users` cleanup — does deletion also remove the auth record? If yes, LB1 applies and this becomes a `deactivate`-style flow (load-bearing). If no (soft-delete only), truly `candidate`.
+
+**If O3 reveals auth.users deletion**: reclassify as load-bearing and park this card.
+
+## Reference
+
+See `context.md`.

--- a/dev/active/manage-user-delete-to-sql-rpc/tasks.md
+++ b/dev/active/manage-user-delete-to-sql-rpc/tasks.md
@@ -1,0 +1,17 @@
+# manage-user delete → SQL RPC — Tasks
+
+## Current Status
+
+**Phase**: SEEDED — awaiting activation after `edge-function-vs-sql-rpc-adr` PR merges
+**Status**: 🟢 ACTIVE (scaffold only)
+**Priority**: Medium
+
+## Tasks
+
+- [ ] Phase 0 — Inspect delete case + handler; resolve O1/O2/O3 questions in plan.md
+- [ ] **Gate** — If O3 reveals `auth.users` deletion → reclassify load-bearing, park card, update ADR Rollout note
+- [ ] Phase 1 — Migration creating `api.delete_user` with Pattern A v2
+- [ ] Phase 2 — Frontend cutover
+- [ ] Phase 3 — Edge Function cleanup + DEPLOY_VERSION bump
+- [ ] Phase 4 — Verification + PR
+- [ ] Post-merge — Archive + append ADR Rollout history

--- a/dev/active/manage-user-delete-to-sql-rpc/tasks.md
+++ b/dev/active/manage-user-delete-to-sql-rpc/tasks.md
@@ -8,8 +8,8 @@
 
 ## Tasks
 
-- [ ] Phase 0 — Inspect delete case + handler; resolve O1/O2/O3 questions in plan.md
-- [ ] **Gate** — If O3 reveals `auth.users` deletion → reclassify load-bearing, park card, update ADR Rollout note
+- [ ] **Prerequisite** — Missing-handlers issue resolved (creates `handle_user_deleted`) — see `dev/active/fix-missing-user-lifecycle-handlers/`
+- [ ] Phase 0 — Inspect delete case + handler; resolve O1/O2 questions in plan.md (O3 already closed)
 - [ ] Phase 1 — Migration creating `api.delete_user` with Pattern A v2
 - [ ] Phase 2 — Frontend cutover
 - [ ] Phase 3 — Edge Function cleanup + DEPLOY_VERSION bump

--- a/dev/active/manage-user-modify-roles-to-sql-rpc/context.md
+++ b/dev/active/manage-user-modify-roles-to-sql-rpc/context.md
@@ -1,0 +1,37 @@
+# manage-user modify_roles → SQL RPC — Context
+
+**Feature**: Extract `modify_roles` operation from `manage-user` Edge Function into a SQL RPC
+**Status**: 🟢 ACTIVE — Seeded by `edge-function-vs-sql-rpc-adr` (2026-04-24)
+**Priority**: Low — defer until `update_notification_preferences` (high-priority card) ships and we have extraction patterns proven
+**Current branch**: TBD
+
+## Activation Trigger
+
+- ✅ `adr-edge-function-vs-sql-rpc.md` published (v1, 2026-04-24)
+- Classification: Phase 0 inventory row #11 — `candidate-for-extraction`; all 6 LB criteria are ❌
+- **Defer rationale**: `manage-user update_notification_preferences` is the architect-validated first target. Ship that extraction, learn from it, then tackle `modify_roles` with the patterns proven. Plus: `modify_roles` emits 1+N+M events (1 `user.role.assigned` per add + M `user.role.revoked` per remove? verify) — multi-emit extraction may surface complexity not present in the single-emit case.
+
+## Scope
+
+### In scope
+- New SQL RPC (name TBD, possibly `api.modify_user_roles`)
+- Multi-event Pattern A v2 per `update_role` COMPLEX-CASE variant (captured `uuid[]` checked with `WHERE id = ANY(v_event_ids)`)
+- Remove `modify_roles` case from `manage-user/index.ts`
+- Frontend service cutover
+
+### Out of scope
+- Other `manage-user` ops
+- Refactoring the underlying role-assignment handlers
+
+## Open Questions (resolve during Phase 0)
+
+- Exact event emission pattern — single `user.roles.modified` event? Or N `role.assigned` + M `role.revoked` like `update_role`?
+- Permission check — requires `user.role_assign` per baseline?
+- Response envelope shape — returns list of assigned role ids?
+
+## Reference Materials
+
+- [adr-edge-function-vs-sql-rpc.md](../../../documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md)
+- [adr-rpc-readback-pattern.md](../../../documentation/architecture/decisions/adr-rpc-readback-pattern.md) — multi-event COMPLEX-CASE pattern in Decision 1 + Rollout history
+- `infrastructure/supabase/supabase/functions/manage-user/index.ts` — modify_roles case
+- `api.update_role` migration (example of multi-event Pattern A v2)

--- a/dev/active/manage-user-modify-roles-to-sql-rpc/plan.md
+++ b/dev/active/manage-user-modify-roles-to-sql-rpc/plan.md
@@ -1,0 +1,24 @@
+# manage-user modify_roles → SQL RPC — Plan
+
+## Executive Summary
+
+Extract `modify_roles` from `manage-user` Edge Function. Use multi-event COMPLEX-CASE Pattern A v2 (same shape as `api.update_role`). Defer activation until `manage-user update_notification_preferences` extraction ships and proves the pattern.
+
+## Phases
+
+| Phase | Description |
+|-------|-------------|
+| 0 | Activation gate — check that `manage-user-to-sql-rpc` (update_notification_preferences) has shipped; inspect modify_roles case + event emission pattern |
+| 1 | Migration: create RPC with captured `v_event_ids uuid[]` pattern |
+| 2 | Frontend service cutover |
+| 3 | Edge Function cleanup |
+| 4 | Verification + PR |
+
+## Open Questions
+
+See `context.md`. Main ones: event emission pattern, permission requirement, response shape.
+
+## Risk
+
+- **R1** — Complexity relative to single-event extraction. Use `update_role` migration as reference.
+- **R2** — Activation gate depends on completion of Card 1 (high-priority).

--- a/dev/active/manage-user-modify-roles-to-sql-rpc/tasks.md
+++ b/dev/active/manage-user-modify-roles-to-sql-rpc/tasks.md
@@ -1,0 +1,22 @@
+# manage-user modify_roles → SQL RPC — Tasks
+
+## Current Status
+
+**Phase**: SEEDED — awaiting activation after (1) `edge-function-vs-sql-rpc-adr` PR merges AND (2) `manage-user-to-sql-rpc` (update_notification_preferences) ships
+**Status**: 🟢 ACTIVE (scaffold only)
+**Priority**: Low
+
+## Pre-activation Checklist
+
+- [ ] `adr-edge-function-vs-sql-rpc.md` PR merged
+- [ ] `manage-user-to-sql-rpc` (notification_preferences) shipped
+- [ ] Learnings from that extraction captured (patterns, gotchas)
+
+## Tasks
+
+- [ ] Phase 0 — Inspect modify_roles case; resolve context.md questions
+- [ ] Phase 1 — Migration with multi-event `v_event_ids uuid[]` Pattern A v2
+- [ ] Phase 2 — Frontend cutover
+- [ ] Phase 3 — Edge Function cleanup + DEPLOY_VERSION bump
+- [ ] Phase 4 — Verification + PR
+- [ ] Post-merge — Archive + append ADR Rollout history

--- a/dev/active/manage-user-reactivate-to-sql-rpc/context.md
+++ b/dev/active/manage-user-reactivate-to-sql-rpc/context.md
@@ -1,0 +1,40 @@
+# manage-user reactivate → SQL RPC — Context
+
+**Feature**: Extract `reactivate` operation from `manage-user` Edge Function into a SQL RPC
+**Status**: 🟢 ACTIVE — Seeded 2026-04-24 by `edge-function-vs-sql-rpc-adr` PR #33 remediation; **blocked** pending missing-handler fix
+**Priority**: Medium
+**Current branch**: TBD
+
+## Activation Trigger
+
+- ✅ `adr-edge-function-vs-sql-rpc.md` published (v1, 2026-04-24)
+- **Reclassified from `load-bearing` (LB1) to `candidate-for-extraction` during PR #33 review audit** (2026-04-24). Original classification assumed the op was load-bearing via `auth.admin.updateUserById`, but grep of `manage-user/index.ts` shows the ban-state sync call at line 721 is gated on `operation === 'deactivate'` only. `reactivate` emits the `user.reactivated` event but makes no `auth.admin` call.
+- **Blocker**: Handler `handle_user_reactivated` is missing from the repo. Must resolve `dev/active/fix-missing-user-lifecycle-handlers/` before this extraction can proceed — the SQL RPC needs a working handler to update `users_projection` after emission.
+
+## Scope
+
+### In scope
+- New SQL RPC (likely `api.reactivate_user`) with Pattern A v2 by construction
+- Remove the `reactivate` case from `manage-user/index.ts`
+- Frontend service cutover
+
+### Out of scope
+- `deactivate` extraction (classified `load-bearing` via LB1 — auth.admin ban call)
+- Fixing the missing `handle_user_reactivated` handler — tracked separately
+
+## Open questions (Phase 0 must resolve)
+
+- **O1 — Is the current "no `auth.admin` on reactivate" semantic intentional, or a latent bug?** The comment at `manage-user/index.ts:723` (`ban_duration: 'none' // Use 'none' to indicate unbanned`) was written as if reactivate should unban the user in `auth.users`, but the `if` guard on line 719 only fires for `deactivate`. Either:
+  - (a) Design intent is "reactivate restores the projection row only; the user was never banned at auth.users level, so no unban is needed"
+  - (b) It's a real bug — reactivate should ALSO call `auth.admin.updateUserById` with an unban value, and the current code never does
+
+  If (b), the extraction must include the missing unban call — which **reclassifies the op back to load-bearing (LB1)** and invalidates this card's scope. Phase 0 must confirm intent before migration design.
+
+- **O2** — Once `handle_user_reactivated` exists, what projection fields does it update? `reactivated_at`, clearing `deactivated_at`, or both? This shapes the RPC's read-back expectations.
+
+## Reference Materials
+
+- [adr-edge-function-vs-sql-rpc.md](../../../documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md) — activation ADR (inventory row 9)
+- [adr-rpc-readback-pattern.md](../../../documentation/architecture/decisions/adr-rpc-readback-pattern.md) — Pattern A v2 contract
+- `infrastructure/supabase/supabase/functions/manage-user/index.ts` — current reactivate case (lines 676–680 + shared emit path 660–710)
+- `dev/active/fix-missing-user-lifecycle-handlers/` — prerequisite handler-fix issue (to be created after PR #33 merges)

--- a/dev/active/manage-user-reactivate-to-sql-rpc/plan.md
+++ b/dev/active/manage-user-reactivate-to-sql-rpc/plan.md
@@ -1,0 +1,29 @@
+# manage-user reactivate → SQL RPC — Plan
+
+## Executive Summary
+
+Extract `reactivate` from `manage-user` Edge Function into an SQL RPC. Blocked pending resolution of missing-handler issue + Phase 0 clarification of reactivate's intended `auth.admin` semantic.
+
+## Phases
+
+| Phase | Description |
+|-------|-------------|
+| 0 | Resolve O1 (intent) + O2 (handler projection fields). If O1 resolves to "bug, should unban" → reclassify LB1, park this card, re-route to retrofit backlog. |
+| 1 | Migration: create `api.reactivate_user` with Pattern A v2 |
+| 2 | Frontend service cutover |
+| 3 | Edge Function cleanup + DEPLOY_VERSION bump |
+| 4 | Verification + PR |
+
+## Prerequisites
+
+- [ ] `dev/active/fix-missing-user-lifecycle-handlers/` resolved (creates `handle_user_reactivated`)
+- [ ] Phase 0 O1 confirms current no-`auth.admin` behavior is intentional (otherwise reclassify to load-bearing)
+
+## Open Questions
+
+See `context.md` (O1, O2).
+
+## Risk
+
+- **R1** — If Phase 0 reveals O1 is a bug, extraction scope changes fundamentally. Keeping the card medium priority until Phase 0 runs.
+- **R2** — `handle_user_reactivated` semantic depends on the missing-handlers fix. Extraction test plan must verify the handler's projection writes before the RPC's read-back will work.

--- a/dev/active/manage-user-reactivate-to-sql-rpc/tasks.md
+++ b/dev/active/manage-user-reactivate-to-sql-rpc/tasks.md
@@ -1,0 +1,23 @@
+# manage-user reactivate → SQL RPC — Tasks
+
+## Current Status
+
+**Phase**: SEEDED — blocked on 2 prerequisites
+**Status**: 🟢 ACTIVE (scaffold only)
+**Priority**: Medium
+**Created**: 2026-04-24 (PR #33 remediation; reclassification of inventory row 9)
+
+## Prerequisites
+
+- [ ] `dev/active/fix-missing-user-lifecycle-handlers/` resolved (creates `handle_user_reactivated`)
+- [ ] Phase 0 O1 confirms no-`auth.admin`-on-reactivate is intentional (OR reclassify to load-bearing and park)
+
+## Tasks
+
+- [ ] Phase 0 — Resolve O1 (intent) + O2 (handler projection fields)
+- [ ] **Gate** — If O1 reveals bug → reclassify LB1, park card, re-route to load-bearing retrofit backlog
+- [ ] Phase 1 — Migration creating `api.reactivate_user` with Pattern A v2
+- [ ] Phase 2 — Frontend cutover
+- [ ] Phase 3 — Edge Function cleanup + DEPLOY_VERSION bump
+- [ ] Phase 4 — Verification + PR
+- [ ] Post-merge — Archive + append ADR Rollout history

--- a/dev/active/manage-user-to-sql-rpc/context.md
+++ b/dev/active/manage-user-to-sql-rpc/context.md
@@ -1,0 +1,60 @@
+# manage-user → SQL RPC (update_notification_preferences) — Context
+
+**Feature**: Extract `update_notification_preferences` operation from the `manage-user` Edge Function into a SQL RPC in the `api.` schema
+**Status**: 🟢 ACTIVE — Seeded by `edge-function-vs-sql-rpc-adr` (2026-04-24); scope pinned to this one operation
+**Priority**: **High** — architect-validated first extraction target (PR #32 architect `a060ef3faaa5b630c`, "strictly superior architecturally")
+**Supersedes**: Blocker-3-followup-7 from the archived `api-rpc-readback-pattern` feature
+**Current branch**: TBD — start from `main` after the ADR PR merges
+
+## Activation Trigger
+
+- ✅ `adr-edge-function-vs-sql-rpc.md` published (v1, 2026-04-24)
+- Classification: Phase 0 inventory row #12 — `candidate-for-extraction`; all 6 LB criteria are ❌; Pattern A v2 reference implementation already in place in TypeScript
+
+## Scope
+
+### In scope
+- New SQL RPC at `api.update_user_notification_preferences` (name to be finalized)
+  - Signature matches the current Edge Function payload: `(p_user_id uuid, p_organization_id uuid, p_notification_preferences jsonb, p_reason text)`
+  - Full Pattern A v2: capture event_id → projection read-back → `processing_error` check → envelope return
+  - Returns `{success: true, notificationPreferences: <projection row>}` on success
+- Edge Function `manage-user` loses its `update_notification_preferences` case:
+  - Either (a) delete the case branch (clean cutover) or (b) keep a thin proxy that forwards to the new RPC (dual-deploy safety window), then delete in a follow-up
+- Frontend service (`SupabaseUserCommandService.updateNotificationPreferences`) switches from `supabase.functions.invoke('manage-user', { body: { operation: 'update_notification_preferences', ... }})` to `supabase.schema('api').rpc('update_user_notification_preferences', ...)`
+- AsyncAPI contract unchanged (event type / stream_type stay the same)
+
+### Out of scope
+- Other `manage-user` operations (`deactivate`, `reactivate`, `delete`, `modify_roles`) — separate cards
+- Pattern A v2 retrofit of `manage-user` load-bearing ops (`deactivate`, `reactivate`) — tracked separately
+- Renaming `user_notification_preferences_projection` or its schema
+
+## Why this is the right first extraction
+
+Per `adr-edge-function-vs-sql-rpc.md` Decision 5, `manage-user update_notification_preferences` (v11) is the SOLE reference implementation cited for Pattern A v2 in an Edge Function — and the architect already concluded that the SQL RPC form would be strictly superior:
+- Single-transaction PL/pgSQL read-back instead of two TypeScript round-trips
+- No version-gated fallback (current v11 uses `deployVersion: 'v11-pattern-a-v2-readback'` marker)
+- No snake↔camel transformation at the response boundary — RPC returns the projection row shape directly
+- Consolidates two deploy surfaces (function + migration) into one (migration only)
+
+Frontend consumers already expect the `{success, notificationPreferences}` envelope shape; the migration is compatible at the TypeScript type level.
+
+## Rollout considerations
+
+- **Dual-deploy vs direct cutover**: The Edge Function currently returns `deployVersion` in its envelope. Dual-deploy means: land the SQL RPC + frontend cutover + KEEP the Edge Function case branch as a fallback for 1–2 weeks, then delete the branch. Direct cutover means: land the SQL RPC + frontend cutover + delete the Edge Function case branch in the same PR. Recommendation: direct cutover, given the narrow consumer surface and the architect's already-validated design.
+- **Rollback**: If the SQL RPC form fails post-deploy, rollback = revert the frontend service change; the Edge Function remains callable via `supabase.functions.invoke()`. Direct cutover deletes the Edge Function path, so rollback requires redeploying the function. Dual-deploy preserves an in-place fallback.
+- **Zero pre-existing callers outside the frontend**: Verify via git grep across `workflows/`, admin scripts, smoke tests.
+
+## Constraints
+
+- Preserve the `processing_error` surfacing behavior. Existing v11 consumer VMs expect `{success: false, error: 'Event processing failed: ...'}` on handler failure; new RPC must produce the same envelope.
+- Do NOT change AsyncAPI event definitions (`user.notification_preferences.updated` stays on the `user` stream).
+- The handler (`handle_user_notification_preferences_updated`) is UPSERT-based; read-back NOT-FOUND is a genuine invariant violation (not a stale-row case) and must be logged accordingly.
+
+## Reference Materials
+
+- [adr-edge-function-vs-sql-rpc.md](../../../documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md) — activation ADR
+- [adr-rpc-readback-pattern.md](../../../documentation/architecture/decisions/adr-rpc-readback-pattern.md) — Pattern A v2 contract that the new RPC must implement
+- `infrastructure/supabase/supabase/functions/manage-user/index.ts` — current v11 implementation (reference-impl two-step check to port)
+- `infrastructure/supabase/handlers/user/handle_user_notification_preferences_updated.sql` — handler that the read-back must confirm wrote the row
+- `frontend/src/services/users/SupabaseUserCommandService.ts` — `updateNotificationPreferences` consumer that will switch to `rpc()`
+- `dev/archived/api-rpc-readback-pattern/` — archived feature that motivated this extraction

--- a/dev/active/manage-user-to-sql-rpc/context.md
+++ b/dev/active/manage-user-to-sql-rpc/context.md
@@ -24,8 +24,8 @@
 - AsyncAPI contract unchanged (event type / stream_type stay the same)
 
 ### Out of scope
-- Other `manage-user` operations (`deactivate`, `reactivate`, `delete`, `modify_roles`) — separate cards
-- Pattern A v2 retrofit of `manage-user` load-bearing ops (`deactivate`, `reactivate`) — tracked separately
+- Other `manage-user` operations (`deactivate`, `reactivate`, `delete`, `modify_roles`) — separate cards (note: `reactivate` reclassified as `candidate-for-extraction` 2026-04-24; see `dev/active/manage-user-reactivate-to-sql-rpc/`)
+- Pattern A v2 retrofit of `manage-user deactivate` (remaining LB1 op) — tracked separately; blocked on `dev/active/fix-missing-user-lifecycle-handlers/`
 - Renaming `user_notification_preferences_projection` or its schema
 
 ## Why this is the right first extraction
@@ -36,7 +36,7 @@ Per `adr-edge-function-vs-sql-rpc.md` Decision 5, `manage-user update_notificati
 - No snake↔camel transformation at the response boundary — RPC returns the projection row shape directly
 - Consolidates two deploy surfaces (function + migration) into one (migration only)
 
-Frontend consumers already expect the `{success, notificationPreferences}` envelope shape; the migration is compatible at the TypeScript type level.
+Frontend consumers already expect the `{success, notificationPreferences}` envelope shape at the service-boundary level. The open question Phase 0 must resolve (per `plan.md` R2) is whether the RPC returns **camelCase** directly (making the service mapper a no-op, but creating drift between the RPC shape and the AsyncAPI snake_case convention) or **snake_case** (preserving AsyncAPI alignment, requiring the mapper to continue converting). This is the primary design decision for the extraction — not a pre-answered compatibility claim.
 
 ## Rollout considerations
 

--- a/dev/active/manage-user-to-sql-rpc/plan.md
+++ b/dev/active/manage-user-to-sql-rpc/plan.md
@@ -1,0 +1,111 @@
+# manage-user → SQL RPC (update_notification_preferences) — Plan
+
+## Executive Summary
+
+Port the `update_notification_preferences` operation of `manage-user` Edge Function v11 to a new `api.update_user_notification_preferences` SQL RPC. Pattern A v2 read-back moves from two TypeScript round-trips to one in-transaction PL/pgSQL block. Frontend service cuts over from `functions.invoke()` to `rpc()`. AsyncAPI contract unchanged.
+
+## Scope
+
+See `context.md`. In scope: one SQL RPC + one frontend service method + delete the Edge Function case. Out of scope: other `manage-user` ops.
+
+## Phases
+
+| Phase | Description | Deliverable |
+|-------|------------|-------------|
+| 0 | Signature design — match Edge Function payload | Documented param list in this plan |
+| 1 | Migration: create `api.update_user_notification_preferences` with Pattern A v2 | `supabase/migrations/<timestamp>_extract_user_notification_preferences_rpc.sql` |
+| 2 | Frontend service cutover | `SupabaseUserCommandService.updateNotificationPreferences` uses `rpc()`; mock service mirrors |
+| 3 | Edge Function cleanup | Remove `update_notification_preferences` case from `manage-user/index.ts`; bump version marker (v12) |
+| 4 | Verification | Manual test via dev project; unit tests in `SupabaseUserCommandService.mapping.test.ts` updated to reflect RPC path |
+| 5 | PR + merge | Single PR, direct cutover (no dual-deploy per context.md recommendation) |
+
+## Phase 1 — Migration details (to be fleshed out pre-execution)
+
+Canonical form:
+
+```sql
+CREATE OR REPLACE FUNCTION api.update_user_notification_preferences(
+    p_user_id uuid,
+    p_organization_id uuid,
+    p_notification_preferences jsonb,
+    p_reason text DEFAULT 'User updated notification preferences'
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, api, pg_temp
+AS $$
+DECLARE
+    v_event_id uuid;
+    v_row public.user_notification_preferences_projection%ROWTYPE;
+    v_processing_error text;
+BEGIN
+    -- Permission check + caller-driven failures (pre-emit) elided here;
+    -- will be expanded to mirror current Edge Function checks.
+
+    v_event_id := api.emit_domain_event(
+        p_stream_id      := p_user_id,
+        p_stream_type    := 'user',
+        p_event_type     := 'user.notification_preferences.updated',
+        p_event_data     := jsonb_build_object(
+            'organization_id', p_organization_id,
+            'notification_preferences', p_notification_preferences
+        ),
+        p_event_metadata := jsonb_build_object(
+            'user_id', auth.uid(),
+            'organization_id', p_organization_id,
+            'reason', p_reason
+        )
+    );
+
+    SELECT * INTO v_row
+    FROM public.user_notification_preferences_projection
+    WHERE user_id = p_user_id AND organization_id = p_organization_id;
+
+    IF NOT FOUND THEN
+        SELECT processing_error INTO v_processing_error
+        FROM domain_events WHERE id = v_event_id;
+        RETURN jsonb_build_object(
+            'success', false,
+            'error', 'Event processing failed: ' || COALESCE(v_processing_error, 'handler invariant violated: projection row missing after UPSERT')
+        );
+    END IF;
+
+    SELECT processing_error INTO v_processing_error
+    FROM domain_events WHERE id = v_event_id;
+    IF v_processing_error IS NOT NULL THEN
+        RETURN jsonb_build_object(
+            'success', false,
+            'error', 'Event processing failed: ' || v_processing_error
+        );
+    END IF;
+
+    RETURN jsonb_build_object(
+        'success', true,
+        'notificationPreferences', jsonb_build_object(
+            'user_id', v_row.user_id,
+            'organization_id', v_row.organization_id,
+            'email_notifications', v_row.email_notifications,
+            'in_app_notifications', v_row.in_app_notifications
+            -- TODO: confirm exact projection column list before landing
+        )
+    );
+END;
+$$;
+```
+
+**Open questions** (resolve during Phase 0):
+- Exact projection column shape — confirm against `user_notification_preferences_projection` schema
+- Permission check — current Edge Function v11 uses `hasPermission(effectivePermissions, 'user.update')`? Confirm and port.
+- Mapping — should we return snake_case or camelCase keys? Current frontend type `UpdateNotificationPreferencesResult.notificationPreferences` expects `snake_case` per AsyncAPI convention; verify.
+
+## Risks & Open Questions
+
+- **R1** — Permission semantics. Edge Function has JWT access + service-role secret separation. SQL RPC `SECURITY DEFINER` with RLS check via `auth.uid()` must reproduce the same authorization. Resolution: during Phase 0, enumerate every permission/invariant check currently in v11 and map each to a PL/pgSQL expression.
+- **R2** — Test drift. `SupabaseUserCommandService.mapping.test.ts` (added during PR #32) tests the snake→camel mapping layer. If the new RPC returns camelCase directly, the mapping test becomes a no-op and should be replaced with an RPC-boundary contract test.
+- **O1** — Should the new RPC replace the `manage-user` case or dual-deploy as a shim? See context.md — recommendation is direct cutover.
+
+## Pre-implementation gates
+
+- [ ] Confirm projection column list via Supabase MCP `list_tables`
+- [ ] Enumerate v11 permission/invariant checks; decide SQL port strategy
+- [ ] Architect pre-review of the final RPC signature + body? (Optional — Pattern A v2 is well-established; this is a mechanical port)

--- a/dev/active/manage-user-to-sql-rpc/tasks.md
+++ b/dev/active/manage-user-to-sql-rpc/tasks.md
@@ -1,0 +1,57 @@
+# manage-user → SQL RPC (update_notification_preferences) — Tasks
+
+## Current Status
+
+**Phase**: SEEDED — awaiting activation after `edge-function-vs-sql-rpc-adr` PR merges
+**Status**: 🟢 ACTIVE (scaffold only, no work started)
+**Last Updated**: 2026-04-24
+**Branch**: TBD (start from `main` after ADR PR merges)
+**Priority**: **High** — first extraction target per ADR inventory
+
+## Pre-activation Checklist
+
+- [ ] `adr-edge-function-vs-sql-rpc.md` PR merged to main
+- [ ] No blocking concurrent work on `manage-user` Edge Function
+- [ ] Confirmed zero non-frontend callers (grep `workflows/`, admin scripts, smoke tests)
+
+## Phase 0 — Signature + Port Design 🟡 NOT STARTED
+
+- [ ] Confirm `user_notification_preferences_projection` schema (columns, PK)
+- [ ] Enumerate v11 permission checks and map to PL/pgSQL
+- [ ] Finalize RPC name (`api.update_user_notification_preferences`?)
+- [ ] Decide response shape — match current TypeScript or switch to snake_case
+
+## Phase 1 — Migration 🟡 NOT STARTED
+
+- [ ] `supabase migration new extract_user_notification_preferences_rpc`
+- [ ] Implement Pattern A v2 body per plan.md template
+- [ ] Apply via `supabase db push --linked`
+- [ ] Verify via post-apply dump
+
+## Phase 2 — Frontend Cutover 🟡 NOT STARTED
+
+- [ ] `SupabaseUserCommandService.updateNotificationPreferences` → `rpc()`
+- [ ] `MockUserCommandService.updateNotificationPreferences` → mirror envelope
+- [ ] Update/replace `SupabaseUserCommandService.mapping.test.ts` tests that targeted the Edge Function path
+
+## Phase 3 — Edge Function Cleanup 🟡 NOT STARTED
+
+- [ ] Remove `update_notification_preferences` case from `manage-user/index.ts`
+- [ ] Bump DEPLOY_VERSION to `v12-post-notification-prefs-extraction` (or similar)
+- [ ] Deploy via `supabase functions deploy manage-user`
+- [ ] Update `documentation/infrastructure/reference/edge-functions/manage-user.md` to reflect the smaller operation surface
+
+## Phase 4 — Verification 🟡 NOT STARTED
+
+- [ ] Manual dev-project test: update prefs via frontend, confirm round-trip
+- [ ] Manual dev-project test: force handler failure, confirm `{success: false, error: 'Event processing failed: ...'}` surfaces correctly
+- [ ] `npm run test` in `frontend/` passes
+- [ ] Architect spot-review (optional)
+
+## Phase 5 — PR + Merge 🟡 NOT STARTED
+
+- [ ] Commit on extraction branch
+- [ ] Open PR referencing ADR + this dev-doc
+- [ ] Post-merge: archive `dev/active/manage-user-to-sql-rpc/` → `dev/archived/`
+- [ ] Post-merge: append to ADR Rollout history ("2026-XX-XX — update_notification_preferences extracted; inventory row 12 moves `candidate` → `extracted`")
+- [ ] Post-merge: `MEMORY.md` note on the first Edge Function → SQL RPC extraction

--- a/documentation/AGENT-INDEX.md
+++ b/documentation/AGENT-INDEX.md
@@ -107,8 +107,11 @@ purpose: agent-navigation
 | `deletion-workflow` | [organization-management-architecture.md](architecture/data/organization-management-architecture.md) | activities-reference.md, temporal-overview.md |
 | `dual-write` | [cqrs-dual-write-audit.md](../dev/archived/cqrs-dual-write-audit/cqrs-dual-write-audit-context.md) | event-handler-pattern.md, event-processing-patterns.md |
 | `duration-ms` | [event-observability.md](infrastructure/guides/event-observability.md) | event-metadata-schema.md |
-| `edge-function` | [EDGE_FUNCTION_TESTS.md](infrastructure/guides/supabase/EDGE_FUNCTION_TESTS.md) | DEPLOYMENT_INSTRUCTIONS.md |
+| `edge-function` | [EDGE_FUNCTION_TESTS.md](infrastructure/guides/supabase/EDGE_FUNCTION_TESTS.md) | DEPLOYMENT_INSTRUCTIONS.md, adr-edge-function-vs-sql-rpc.md |
 | `edge-function-jwt` | [JWT-CLAIMS-SETUP.md](infrastructure/guides/supabase/JWT-CLAIMS-SETUP.md) | EDGE_FUNCTION_TESTS.md |
+| `edge-function-vs-sql-rpc` | [adr-edge-function-vs-sql-rpc.md](architecture/decisions/adr-edge-function-vs-sql-rpc.md) | adr-rpc-readback-pattern.md, event-handler-pattern.md |
+| `sql-rpc` | [adr-edge-function-vs-sql-rpc.md](architecture/decisions/adr-edge-function-vs-sql-rpc.md) | adr-rpc-readback-pattern.md, event-handler-pattern.md |
+| `orchestration-tier` | [adr-edge-function-vs-sql-rpc.md](architecture/decisions/adr-edge-function-vs-sql-rpc.md) | adr-rpc-readback-pattern.md |
 | `email` | [resend-email-provider.md](workflows/guides/resend-email-provider.md) | resend-key-rotation.md |
 | `entity-service` | [organization-management-architecture.md](architecture/data/organization-management-architecture.md) | organization-management-architecture.md |
 | `event-archival` | [observability-operations.md](infrastructure/guides/observability-operations.md) | event-observability.md |
@@ -313,6 +316,7 @@ purpose: agent-navigation
 | [adr-client-management-schema.md](architecture/decisions/adr-client-management-schema.md) | ADR: Client management schema — 12 tables, 84 decisions, intake/lifecycle | `adr`, `client-management`, `schema-design`, `intake-form`, `configurable-fields`, `contact-designation`, `placement-history`, `discharge`, `analytics-dimensions`, `enum-reference` | 5000 |
 | [adr-client-ou-placement.md](architecture/decisions/adr-client-ou-placement.md) | ADR: Client OU placement — single-path OU mutation, `client.transfer` permission, row lock, read-time OU state enrichment | `adr`, `client-placement`, `client-transfer`, `organization-unit`, `placement-history`, `row-lock`, `cqrs-read-model` | 1200 |
 | [adr-rpc-readback-pattern.md](architecture/decisions/adr-rpc-readback-pattern.md) | ADR: All `api.update_*`/`change_*` RPCs use Pattern A (return-error envelope) for handler-driven failures; RAISE EXCEPTION forbidden because it rolls back the audit row | `adr`, `rpc-readback`, `processing-error`, `projection-guard`, `api-contract` | 2400 |
+| [adr-edge-function-vs-sql-rpc.md](architecture/decisions/adr-edge-function-vs-sql-rpc.md) | ADR: SQL RPC is the default for write operations; Edge Functions reserved for 6 load-bearing criteria (LB1–LB6). Includes inventory of all 7 Edge Functions with per-operation classification + extraction backlog. | `adr`, `edge-function`, `sql-rpc`, `orchestration-tier`, `cqrs` | 2800 |
 | [multi-tenancy-architecture.md](architecture/data/multi-tenancy-architecture.md) | Organization isolation via RLS and JWT claims | `rls`, `multi-tenant`, `org_id` | 2800 |
 | [event-sourcing-overview.md](architecture/data/event-sourcing-overview.md) | CQRS pattern, domain events, projections | `cqrs`, `events`, `projections` | 2500 |
 | [temporal-overview.md](architecture/workflows/temporal-overview.md) | Workflow orchestration concepts and patterns | `temporal`, `workflow`, `saga` | 3200 |

--- a/documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md
+++ b/documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md
@@ -1,0 +1,284 @@
+---
+status: current
+last_updated: 2026-04-24
+adr_version: v1
+---
+
+<!-- TL;DR-START -->
+## TL;DR
+
+**Summary**: SQL RPC is the default for write operations in A4C-AppSuite; Edge Functions are reserved for operations meeting ≥1 of six load-bearing criteria (LB1–LB6). Every new Edge Function file must cite this ADR; existing ops classified `candidate-for-extraction` in the inventory are migration targets tracked under `dev/active/<function>-to-sql-rpc/`.
+
+**When to read**:
+- Creating a new Edge Function or new `api.*` write RPC
+- Reviewing a PR that adds a new operation to an existing Edge Function
+- Classifying an ambiguous case where the choice isn't obvious
+- Planning extraction of an Edge Function operation to a SQL RPC
+
+**Prerequisites** (recommended): [adr-rpc-readback-pattern.md](./adr-rpc-readback-pattern.md), [event-handler-pattern.md](../../infrastructure/patterns/event-handler-pattern.md)
+
+**Key topics**: `adr`, `edge-function`, `sql-rpc`, `orchestration-tier`, `cqrs`
+
+**Estimated read time**: 12 minutes
+<!-- TL;DR-END -->
+
+# ADR: Edge Function vs SQL RPC Selection
+
+**Date**: 2026-04-24
+**Status**: Current (initial publication)
+**ADR version**: v1
+**Deciders**: Lars (architect), software-architect-dbc (pre-review agents `a060ef3faaa5b630c` + `afc812e89a6fbed46`), Claude (drafting)
+
+## Context
+
+A4C-AppSuite has two orthogonal ways to implement write operations invoked by the frontend:
+
+1. **SQL RPCs** — PL/pgSQL functions in the `api.` schema, called via `supabase.schema('api').rpc(...)`. Single round-trip. RLS + JWT claim helpers (`get_current_org_id()`, `has_platform_privilege()`) enforce auth. After the 2026-04-23 retrofit (see [adr-rpc-readback-pattern.md](./adr-rpc-readback-pattern.md)), every write RPC follows Pattern A v2 (in-transaction projection read-back + captured-event-id processing_error check).
+
+2. **Edge Functions** — Deno TypeScript modules under `infrastructure/supabase/supabase/functions/`, called via `supabase.functions.invoke(...)`. Run in Deno Deploy. Can hold Supabase Auth admin secrets, call external APIs, forward to the Backend API / Temporal workflow layer, and serve unauthenticated endpoints with bespoke token validation.
+
+Until now, no written criteria distinguished them. As a consequence:
+
+- Operations that are really "DB write + auth check + permission check + projection read-back" sometimes landed as Edge Functions, because the broader Edge Function already existed and adding a `case` branch was easier than extracting to SQL RPC. The concrete example: `manage-user update_notification_preferences`, which surfaced during PR #32 review. Software-architect-dbc (agent `a060ef3faaa5b630c`) concluded a SQL RPC wrapper would be "strictly superior architecturally" — single-transaction PL/pgSQL read-back, no two-client-call round-trip. The extraction was deferred to this ADR pass.
+- Pattern A v2 read-back semantics had to be re-implemented in TypeScript in `manage-user` v11 (two separate `supabase.from()` calls — one to `domain_events`, one to `user_notification_preferences_projection`) where a SQL RPC would have had atomic in-transaction read-back.
+- New contributors could not tell which tool to reach for; PR reviewers could not consistently redirect.
+
+This ADR establishes selection criteria, classifies every currently-deployed Edge Function operation against those criteria, and lands a four-layer enforcement mechanism to keep the decision consistent over time.
+
+A pre-review was conducted with `software-architect-dbc` agent `afc812e89a6fbed46` (2026-04-24). Verdict: LGTM-with-remediation; all 3 MUST-FIX items + 6 SHOULD-ADD items integrated before Phase 1 drafting. Key architect-driven decisions:
+- Removed "service-role reads of non-`api.` tables" as a positive indicator (false-positive — `SECURITY DEFINER` SQL RPCs can read any table)
+- Scoped Pattern A v2 reference-implementation citation to `update_notification_preferences` only (other `manage-user` ops still have the pre-v11 silent-failure gap; retrofit tracked separately)
+- Added CI citation check as a fourth enforcement layer (zero retrofit for existing files)
+
+## Decisions
+
+### Decision 1 — SQL RPC is the default for write operations
+
+**Decision**: Any new write operation invoked by the frontend MUST be a SQL RPC in the `api.` schema unless it meets at least one load-bearing criterion from Decision 2. Existing Edge Function operations classified `candidate-for-extraction` in the inventory (see below) are migration targets.
+
+**Rationale**: SQL RPCs are cheaper architecturally — single round-trip, in-transaction Pattern A v2 semantics, RLS enforcement without TypeScript mirroring, one deploy surface (migrations) instead of two (migrations + `supabase functions deploy`). Every Edge Function adds an orchestration boundary; every orchestration boundary must justify itself.
+
+### Decision 2 — Load-bearing criteria (LB1–LB6)
+
+An operation is `load-bearing` (→ Edge Function is appropriate) if it meets **one or more** of:
+
+- **LB1 — Mints auth tokens or creates `auth.users` rows.** Requires the Supabase Auth admin client (`supabase.auth.admin.createUser()`, `updateUserById()`, `deleteUser()`) with the service-role secret. Cannot be done from PostgreSQL.
+- **LB2 — Calls external APIs.** Any non-PostgreSQL, non-Supabase-internal service: Cloudflare (DNS), Resend (email), Backend API (workflow trigger), Temporal, OAuth providers, etc. PL/pgSQL can invoke HTTP via `pg_net`, but this is discouraged for credential handling, retry semantics, and observability reasons.
+- **LB3 — Forwards to workflow orchestration layer.** Requests that dispatch to the Backend API → Temporal must pass JWT + auth headers through a trusted edge. The Edge Function is the canonical boundary.
+- **LB4 — Unauthenticated entry point with bespoke token validation.** Invitation-token acceptance, password-reset links, public webhooks — cases where no JWT is available and a custom token (invitation UUID, magic link hash) must be validated. SQL RPCs can be granted to `anon`, but rate-limiting + correlation-id business-scope lookup + token-hash verification is easier to read in TypeScript.
+- **LB5 — Read orchestration of cross-tier state.** Querying Temporal workflow status, external job queues, or other non-PostgreSQL state that can't be answered by a single `api.*` schema SELECT. Example: `workflow-status` reads `bootstrap_workflows` (a projection) but composes the response against Temporal's workflow lifecycle.
+- **LB6 — Emits to a stream whose caller's JWT cannot be RLS-authorized.** The narrow but real case where events must be emitted before the authoritative user/org exists in `auth.users` / `organizations_projection`. `accept-invitation` is the canonical example: it emits `user.created` + `user.role.assigned` + `user.phone.added` for a user that did not exist when the invitation was created.
+
+An operation meeting **zero** of LB1–LB6 is `candidate-for-extraction`: SQL RPC is the correct fit.
+
+### Decision 3 — Explicit non-criterion: service-role reads of non-`api.` tables are NOT load-bearing
+
+**Decision**: "This Edge Function reads `organizations_projection` / `user_notification_preferences_projection` / etc. via the service-role client" is **not** a reason to keep it as an Edge Function.
+
+**Rationale**: A `SECURITY DEFINER` SQL RPC with `SET search_path = public, api, pg_temp` can SELECT from any table. The `api.` schema boundary is a **CQRS rule on the frontend query path** (per [infrastructure/CLAUDE.md](../../../infrastructure/CLAUDE.md) Rule 4), NOT a capability boundary on PL/pgSQL. If the only reason to keep an op in an Edge Function is "it reads a table outside `api.`", extract it — the equivalent SQL RPC is straightforward.
+
+This resolves the MF1 ambiguity flagged during architect pre-review: `invite-user`'s direct read of `organizations_projection` is cited as precedent for service-role reads in the codebase (which IS legitimate inside an Edge Function) but does not itself make the function load-bearing. `invite-user` is load-bearing because it mints auth users (LB1) and calls Resend (LB2), not because it reads orgs.
+
+### Decision 4 — Edge Functions are the orchestration tier; CQRS Rule 4 does not apply to them
+
+**Decision**: The "frontend queries go via `api.` schema RPC only" rule ([infrastructure/CLAUDE.md](../../../infrastructure/CLAUDE.md) Rule 4) is a **browser-facing** contract. Edge Functions run server-side with the service-role secret, outside the RLS enforcement boundary. They may read any table via the service-role client when needed.
+
+**Rationale**: Edge Functions ARE the trust boundary between the browser and the DB-internal projection surface. Once a request is inside an Edge Function, the JWT verification + permission check have already happened. The CQRS rule is protecting the OUT-bound surface (browser can't compose queries that bypass RLS by joining two projections); it is not protecting the INBOUND surface (Edge Function reading for response shaping).
+
+Precedent:
+- `invite-user` reads `organizations_projection` directly (via service-role) to embed org context in the invitation email
+- `manage-user` v11 reads `user_notification_preferences_projection` directly for its Pattern A v2 read-back
+
+Both are legitimate.
+
+### Decision 5 — Pattern A v2 compatibility for load-bearing Edge Function writes
+
+**Decision**: Any Edge Function operation that (a) remains classified `load-bearing` AND (b) performs a DB write MUST implement the two-step Pattern A v2 check via the service-role client:
+
+1. Capture `eventId` from `api.emit_domain_event(...)` return value
+2. After emit: SELECT `processing_error FROM domain_events WHERE id = eventId` — return error envelope if populated
+3. SELECT the projection row to confirm the write applied; return error envelope on NOT FOUND (tagged `handlerInvariantViolated: true` in logs since handlers should UPSERT)
+4. Transform DB columns to the AsyncAPI snake_case shape and include in response: `{success: true, <entity>}`
+5. Response shape conforms to `adr-rpc-readback-pattern.md` Decision 4: `{success, error?, <entity>?}`
+
+**Reference implementation**: `infrastructure/supabase/supabase/functions/manage-user/index.ts` v11, `update_notification_preferences` operation ONLY. Other `manage-user` operations (`deactivate`, `reactivate`, `delete`, `modify_roles`) retain the pre-v11 emit-and-return-success shape and are flagged "Pattern A v2 retrofit TBD" in the inventory. **Do not cite them as references** — the retrofit is a separate follow-up.
+
+**Race safety**: `domain_events.id = eventId` is an indexed PK lookup. The `BEFORE INSERT` trigger `process_domain_event()` runs inside the INSERT transaction, which commits before `api.emit_domain_event(...)` returns. The subsequent Edge Function round-trip always sees the final state of `processing_error` (populated if handler raised, NULL if handler succeeded).
+
+**SQL RPC form is simpler**: the same two-step check is a single PL/pgSQL function body with in-transaction SELECTs — see `adr-rpc-readback-pattern.md` Decisions 1+2 for the canonical form. This is the architectural asymmetry that motivates Decision 1 (SQL RPC is the default).
+
+### Decision 6 — Four-layer enforcement mechanism
+
+To keep the selection criteria consistent over time, four enforcement layers ship together:
+
+**Layer 1 — This ADR as authoritative criteria.** Every guard rail and every migration card forward-links here. Versioned (`adr_version: v1` in frontmatter); future revisions append to Rollout history.
+
+**Layer 2 — SKILL.md + CLAUDE.md guard rails on new work.** Two rules mirrored across `infrastructure/CLAUDE.md` and `.claude/skills/infrastructure-guidelines/SKILL.md`:
+- *"Before creating a new Edge Function, consult this ADR. SQL RPC is the default; Edge Function requires meeting one of the load-bearing criteria (LB1–LB6)."*
+- *"When touching an Edge Function operation classified `candidate-for-extraction` in the inventory, prefer extracting that operation to an SQL RPC in the same PR."*
+
+**Layer 3 — Inventory table as migration backlog.** Every `candidate-for-extraction` op in the inventory seeds a `dev/active/<function>-to-sql-rpc/` folder. The inventory is a point-in-time snapshot (date-stamped with a regeneration recipe); the criteria above are the durable part.
+
+**Layer 4 — CI citation check (NEW-file only).** `.github/workflows/supabase-edge-functions-lint.yml` enforces that new files under `supabase/functions/*/index.ts` cite this ADR in a top-of-file comment:
+
+```typescript
+/**
+ * ADR: documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md
+ * Load-bearing criterion: <which LB this function meets, e.g. "LB1 + LB2">
+ */
+```
+
+The grep uses `git diff --diff-filter=A` so existing file modifications are never blocked. Zero retrofit burden.
+
+## Hybrid case walkthrough — `organization-delete`
+
+Some Edge Functions combine permission checks, `api.*` RPC calls, and workflow-layer forwards. `organization-delete` is the canonical example:
+
+1. Validates JWT + permission (`organization.delete`) — could be SQL RPC
+2. Calls `api.soft_delete_organization(org_id, reason)` via the service-role client — could be SQL RPC
+3. Forwards to Backend API → Temporal workflow trigger for downstream cleanup (DNS, email, cross-tier resources) — **LB3: forwarding to workflow orchestration layer**
+
+Classification: `load-bearing` via LB3. The orchestration-tier forward is the load-bearing capability; steps 1–2 are not independently load-bearing but travel with step 3 naturally (the forward needs the auth'd context + the event emission for downstream consumers).
+
+**Pitfall** the classifier must avoid: "step 1 is SQL-RPC-eligible, step 2 is SQL-RPC-eligible, therefore this is mostly SQL-RPC-eligible and we should split it." That reasoning ignores that the operation's **purpose** is step 3; splitting creates a choreography where the frontend must separately call RPC then Edge Function, multiplying failure modes. Keep the function intact.
+
+## Out-of-scope boundary — Temporal activities
+
+Temporal activities under `workflows/src/activities/` share Edge Functions' service-role access but have **different failure semantics**: saga compensation + retry queues + workflow history, not HTTP request/response. This ADR does **not** govern them. Activity-layer selection is governed by `workflows/src/activities/CLAUDE.md` and the three-layer idempotency pattern documented there.
+
+If a future activity could plausibly be an Edge Function or SQL RPC, escalate the case separately. Don't apply LB1–LB6 to activities — the criteria are calibrated for HTTP-request boundaries.
+
+## Inventory (as of 2026-04-24)
+
+**Point-in-time snapshot** (per SKILL.md anti-staleness Rule 8). Regenerate via:
+
+```bash
+# List all Edge Functions
+find infrastructure/supabase/supabase/functions -name 'index.ts' -not -path '*/_shared/*'
+
+# Per-operation inspection: search top-level switch on 'operation' param;
+# read the body of each case and answer LB1-LB6.
+```
+
+Total: 16 operations across 7 functions, 3,390 LOC. **13 load-bearing** + **3 candidate-for-extraction** + **1 reference-impl candidate** (`update_notification_preferences`, used as Pattern A v2 reference in Decision 5).
+
+| # | Function | Operation | LB1 | LB2 | LB3 | LB4 | LB5 | LB6 | Classification | Notes |
+|---|----------|-----------|-----|-----|-----|-----|-----|-----|----------------|-------|
+| 1 | `accept-invitation` | email/password + oauth user creation | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | **load-bearing** | Mints auth user; invitation-token auth; pre-user events |
+| 2 | `accept-invitation` | emit `user.role.assigned` | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | **load-bearing** | |
+| 3 | `accept-invitation` | emit `user.phone.added` + `user.notification_preferences.updated` | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | **load-bearing** | |
+| 4 | `accept-invitation` | query organization for redirect | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | **load-bearing** | LB4 — unauthenticated via invitation token |
+| 5 | `invite-user` | `create` | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | **load-bearing** | Ensures auth.users + Resend API email |
+| 6 | `invite-user` | `resend` | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | **load-bearing** | Resend API |
+| 7 | `invite-user` | `revoke` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | **candidate-for-extraction** | Pure RPC + event emission on existing invitation |
+| 8 | `manage-user` | `deactivate` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | **load-bearing** | LB1 — `auth.admin.updateUserById` ban. **Pattern A v2 retrofit TBD** |
+| 9 | `manage-user` | `reactivate` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | **load-bearing** | LB1 — ban reversal. **Pattern A v2 retrofit TBD** |
+| 10 | `manage-user` | `delete` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | **candidate-for-extraction** | Pure RPC + event. **Pattern A v2 retrofit inherited on extraction** |
+| 11 | `manage-user` | `modify_roles` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | **candidate-for-extraction** | Pure RPC + 1+N+M events. **Pattern A v2 retrofit TBD** |
+| 12 | `manage-user` | `update_notification_preferences` (v11) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | **candidate-for-extraction** | **Pattern A v2 reference implementation**; architect-validated first extraction target |
+| 13 | `organization-bootstrap` | initiate workflow | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | **load-bearing** | Backend API + workflow status response |
+| 14 | `organization-delete` | trigger deletion | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | **load-bearing** | **Hybrid** — see walkthrough above |
+| 15 | `validate-invitation` | lookup + validate | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | **load-bearing** | LB4 — unauthenticated bespoke token validation |
+| 16 | `workflow-status` | query status | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | **load-bearing** | LB5 — cross-tier state orchestration |
+
+### Function-level composition
+
+| Function | Composition |
+|----------|-------------|
+| `accept-invitation` | All 4 ops load-bearing |
+| `invite-user` | **partial-candidate** (2 load-bearing + 1 candidate `revoke`) |
+| `manage-user` | **partial-candidate** (2 load-bearing + 3 candidates) |
+| `organization-bootstrap` | Load-bearing whole-function |
+| `organization-delete` | Load-bearing whole-function (hybrid) |
+| `validate-invitation` | Load-bearing whole-function |
+| `workflow-status` | Load-bearing whole-function |
+
+### Candidate extraction backlog
+
+Each row below is a seeded follow-up card under `dev/active/<folder>/`:
+
+| Priority | Card | Source op | Notes |
+|----------|------|-----------|-------|
+| **High** | `dev/active/manage-user-to-sql-rpc/` | `update_notification_preferences` | Architect-validated first target. Supersedes Blocker-3-followup-7. Scope = this one op only. |
+| Medium | `dev/active/invite-user-revoke-to-sql-rpc/` | `invite-user revoke` | Pure RPC wrapper; no rollout complexity |
+| Medium | `dev/active/manage-user-delete-to-sql-rpc/` | `manage-user delete` | Couples with Pattern A v2 retrofit opportunity |
+| Low | `dev/active/manage-user-modify-roles-to-sql-rpc/` | `manage-user modify_roles` | 1+N+M event emission; revisit after High-priority card ships |
+
+### Inventory cadence
+
+Walk the inventory every 6 months or when adding a new Edge Function. Append Rollout history entries when a `candidate` extraction ships (moves a row out of `candidate` → "extracted; see migration X").
+
+## Rollout history
+
+- **2026-04-24** — Initial publication (`adr_version: v1`). Establishes criteria LB1–LB6, inventory of 16 operations across 7 functions, four-layer enforcement mechanism (this ADR + `infrastructure/CLAUDE.md` guard rails + `.claude/skills/infrastructure-guidelines/SKILL.md` mirror + CI citation check). Seeds 4 extraction follow-up cards. No operations extracted in this PR.
+
+## Alternatives considered
+
+### Status quo (no written criteria)
+
+Rejected. Evidence: `manage-user update_notification_preferences` is the worked example — it landed as an Edge Function `case` branch because that was the path of least resistance at the time, not because it met any load-bearing criterion. Software-architect-dbc (agent `a060ef3faaa5b630c`) reviewing PR #32 concluded a SQL RPC wrapper would be "strictly superior architecturally" but correctly deferred the extraction to this ADR pass. Continuing without criteria would repeat this pattern with every new feature.
+
+### All Edge Functions, no SQL RPCs
+
+Rejected. Violates Pattern A v2 atomicity — the in-transaction read-back is only possible inside a single PL/pgSQL function body. Two-step TypeScript implementations (e.g., `manage-user` v11) work but are strictly more complex: two `supabase.from()` round-trips, manual snake↔camel conversion, version-gated response envelope. Reference: [adr-rpc-readback-pattern.md](./adr-rpc-readback-pattern.md) Decisions 1–4.
+
+### All SQL RPCs, no Edge Functions
+
+Rejected. Capability gaps are bright lines:
+- **LB1** (auth user creation, token minting) — requires the Supabase Auth admin client, not available to PL/pgSQL
+- **LB2** (external APIs) — `pg_net` exists but is discouraged for credential handling, retry semantics, and observability
+- **LB3** (workflow-layer forwarding) — needs trusted JWT-forwarding edge
+- **LB4** (unauthenticated token auth) — requires rate limiting + correlation-id lookup; impractical in `anon`-callable SQL
+- **LB5** (cross-tier read orchestration) — requires Temporal client / external queue client
+
+### Per-function (not per-operation) classification
+
+Rejected during architect pre-review (agent `afc812e89a6fbed46`, Q3). `manage-user` is the counterexample: 2 load-bearing ops (deactivate/reactivate use `auth.admin`) + 3 candidate ops. Forcing it into a single bucket either freezes the 3 extractable ops as load-bearing (overclaim) or classifies the whole function as candidate (ignoring `auth.admin`). Per-operation granularity with a function-level `partial-candidate` summary tag is the correct cut.
+
+### Helper function to eliminate the Pattern A v2 two-step boilerplate in Edge Functions
+
+Not a rejection — a noted follow-up. The TypeScript two-step check in `manage-user` v11 is ~30 lines of boilerplate that would be ~5 lines in SQL RPC. If multiple Edge Functions end up staying load-bearing AND doing DB writes, a shared `_shared/pattern-a-v2-check.ts` helper would reduce duplication. Orthogonal to this ADR; revisit when the duplicate sites exist.
+
+## Consequences
+
+### Predictability and review speed
+
+- New-feature authors have a decision flow: "Does my op meet LB1–LB6? If no → SQL RPC."
+- PR reviewers have a consistent redirect: "This is `candidate-for-extraction` per the inventory; please extract or justify why."
+- SKILL.md activation surfaces the rule whenever agents begin infrastructure work (Layer 2).
+- CI check enforces ADR citation on new Edge Function files (Layer 4).
+
+### Migration burden
+
+- 4 `candidate` ops are backlog. `manage-user update_notification_preferences` is architect-validated and ready to extract; the others are lower-priority. Each extraction is its own PR (no Big Bang). The criteria don't force retroactive migration of load-bearing functions.
+
+### Frontend call-site churn during extractions
+
+- Extracting an op changes the frontend service from `supabase.functions.invoke(...)` to `supabase.schema('api').rpc(...)`. The service-layer abstraction (e.g., `IUserCommandService`) typically hides this; each extraction updates one service file.
+- Response envelope stays the same (`{success, error?, <entity>?}`) per Decision 5 — ViewModels don't need changes as long as they consume the envelope through the service interface.
+
+### Deploy-surface consolidation
+
+- Extracting an op turns two deploy surfaces (`supabase db push --linked` for migrations + `supabase functions deploy` for the function) into one (migration only). Subtle but real improvement — reduces the "did I forget to deploy the function?" class of incidents.
+
+### AsyncAPI invariance
+
+- Extraction does **not** change AsyncAPI event definitions. `stream_type` / `event_type` stay the same. The event emitter moves from the Edge Function's `supabase.rpc('emit_domain_event', ...)` to the SQL RPC's `api.emit_domain_event(...)` call — same arguments, same wire format. No contract changes, no consumer re-registration.
+
+### Pattern A v2 retrofit surfaces during extraction
+
+- Extracting `manage-user delete` or `modify_roles` provides an opportunity to fold in Pattern A v2 (they're currently emit-and-return-success). The SQL RPC form includes the read-back by construction. Extraction = retrofit, coupled.
+
+### Observability shifts
+
+- Edge Function logs → Deno Deploy. SQL RPC logs → PostgreSQL (`RAISE NOTICE`) + `processing_error` on `domain_events`. Admin dashboard at `/admin/events` surfaces the latter; extracting an op shifts its observability surface there.
+
+## Related Documentation
+
+- [adr-rpc-readback-pattern.md](./adr-rpc-readback-pattern.md) — SQL-RPC-side Pattern A v2 contract that extractions must conform to; this ADR's Decision 5 is the Edge Function mirror
+- [event-handler-pattern.md](../../infrastructure/patterns/event-handler-pattern.md) — Event dispatcher + handler architecture; router CASE branches + projection read-back guard
+- [event-sourcing-overview.md](../data/event-sourcing-overview.md) — CQRS architecture; read-side / write-side split
+- [rpc-readback-vm-patch.md](../../frontend/patterns/rpc-readback-vm-patch.md) — Frontend VM in-place-patch pattern that consumes Pattern A v2 envelopes from both SQL RPCs and load-bearing Edge Functions
+- [infrastructure/CLAUDE.md](../../../infrastructure/CLAUDE.md) — Rule 4 (CQRS), Rule 9 (API functions must not write projections), Rule 13 (projection read-back guard); guard rails referencing this ADR land alongside it
+- [infrastructure/supabase/CLAUDE.md](../../../infrastructure/supabase/CLAUDE.md) — Supabase-specific migration patterns
+- [adr-client-ou-placement.md](./adr-client-ou-placement.md) — Example ADR with enforcement + rollout history sections used as structural template

--- a/documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md
+++ b/documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md
@@ -67,7 +67,7 @@ An operation is `load-bearing` (→ Edge Function is appropriate) if it meets **
 - **LB3 — Forwards to workflow orchestration layer.** Requests that dispatch to the Backend API → Temporal must pass JWT + auth headers through a trusted edge. The Edge Function is the canonical boundary.
 - **LB4 — Unauthenticated entry point with bespoke token validation.** Invitation-token acceptance, password-reset links, public webhooks — cases where no JWT is available and a custom token (invitation UUID, magic link hash) must be validated. SQL RPCs can be granted to `anon`, but rate-limiting + correlation-id business-scope lookup + token-hash verification is easier to read in TypeScript.
 - **LB5 — Read orchestration of cross-tier state.** Querying Temporal workflow status, external job queues, or other non-PostgreSQL state that can't be answered by a single `api.*` schema SELECT. Example: `workflow-status` reads `bootstrap_workflows` (a projection) but composes the response against Temporal's workflow lifecycle.
-- **LB6 — Emits to a stream whose caller's JWT cannot be RLS-authorized.** The narrow but real case where events must be emitted before the authoritative user/org exists in `auth.users` / `organizations_projection`. `accept-invitation` is the canonical example: it emits `user.created` + `user.role.assigned` + `user.phone.added` for a user that did not exist when the invitation was created.
+- **LB6 — Emits domain events *before the RLS-authoritative row* for the target stream exists** (the caller's JWT, if any, cannot satisfy RLS policies on the target stream's projection). This separates the emitter-auth question (anonymous vs authenticated) from the target-state question (row exists vs not). `accept-invitation` is the canonical example: it emits `user.created` + `user.role.assigned` + `user.phone.added` for a user that did not exist when the invitation was created. A future operation where an authenticated admin creates resources on behalf of a not-yet-materialized user also qualifies — the emitter has a JWT, but the target row doesn't exist yet.
 
 An operation meeting **zero** of LB1–LB6 is `candidate-for-extraction`: SQL RPC is the correct fit.
 
@@ -90,6 +90,8 @@ Precedent:
 - `manage-user` v11 reads `user_notification_preferences_projection` directly for its Pattern A v2 read-back
 
 Both are legitimate.
+
+**Important — does not override Decision 3**: This permission (Edge Functions may read any table via service-role) does NOT elevate service-role reads to load-bearing. Edge Functions CAN read outside `api.`, but that capability alone does not justify keeping an operation as an Edge Function. See Decision 3.
 
 ### Decision 5 — Pattern A v2 compatibility for load-bearing Edge Function writes
 
@@ -130,6 +132,12 @@ To keep the selection criteria consistent over time, four enforcement layers shi
 
 The grep uses `git diff --diff-filter=A` so existing file modifications are never blocked. Zero retrofit burden.
 
+**CI v1 known limitations**:
+- Enforces only that the ADR filename fragment appears in the file (substring match). A file comment such as `// this does NOT follow adr-edge-function-vs-sql-rpc` would pass the check. The required block's **shape** (JSDoc `ADR:` + `Load-bearing criterion:`) is not validated — only the filename fragment presence.
+- Matches only files named `index.ts` per path regex `^infrastructure/supabase/supabase/functions/[^/]+/index\.ts$`. A new Edge Function using `server.ts` / `main.ts` / split across multiple files would silently pass.
+
+Both tradeoffs favor zero false-positives at the cost of known false-negatives. Acceptable for v1; revisit when either limitation surfaces in practice.
+
 ## Hybrid case walkthrough — `organization-delete`
 
 Some Edge Functions combine permission checks, `api.*` RPC calls, and workflow-layer forwards. `organization-delete` is the canonical example:
@@ -160,7 +168,9 @@ find infrastructure/supabase/supabase/functions -name 'index.ts' -not -path '*/_
 # read the body of each case and answer LB1-LB6.
 ```
 
-Total: 16 operations across 7 functions, 3,390 LOC. **12 load-bearing** + **4 candidate-for-extraction** (one of which — `update_notification_preferences` — is also the sole Pattern A v2 reference implementation per Decision 5).
+Total: 16 operations across 7 functions, 3,390 LOC. **11 load-bearing** + **5 candidate-for-extraction** (one of which — `update_notification_preferences` — is also the sole Pattern A v2 reference implementation per Decision 5).
+
+> **Classification audit note (2026-04-24)**: During PR #33 review, an audit of `manage-user reactivate` revealed no `auth.admin` call on its path (the ban/unban call at `manage-user/index.ts:719` is gated on `operation === 'deactivate'`). Row 9 was therefore moved from `load-bearing` (LB1) to `candidate-for-extraction`. The same audit uncovered a separate data-integrity finding: three user-lifecycle handlers referenced by `process_user_event` (`handle_user_deactivated`, `handle_user_reactivated`, `handle_user_deleted`) are missing from the repo — tracked separately at `dev/active/fix-missing-user-lifecycle-handlers/` (filed after PR #33 merges).
 
 | # | Function | Operation | LB1 | LB2 | LB3 | LB4 | LB5 | LB6 | Classification | Notes |
 |---|----------|-----------|-----|-----|-----|-----|-----|-----|----------------|-------|
@@ -171,13 +181,13 @@ Total: 16 operations across 7 functions, 3,390 LOC. **12 load-bearing** + **4 ca
 | 5 | `invite-user` | `create` | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | **load-bearing** | Ensures auth.users + Resend API email |
 | 6 | `invite-user` | `resend` | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | **load-bearing** | Resend API |
 | 7 | `invite-user` | `revoke` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | **candidate-for-extraction** | Pure RPC + event emission on existing invitation |
-| 8 | `manage-user` | `deactivate` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | **load-bearing** | LB1 — `auth.admin.updateUserById` ban. **Pattern A v2 retrofit TBD** |
-| 9 | `manage-user` | `reactivate` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | **load-bearing** | LB1 — ban reversal. **Pattern A v2 retrofit TBD** |
-| 10 | `manage-user` | `delete` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | **candidate-for-extraction** | Pure RPC + event. **Pattern A v2 retrofit inherited on extraction** |
-| 11 | `manage-user` | `modify_roles` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | **candidate-for-extraction** | Pure RPC + 1+N+M events. **Pattern A v2 retrofit TBD** |
+| 8 | `manage-user` | `deactivate` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | **load-bearing** | LB1 — `auth.admin.updateUserById` ban-state sync at `index.ts:721`. **Pattern A v2 retrofit TBD** (blocked on missing `handle_user_deactivated` handler — see `dev/active/fix-missing-user-lifecycle-handlers/`). |
+| 9 | `manage-user` | `reactivate` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | **candidate-for-extraction** | Reclassified 2026-04-24 — no `auth.admin` call on this path (ban gated on `operation === 'deactivate'` at `index.ts:719`). Handler `handle_user_reactivated` missing — see `dev/active/fix-missing-user-lifecycle-handlers/`. |
+| 10 | `manage-user` | `delete` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | **candidate-for-extraction** | Pure RPC + event; no `auth.admin` call. Handler `handle_user_deleted` missing — see `dev/active/fix-missing-user-lifecycle-handlers/`. |
+| 11 | `manage-user` | `modify_roles` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | **candidate-for-extraction** | Pure RPC + 1+N+M events. Existing role-assignment handlers used. |
 | 12 | `manage-user` | `update_notification_preferences` (v11) | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | **candidate-for-extraction** | **Pattern A v2 reference implementation**; architect-validated first extraction target |
 | 13 | `organization-bootstrap` | initiate workflow | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | **load-bearing** | Backend API + workflow status response |
-| 14 | `organization-delete` | trigger deletion | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | **load-bearing** | **Hybrid** — see walkthrough above |
+| 14 | `organization-delete` | trigger deletion | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ | **load-bearing** | **Hybrid** — see [walkthrough](#hybrid-case-walkthrough--organization-delete) above |
 | 15 | `validate-invitation` | lookup + validate | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | **load-bearing** | LB4 — unauthenticated bespoke token validation |
 | 16 | `workflow-status` | query status | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | **load-bearing** | LB5 — cross-tier state orchestration |
 
@@ -187,7 +197,7 @@ Total: 16 operations across 7 functions, 3,390 LOC. **12 load-bearing** + **4 ca
 |----------|-------------|
 | `accept-invitation` | All 4 ops load-bearing |
 | `invite-user` | **partial-candidate** (2 load-bearing + 1 candidate `revoke`) |
-| `manage-user` | **partial-candidate** (2 load-bearing + 3 candidates) |
+| `manage-user` | **partial-candidate** (1 load-bearing + 4 candidates) |
 | `organization-bootstrap` | Load-bearing whole-function |
 | `organization-delete` | Load-bearing whole-function (hybrid) |
 | `validate-invitation` | Load-bearing whole-function |
@@ -201,8 +211,19 @@ Each row below is a seeded follow-up card under `dev/active/<folder>/`:
 |----------|------|-----------|-------|
 | **High** | `dev/active/manage-user-to-sql-rpc/` | `update_notification_preferences` | Architect-validated first target. Supersedes Blocker-3-followup-7. Scope = this one op only. |
 | Medium | `dev/active/invite-user-revoke-to-sql-rpc/` | `invite-user revoke` | Pure RPC wrapper; no rollout complexity |
-| Medium | `dev/active/manage-user-delete-to-sql-rpc/` | `manage-user delete` | Couples with Pattern A v2 retrofit opportunity |
+| Medium | `dev/active/manage-user-delete-to-sql-rpc/` | `manage-user delete` | Blocked on missing `handle_user_deleted` handler (see separate issue). |
+| Medium | `dev/active/manage-user-reactivate-to-sql-rpc/` | `manage-user reactivate` | Reclassified 2026-04-24. Blocked on missing `handle_user_reactivated` handler (see separate issue). Phase 0 must resolve: is the current semantic (no `auth.admin` call) intentional, or a latent bug requiring an unban on reactivate? |
 | Low | `dev/active/manage-user-modify-roles-to-sql-rpc/` | `manage-user modify_roles` | 1+N+M event emission; revisit after High-priority card ships |
+
+### Load-bearing retrofit backlog
+
+Ops classified `load-bearing` that still carry the pre-v11 emit-and-return-success shape (no Pattern A v2 two-step read-back). These are NOT extraction candidates — they meet load-bearing criteria (LB1–LB6) and must remain as Edge Functions — but their silent-failure shape warrants the v11-style Pattern A v2 retrofit per Decision 5.
+
+| Priority | Op | Retrofit action | Blocker |
+|----------|-----|-----------------|---------|
+| High | `manage-user deactivate` | Add Pattern A v2 two-step read-back (per v11 reference impl for `update_notification_preferences`) + include projection entity in response envelope | Missing `handle_user_deactivated` handler — see `dev/active/fix-missing-user-lifecycle-handlers/` |
+
+When the missing-handlers issue resolves, a retrofit card will be seeded at `dev/active/manage-user-deactivate-pattern-a-v2-retrofit/`.
 
 ### Inventory cadence
 

--- a/documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md
+++ b/documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md
@@ -160,7 +160,7 @@ find infrastructure/supabase/supabase/functions -name 'index.ts' -not -path '*/_
 # read the body of each case and answer LB1-LB6.
 ```
 
-Total: 16 operations across 7 functions, 3,390 LOC. **13 load-bearing** + **3 candidate-for-extraction** + **1 reference-impl candidate** (`update_notification_preferences`, used as Pattern A v2 reference in Decision 5).
+Total: 16 operations across 7 functions, 3,390 LOC. **12 load-bearing** + **4 candidate-for-extraction** (one of which — `update_notification_preferences` — is also the sole Pattern A v2 reference implementation per Decision 5).
 
 | # | Function | Operation | LB1 | LB2 | LB3 | LB4 | LB5 | LB6 | Classification | Notes |
 |---|----------|-----------|-----|-----|-----|-----|-----|-----|----------------|-------|

--- a/documentation/architecture/decisions/adr-rpc-readback-pattern.md
+++ b/documentation/architecture/decisions/adr-rpc-readback-pattern.md
@@ -3,6 +3,7 @@ status: current
 last_updated: 2026-04-24
 ---
 
+
 <!-- TL;DR-START -->
 ## TL;DR
 
@@ -327,5 +328,6 @@ The same pattern should be applied to `RpcResult` in `frontend/src/types/client-
 - [event-observability.md](../../infrastructure/guides/event-observability.md) — Failed-event monitoring; `processing_error` query examples; `/admin/events` dashboard reference
 - [event-sourcing-overview.md](../data/event-sourcing-overview.md) — CQRS architecture; why the read-side / write-side split makes the read-back pattern necessary
 - [adr-client-ou-placement.md](./adr-client-ou-placement.md) — Decision 2 Enforcement section is the proof-of-pattern application; this ADR generalizes that decision to all RPCs
+- [adr-edge-function-vs-sql-rpc.md](./adr-edge-function-vs-sql-rpc.md) — When to choose SQL RPC vs Edge Function; Decision 5 of that ADR references the Pattern A v2 contract codified here
 - [infrastructure/supabase/CLAUDE.md](../../../infrastructure/supabase/CLAUDE.md) — "RPC functions that read back from projections MUST check for NOT FOUND" guard rail predates this ADR; cross-referenced in that section
 - [frontend/src/services/CLAUDE.md](../../../frontend/src/services/CLAUDE.md) — Frontend service envelope contract that this ADR's response shape conforms to

--- a/infrastructure/CLAUDE.md
+++ b/infrastructure/CLAUDE.md
@@ -144,6 +144,14 @@ Projection tables are denormalized read models — never query directly with Pos
 | `api.list_users(p_org_id)` | `.from('users').select(..., user_roles_projection!inner(...))` |
 | `api.get_roles(p_org_id)` | `.from('roles_projection').select(..., permissions!inner(...))` |
 
+### Edge Function vs SQL RPC Selection
+
+> **⚠️ Before creating a new Edge Function, consult [adr-edge-function-vs-sql-rpc.md](../documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md).** SQL RPC is the default; Edge Function requires meeting one of the load-bearing criteria (LB1–LB6): auth-user minting, external API calls, workflow-layer forwarding, unauthenticated bespoke token validation, cross-tier read orchestration, or pre-user-existence event emission.
+
+> **Opportunistic migration**: When touching an Edge Function operation classified `candidate-for-extraction` in the ADR's inventory, prefer extracting that operation to an SQL RPC in the same PR.
+
+CI check `.github/workflows/supabase-edge-functions-lint.yml` enforces that NEW Edge Function files cite the ADR in a top-of-file comment. Existing-file modifications are unaffected.
+
 ### Event Metadata Requirements
 
 All domain events emitted via `api.emit_domain_event()` must include audit context. Required fields:

--- a/infrastructure/CLAUDE.md
+++ b/infrastructure/CLAUDE.md
@@ -137,7 +137,7 @@ kubectl get secret workflow-worker-secrets -n temporal -o yaml
 
 > **⚠️ CRITICAL: All frontend queries MUST use `api.` schema RPC functions.**
 
-Projection tables are denormalized read models — never query directly with PostgREST embedding across tables. Detailed rationale + examples in [`supabase/CLAUDE.md`](supabase/CLAUDE.md).
+Projection tables are denormalized read models — never query directly with PostgREST embedding across tables. Detailed rationale + examples in [`supabase/CLAUDE.md`](supabase/CLAUDE.md). **Edge Functions are exempt from this rule** — they are the orchestration tier and may use service-role reads of any table when needed (see next section + ADR Decision 4).
 
 | ✅ Correct | ❌ Wrong |
 |-----------|----------|


### PR DESCRIPTION
## Summary

Establishes written selection criteria between Supabase Edge Functions and SQL RPCs, classifies every currently-deployed Edge Function operation against those criteria, and lands a four-layer enforcement mechanism. Unblocks Blocker-3-followup-7 (the `manage-user update_notification_preferences` extraction architect flagged as "strictly superior architecturally" during PR #32).

## The four layers

1. **ADR as authoritative criteria** — `documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md` (v1, 284 lines). SQL RPC is the default; Edge Function requires meeting one of 6 load-bearing criteria (LB1–LB6): auth-user mint, external API, workflow-layer forwarding, unauthenticated token validation, cross-tier read orchestration, pre-user event emission. Explicit non-criterion: service-role reads of non-`api.` tables are NOT load-bearing.
2. **Guard rails on new code** — `infrastructure/CLAUDE.md` Cross-Cutting Rules + `.claude/skills/infrastructure-guidelines/SKILL.md` Rule 14, both forward-linking the ADR. Opportunistic-migration nudge for touching `candidate-for-extraction` ops.
3. **Migration backlog** — 4 seeded dev-doc cards under `dev/active/<function>-to-sql-rpc/` (context/plan/tasks per card). High-priority: `manage-user-to-sql-rpc` for `update_notification_preferences` (architect-validated first target; supersedes Blocker-3-followup-7).
4. **CI check** — `.github/workflows/supabase-edge-functions-lint.yml` enforcing ADR citation on NEW Edge Function `index.ts` files (`--no-renames --diff-filter=A`; zero retrofit burden on the 7 existing functions).

## Phase 0 inventory headline

16 operations across 7 Edge Functions (3,390 LOC). **12 load-bearing** + **4 candidate-for-extraction**. Per-operation classification; two functions (`invite-user`, `manage-user`) are `partial-candidate` at the function level.

## Architect reviews

- **Pre-review** — `software-architect-dbc` agent `afc812e89a6fbed46` (2026-04-24). Verdict: **LGTM-with-remediation**. 3 MUST-FIX + 6 SHOULD-ADD + 6 blind-spots — all folded before Phase 1 drafting. Tracked in `dev/active/edge-function-vs-sql-rpc-adr/edge-function-vs-sql-rpc-adr-tasks.md`.
- **Post-execution review** — `software-architect-dbc` agent `a986209572b29e519` (2026-04-24). Verdict: **LGTM-TO-SHIP**. Zero MUST-FIX. Three small items folded in commit `9fad4e1c` before this PR opened: inventory count correction (12/4, not 13/3/1); `--no-renames` guard on CI workflow; one-sentence cross-link in CLAUDE.md Rule 4 to Rule 14.
- **Deferred to follow-up** (architect-accepted): CI smoke-test fixtures directory, cosmetic nits, 3 noted risks (deployVersion marker drift, partial-candidate CI enforcement gap, inventory drift discipline).

## Unblocks

- Blocker-3-followup-7 (`manage-user update_notification_preferences` → SQL RPC extraction) — seed card live at `dev/active/manage-user-to-sql-rpc/` with full Pattern A v2 migration template
- Future Edge Function authoring now has a written rubric

## Test plan

- [x] Manual link walk — all 7 relative links in new ADR resolve; 5 forward-links from SKILL.md + CLAUDE.md to ADR verified via grep
- [x] AGENT-INDEX keyword rows match ADR TL;DR Key topics exactly
- [x] Document Catalog entry matches ADR frontmatter + keywords
- [x] `npm run docs:check` — green (pre-existing trailing-slash warning unchanged; this PR does not touch frontend JSDoc)
- [ ] CI workflow live-test — will self-validate on the first PR that adds a new Edge Function (cannot pre-validate without artificially adding one)
- [ ] Four-layer cross-link verification confirmed by architect post-review

## Files

- New: 1 ADR, 1 CI workflow, 12 dev-doc files (4 seed cards × 3)
- Modified: 3 docs (CLAUDE.md + SKILL.md + AGENT-INDEX + adr-rpc-readback cross-link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)