### PR TITLE
docs: file critical card — missing user lifecycle handlers (filing only)

### DIFF
--- a/dev/active/fix-missing-user-lifecycle-handlers/context.md
+++ b/dev/active/fix-missing-user-lifecycle-handlers/context.md
@@ -1,0 +1,107 @@
+# Fix Missing User Lifecycle Handlers — Context
+
+**Feature**: Create the 3 user-lifecycle event handlers that are referenced by `process_user_event` but have never been defined by any migration in the repo
+**Status**: 🔴 CRITICAL — Production data integrity issue
+**Priority**: **HIGH** (blocks 3 downstream seed cards + silent production data corruption)
+**Surfaced**: 2026-04-24 during PR #33 reactivate-classification audit
+**Current branch**: TBD — start from `main`
+
+## Problem Statement
+
+Three handlers referenced in `process_user_event()`'s CASE branches have **never been created** by any migration in the repo:
+
+| Handler | Referenced by | CASE branch location |
+|---------|--------------|----------------------|
+| `handle_user_deactivated` | `process_user_event` | `infrastructure/supabase/handlers/routers/process_user_event.sql:12` + 3 migrations |
+| `handle_user_reactivated` | `process_user_event` | `infrastructure/supabase/handlers/routers/process_user_event.sql:14` + 3 migrations |
+| `handle_user_deleted` | `process_user_event` | `infrastructure/supabase/handlers/routers/process_user_event.sql:15` + 3 migrations |
+
+Evidence:
+- `grep -rln "CREATE.*FUNCTION.*handle_user_deactivated" infrastructure/` returns empty
+- `grep -rln "CREATE.*FUNCTION.*handle_user_reactivated" infrastructure/` returns empty
+- `grep -rln "CREATE.*FUNCTION.*handle_user_deleted" infrastructure/` returns empty
+- Baseline `20260212010625_baseline_v4.sql` mentions these handlers **only in a COMMENT docstring** (line 11550), not as `CREATE FUNCTION` statements
+- No current migration defines them
+- No handler reference file exists at `infrastructure/supabase/handlers/user/handle_user_{deactivated,reactivated,deleted}.sql`
+
+## Historical trace
+
+1. **Pre-Feb 2026** — CASE branches for `user.deactivated`/`reactivated`/`organization_switched` were in the router but handlers never existed
+2. **2026-02-11** — Migration `20260211234604_cleanup_dead_dispatcher_branches_and_legacy_functions.sql` **removed** the CASE branches stating *"3 dead CASE lines in process_user_event() for handler functions that don't exist (handle_user_deactivated, handle_user_reactivated, handle_user_organization_switched)"*
+3. **2026-02-17** — Migration `20260217211231_schedule_template_refactor.sql` (schedule feature) rewrote `process_user_event` and **restored** the CASE branches (line 518)
+4. **2026-02-18** — Migration `20260218234005_restore_user_invited_route.sql` kept the restored branches
+5. **2026-02-20** — Migration `20260220185837_fix_event_routing.sql` kept them again
+6. **2026-04-24** — Surfaced during `dev/archived/edge-function-vs-sql-rpc-adr/` PR #33 review audit (originally looking only at the `reactivate` classification)
+
+Net effect: the `user.deactivated`/`reactivated`/`deleted` event types have been silently failing since Feb 2026, because the router's CASE branches call handler functions that don't exist — `process_user_event` raises `undefined function` errors, which are caught by `process_domain_event`'s catch-all and stored in `processing_error`.
+
+## Impact (if production matches the repo)
+
+- **Deactivate**: `manage-user/index.ts:721` calls `auth.admin.updateUserById` with a ban, so the user IS banned in `auth.users`. But the `user.deactivated` event's projection update (e.g., setting `users.deactivated_at`, `users.is_active = false`) never runs. Projection state is stale — UI shows the user as active, but they can't log in.
+- **Reactivate**: No `auth.admin` call happens (gated on `operation === 'deactivate'` at line 719). The `user.reactivated` event's projection update (clearing `deactivated_at`, setting `is_active = true`) never runs. The operation is completely silent — the user remains banned AND the projection is unchanged.
+- **Delete**: No `auth.admin` call. The `user.deleted` event's projection update (e.g., `users.deleted_at = now()`) never runs. UI continues to show the user; Row Level Security continues to let them query; they can still log in.
+
+Every such call creates a `domain_events` row with `processing_error` populated. The admin dashboard at `/admin/events` should show these.
+
+## Dependency on downstream work
+
+This card BLOCKS 3 seeded extraction cards (all created in PR #33):
+- `dev/active/manage-user-delete-to-sql-rpc/` — SQL RPC form will emit `user.deleted` and expect the handler to update the projection
+- `dev/active/manage-user-reactivate-to-sql-rpc/` — same
+- Future `dev/active/manage-user-deactivate-pattern-a-v2-retrofit/` — retrofit will read back the projection which requires the handler to have updated it
+
+## Scope
+
+### In scope
+- **Audit step first**: Query live dev Supabase to confirm whether the handlers exist in production (possibly added out-of-band via Supabase Studio). Sample queries:
+  ```sql
+  -- Do the handler functions exist?
+  SELECT proname FROM pg_proc
+    WHERE proname IN ('handle_user_deactivated','handle_user_reactivated','handle_user_deleted');
+
+  -- What events have been silently failing?
+  SELECT event_type, count(*), min(created_at), max(created_at)
+    FROM domain_events
+   WHERE event_type IN ('user.deactivated','user.reactivated','user.deleted')
+     AND processing_error IS NOT NULL
+   GROUP BY event_type
+   ORDER BY 1;
+
+  -- Sample the actual error messages
+  SELECT event_type, processing_error, created_at
+    FROM domain_events
+   WHERE event_type IN ('user.deactivated','user.reactivated','user.deleted')
+     AND processing_error IS NOT NULL
+   ORDER BY created_at DESC
+   LIMIT 20;
+  ```
+- **Migration**: `CREATE OR REPLACE FUNCTION` for all three handlers. Each should:
+  - Accept `p_event record`
+  - Use `p_event.stream_id` (NOT `aggregate_id`)
+  - UPSERT into the `users` base table (projection) — NOT separate `users_projection` unless schema says otherwise
+  - Set the appropriate timestamp field (`deactivated_at`, `reactivated_at` / `deactivated_at = NULL`, `deleted_at`)
+  - Respect the Rule 6 `ON CONFLICT DO UPDATE` pattern for idempotency
+- **Handler reference files**: Create `infrastructure/supabase/handlers/user/handle_user_{deactivated,reactivated,deleted}.sql` with the canonical definitions
+- **Backfill**: For each `user.deactivated`/`reactivated`/`deleted` event currently in `domain_events` with `processing_error IS NOT NULL`, call `api.retry_failed_event(event_id)` after the migration lands. This re-fires the handler and clears `processing_error` on success
+
+### Out of scope
+- Extracting `manage-user` operations to SQL RPCs — covered by the 3 seed cards
+- Reactivate `auth.admin` unban question — separately flagged in `manage-user-reactivate-to-sql-rpc/context.md` O1
+- Router reference file refresh — will be touched incidentally (router body unchanged; only handler files added)
+
+## Constraints
+
+- Must use `supabase migration new` CLI (NOT manual file creation) per Rule 1
+- Handlers must be idempotent via `ON CONFLICT` per Rule 6
+- Handler reference files required per Rule 7.1
+- Do NOT touch the `process_user_event` router itself — CASE branches already correct; just create the missing handlers
+- Backfill retry must be a follow-up action after the migration applies, NOT part of the migration (retries modify rows that the migration creates handlers for — order matters)
+
+## Reference Materials
+
+- `infrastructure/supabase/handlers/routers/process_user_event.sql` — router CASE dispatching to the missing handlers
+- `infrastructure/supabase/supabase/migrations.archived/2026-february-cleanup/20260211234604_cleanup_dead_dispatcher_branches_and_legacy_functions.sql` — the archived migration that documented the handlers as non-existent
+- `infrastructure/supabase/supabase/migrations/20260217211231_schedule_template_refactor.sql:518` — restoration of the CASE branches
+- `infrastructure/supabase/handlers/user/*.sql` — existing handler reference file patterns to mirror
+- `documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md` — inventory cross-references to this card
+- `dev/archived/edge-function-vs-sql-rpc-adr/` — PR #33 that surfaced this finding

--- a/dev/active/fix-missing-user-lifecycle-handlers/plan.md
+++ b/dev/active/fix-missing-user-lifecycle-handlers/plan.md
@@ -1,0 +1,140 @@
+# Fix Missing User Lifecycle Handlers — Plan
+
+## Executive Summary
+
+Create the 3 missing handlers (`handle_user_deactivated`, `handle_user_reactivated`, `handle_user_deleted`) that are referenced by `process_user_event`'s CASE branches but have never been defined by any migration. Ship handler reference files. Backfill retry for silently-failed events. Unblocks 3 downstream extraction cards.
+
+## Scope
+
+See `context.md`. In scope: 1 migration with 3 handler definitions + 3 reference files + backfill step. Out of scope: any extraction work, router changes.
+
+## Phases
+
+| Phase | Description | Deliverable |
+|-------|------------|-------------|
+| 0 | Live-DB audit (confirm handlers missing in prod; measure backfill scope) | Documented finding in this plan |
+| 1 | Confirm base-table schema for `users` (or `users_projection`) — what columns need to move on each event? | Schema trace in this plan |
+| 2 | Migration: `CREATE OR REPLACE FUNCTION` for all 3 handlers | `<timestamp>_add_missing_user_lifecycle_handlers.sql` |
+| 3 | Handler reference files | 3 `.sql` files at `infrastructure/supabase/handlers/user/` |
+| 4 | Backfill retry for failed events | Script/SQL recipe applied post-migration |
+| 5 | Verification | Manual test via dev project (emit each event type; confirm projection moves) |
+| 6 | PR + merge | Single PR |
+
+## Phase 0 — Live-DB audit (first work of this card)
+
+Run the queries in `context.md` against dev Supabase via `mcp__supabase__execute_sql`:
+
+1. **Handler existence check** — `pg_proc` query. If handlers exist in production:
+   - Compare their definitions to what we're about to create — possibly the production handlers are buggy or intended
+   - Update reference files to match production + close this card as a hygiene fix (no migration needed)
+2. **Failed event volume** — count by event_type
+3. **Failed event samples** — top 20 by recency
+
+Record findings in this plan before Phase 2.
+
+## Phase 1 — Schema trace
+
+Confirm base-table schema:
+- Does `users` table have `deactivated_at`, `reactivated_at`, `deleted_at`, `is_active`? If not — which columns DO exist for lifecycle state?
+- Is there a separate `users_projection` or is `users` the projection directly? (Baseline shows `users` as the base table; no `users_projection` table exists per handler file names like `handlers/user/handle_user_profile_updated.sql` operating on `users`)
+
+Use:
+```sql
+SELECT column_name, data_type, is_nullable
+  FROM information_schema.columns
+ WHERE table_schema = 'public' AND table_name = 'users'
+ ORDER BY ordinal_position;
+```
+
+## Phase 2 — Migration body (template, to be fleshed out after Phase 0/1)
+
+```sql
+-- ============================================================================
+-- Migration: Add missing user lifecycle handlers
+-- ============================================================================
+-- Handlers `handle_user_deactivated`, `handle_user_reactivated`, and
+-- `handle_user_deleted` are referenced in process_user_event()'s CASE branches
+-- (restored by migration 20260217211231) but were never defined. Every event
+-- of these types has set processing_error on domain_events silently since
+-- Feb 2026.
+--
+-- This migration creates the 3 handlers. Backfill of failed events is a
+-- follow-up step (see plan.md Phase 4).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.handle_user_deactivated(p_event record)
+ RETURNS void
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $$
+BEGIN
+    UPDATE public.users
+       SET deactivated_at = (p_event.event_data->>'deactivated_at')::timestamptz,
+           is_active = false,
+           updated_at = p_event.created_at
+     WHERE id = p_event.stream_id;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'User % not found for user.deactivated event', p_event.stream_id
+            USING ERRCODE = 'P0002';
+    END IF;
+END;
+$$;
+
+-- Similar shape for handle_user_reactivated (clears deactivated_at, sets reactivated_at + is_active=true)
+-- Similar shape for handle_user_deleted (soft-delete: sets deleted_at; does NOT clear other fields)
+```
+
+Open questions requiring Phase 1 confirmation:
+- **Q1** — Is there an `is_active` boolean column, or is activity inferred from `deactivated_at IS NULL`?
+- **Q2** — Does `handle_user_deleted` cascade to `user_roles_projection`, `user_phones`, etc.? Or is cascade handled by FK ON DELETE rules?
+- **Q3** — Should the handler raise or silently succeed on "user already in target state" (double-deactivate)? Idempotency consideration.
+
+## Phase 3 — Handler reference files
+
+Three `.sql` files created from the final migration definitions:
+- `infrastructure/supabase/handlers/user/handle_user_deactivated.sql`
+- `infrastructure/supabase/handlers/user/handle_user_reactivated.sql`
+- `infrastructure/supabase/handlers/user/handle_user_deleted.sql`
+
+Each contains the `CREATE OR REPLACE FUNCTION` block verbatim. Matches Rule 7.1 pattern.
+
+## Phase 4 — Backfill retry
+
+After migration applies:
+
+```sql
+-- Retry each silently-failed event
+SELECT api.retry_failed_event(id)
+  FROM domain_events
+ WHERE event_type IN ('user.deactivated','user.reactivated','user.deleted')
+   AND processing_error IS NOT NULL
+ ORDER BY created_at;
+```
+
+On success, `processing_error` is cleared and the handler runs. Monitor post-retry for new errors (indicates handler logic bugs vs the "missing handler" issue).
+
+## Phase 5 — Verification
+
+1. **Live handler existence**: `SELECT proname FROM pg_proc WHERE proname IN (...);` returns 3 rows.
+2. **Manual event test** (dev project):
+   - Call `manage-user` with `operation: 'deactivate'` on a test user
+   - Query `domain_events` — new row, `processing_error IS NULL`
+   - Query `users` — `deactivated_at` populated, `is_active = false`
+   - Repeat for reactivate and delete
+3. **No regressions** in dependent projections (e.g., `user_roles_projection` if delete cascades)
+
+## Phase 6 — PR
+
+```
+git commit -m "fix(handlers): add missing user lifecycle handlers (deactivated/reactivated/deleted)"
+git push origin <branch>
+gh pr create --base main --title "fix(handlers): missing user lifecycle handlers + backfill" --body ...
+```
+
+## Risks
+
+- **R1** — Handlers exist in production (added out-of-band). Phase 0 audit catches this and downgrades this card to hygiene-only.
+- **R2** — Schema drift: `users` table columns don't match expectations. Phase 1 catches.
+- **R3** — Backfill retry triggers a flood of downstream events (e.g., if deactivate cascades to invalidate sessions). Monitor after Phase 4.
+- **R4** — Test users only exist in prod. If so, Phase 5 needs a create-fresh-test-user step first.

--- a/dev/active/fix-missing-user-lifecycle-handlers/tasks.md
+++ b/dev/active/fix-missing-user-lifecycle-handlers/tasks.md
@@ -1,0 +1,62 @@
+# Fix Missing User Lifecycle Handlers — Tasks
+
+## Current Status
+
+**Phase**: FILED — ready for Phase 0 audit
+**Status**: 🔴 CRITICAL (production data-integrity issue)
+**Priority**: **HIGH** — blocks 3 downstream extraction cards
+**Last Updated**: 2026-04-24
+**Branch**: TBD
+**Surfaced by**: `dev/archived/edge-function-vs-sql-rpc-adr/` PR #33 audit
+
+## Pre-activation Checklist
+
+- [ ] Live-DB audit run (Phase 0) — confirms handlers missing AND measures backfill scope
+- [ ] Decision: execute as-described OR downgrade to hygiene-only if handlers exist in prod
+
+## Phase 0 — Live-DB Audit 🟡 NOT STARTED
+
+- [ ] Query `pg_proc` for handler existence
+- [ ] Count failed `user.deactivated`/`reactivated`/`deleted` events with `processing_error IS NOT NULL`
+- [ ] Sample top 20 error messages by recency
+- [ ] Document findings inline in `plan.md` Phase 0 section
+
+**Decision gate**: If handlers exist in production → downgrade card to "hygiene-only, update reference files to match prod, no migration needed."
+
+## Phase 1 — Schema Trace 🟡 NOT STARTED
+
+- [ ] Confirm `users` table columns — what lifecycle fields exist?
+- [ ] Resolve Q1/Q2/Q3 in plan.md
+
+## Phase 2 — Migration 🟡 NOT STARTED
+
+- [ ] `supabase migration new add_missing_user_lifecycle_handlers`
+- [ ] Define `handle_user_deactivated`
+- [ ] Define `handle_user_reactivated`
+- [ ] Define `handle_user_deleted`
+- [ ] Apply via `supabase db push --linked`
+- [ ] Verify via post-apply `pg_proc` query
+
+## Phase 3 — Handler Reference Files 🟡 NOT STARTED
+
+- [ ] Create `handlers/user/handle_user_deactivated.sql`
+- [ ] Create `handlers/user/handle_user_reactivated.sql`
+- [ ] Create `handlers/user/handle_user_deleted.sql`
+
+## Phase 4 — Backfill Retry 🟡 NOT STARTED
+
+- [ ] Execute retry loop over all failed events of these types
+- [ ] Monitor post-retry for NEW processing errors (signals handler logic bugs)
+
+## Phase 5 — Verification 🟡 NOT STARTED
+
+- [ ] Handlers exist via `pg_proc` query
+- [ ] Manual dev-project test: deactivate → reactivate → delete round-trip; confirm projection moves + no new failed events
+- [ ] No regressions in dependent projections
+
+## Phase 6 — PR + Merge 🟡 NOT STARTED
+
+- [ ] Commit + push on branch
+- [ ] Open PR
+- [ ] Post-merge: archive this card → `dev/archived/fix-missing-user-lifecycle-handlers/`
+- [ ] Post-merge: unblock dependent extraction cards (`manage-user-delete-to-sql-rpc/`, `manage-user-reactivate-to-sql-rpc/`, future deactivate retrofit card) — update their Prerequisites sections


### PR DESCRIPTION
## Summary

Files a critical dev-doc card for a production data-integrity finding surfaced during PR #33 review. **This PR is documentation only** — it adds the card scaffold so the work can be picked up later. The actual fix (migration creating the 3 handlers + backfill retry) is Phase 2 of the card and lands in a separate PR.

## Finding

Three handlers referenced by `process_user_event()`'s CASE branches have never been created by any migration in the repo:
- `handle_user_deactivated`
- `handle_user_reactivated`
- `handle_user_deleted`

Archived migration `20260211234604` explicitly removed these CASE branches in Feb 2026 stating *"3 dead CASE lines in process_user_event() for handler functions that don't exist."* Migrations `20260217211231`, `20260218234005`, and `20260220185837` each restored the CASE lines — but no migration has ever created the handler functions.

**Impact (if production matches the repo)**: every `user.deactivated` / `user.reactivated` / `user.deleted` event since Feb 2026 has set `processing_error` on `domain_events` silently. Projections are stale for deactivated/deleted users; reactivate is a complete no-op beyond the failed event row.

## Card contents

- `context.md` (107 lines): problem statement + evidence + historical trace + impact analysis
- `plan.md` (140 lines): 6 phases — Phase 0 is a live-DB audit that must complete before committing to migration scope
- `tasks.md` (62 lines): checkbox breakdown per phase with decision gate between Phase 0 and Phase 2

## Blocks downstream seed cards

This fix unblocks 3 extraction cards created in PR #33:
- `dev/active/manage-user-delete-to-sql-rpc/`
- `dev/active/manage-user-reactivate-to-sql-rpc/`
- Future `dev/active/manage-user-deactivate-pattern-a-v2-retrofit/`

The `adr-edge-function-vs-sql-rpc.md` inventory rows 8/9/10 already cross-reference this card's path — merging this PR closes the forward-link loop.

## Why file as a PR instead of committing direct to main

Two reasons: (1) the card proposes scope (Phase 0 audit, migration shape, backfill recipe) that benefits from review before Phase 2 starts; (2) consistency with the post-PR-#32 convention of filing dev-docs on branches rather than direct-to-main.

## Next action on merge

Phase 0 live-DB audit — run `pg_proc` query to confirm handler absence in production + measure backfill scope via count of failed events.

## Test plan

- [x] Card has 3 files following the dev-doc convention (context/plan/tasks)
- [x] Cross-references to ADR inventory rows verified
- [x] No code changes (documentation only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)