### PR TITLE
docs(seed): capture frontend feedback + testing-pattern codification

### DIFF
--- a/dev/active/codify-frontend-feedback-and-testing-standards-seed.md
+++ b/dev/active/codify-frontend-feedback-and-testing-standards-seed.md
@@ -1,0 +1,68 @@
+# Codify Frontend Feedback + Testing Standards — Seed Findings
+
+## Source
+
+`software-architect-dbc` review of PR #37 (notification-prefs save toast fix), 2026-04-24.
+[Review comment](https://github.com/Analytics4Change/A4C-AppSuite/pull/37#issuecomment-4316544213) under "Standards worth codifying (post-merge, not this PR)".
+
+The architect deferred two cross-cutting standards to post-merge codification rather than blocking the (small, focused) UX fix on a documentation refactor.
+
+---
+
+## S1: Toast + persistent-banner double-surface convention — LOW / DOCUMENTATION
+
+**Pattern**: Successful and failed command results in the frontend are surfaced via two parallel mechanisms — a transient Sonner `toast.success/error` AND a page-local persistent banner (typically `role="alert"`). The convention is now de facto at three call sites:
+
+- `frontend/src/pages/auth/ResetPasswordPage.tsx:144` — toast only (page redirects, no banner)
+- `frontend/src/viewModels/organization/OrganizationFormViewModel.ts:514` — toast on bootstrap-failure path; VM `error` also bannered by consumer pages
+- `frontend/src/pages/users/UsersManagePage.tsx` (post PR #37) — toast for notification-prefs save; VM `error` cleared on this path to avoid double aria-live
+
+**Problem**: Three call sites, three slightly different policies. New contributors have no canonical guidance:
+- When does toast suffice vs require a banner?
+- When does the banner double-announce alongside the toast (both are `role="alert"`) and how should we resolve that?
+- Are toast colors (richColors `success`/`error`) authoritative for command outcomes, or just one option?
+
+**Target document**: New section in `frontend/CLAUDE.md` ("User Feedback on Command Results") OR new file `documentation/frontend/patterns/command-feedback.md`.
+
+**Proposed content sketch** (for the codification PR):
+
+1. **Default**: success → `toast.success(<short verb-noun message>)`; error → `toast.error(<sanitized user-friendly message>)`.
+2. **Add a persistent banner** when the failure prevents the user from continuing on the same page (e.g. `viewModel.error` bannered on a form they must fix). Don't double up — clear the banner if the toast already announced.
+3. **Sanitization rule**: error envelopes from `api.*` RPCs may contain handler internals (`Event processing failed: <constraint name>`). Strip the prefix and substitute a friendly fallback for the toast / banner; keep the raw form in `log.warn`.
+4. **Aria-live**: when both surfaces are visible simultaneously, exactly one should be `role="alert"`; the other becomes `role="status"` or `aria-live="off"`. Default toast is `alert`, so demote any concurrent banner.
+
+**Recommendation**: Single doc-only PR; ~30 minutes; refactor existing ad-hoc comments into this canonical doc and add a forward-link from `frontend/CLAUDE.md`.
+
+---
+
+## S2: "Extract-to-hook-to-test" as anti-pattern — LOW / DOCUMENTATION
+
+**Pattern**: PR #37's `2ca9d951` commit (subsequently reverted) extracted a 30-line `useCallback` save handler from `UsersManagePage` into a standalone `useNotificationPreferencesSave` hook + a pure `performNotificationPreferencesSave` function, primarily so the toast emission could be unit-tested without rendering the page.
+
+**Why it's an anti-pattern**:
+
+- The hook had exactly one caller and one call site → violates root `CLAUDE.md`'s "three similar lines is better than a premature abstraction".
+- The "test coverage" actually covered the pure helper, not the hook — `useState` + `useCallback` had zero direct coverage.
+- The motivation (`@testing-library/react` not installed) is itself fixable: install the harness, don't redesign the production code around the absence of one.
+- Routing through a bespoke hook bypassed `UsersViewModel.updateNotificationPreferences()` — the canonical write path that owns Pattern A v2 in-place projection patches and `isSubmitting` semantics. Architect flagged this as the same dual-write CQRS-compliance regression class already cleaned up once (see `memory/remediation-history-2026-feb-mar.md`).
+- `useCallback([params])` with `params` as a fresh-object-literal-each-render defeated memoization — silently wasteful, not incorrect.
+
+**Target document**: New "Testing Patterns" section in `frontend/CLAUDE.md`, near the existing MobX testing notes.
+
+**Proposed content sketch**:
+
+> **Test ViewModels as the unit of MobX logic.** A page handler that wraps a VM call is rarely worth its own test — test the VM. Do NOT extract a page-level `useCallback` into a custom hook (or worse, a pure helper called from a hook) purely to reach a test seam. If the project's existing test harness (`@testing-library/react`, `renderHook`) is missing, install it; do not redesign production code around the absence.
+
+> **Antithesis flag**: a hook with one caller, in one file, whose only justification is "now I can unit-test it" — re-evaluate whether the test would be better written against the VM, the service, or a Playwright UAT.
+
+**Tie-in**: Two existing hook test files (`useFocusAdvancement.test.tsx`, `useKeyboardNavigation.test.tsx`) had latent broken `renderHook` imports until PR #37 installed `@testing-library/react`. They're now collectible but 13 of 28 cases still fail — separate concern, not blocked by this codification.
+
+**Recommendation**: Same doc-only PR as S1, OR separate small PR; ~20 minutes; add the new section + forward-link from `documentation/frontend/patterns/`.
+
+---
+
+## Suggested execution
+
+Both S1 and S2 are small documentation tasks that can ship as a single PR ("frontend: codify command-feedback + testing patterns"). Estimated effort: 60–90 minutes including AGENT-INDEX entry + cross-links.
+
+After codification, this seed file moves to `dev/archived/` with a "shipped in PR #N" note.


### PR DESCRIPTION
## Summary

Captures two cross-cutting standards items the `software-architect-dbc` review of PR #37 deferred to post-merge codification:

1. **Toast + persistent-banner double-surface convention** — three call sites with three slightly different policies (`ResetPasswordPage`, `OrganizationFormViewModel`, post-#37 `UsersManagePage`); no canonical guidance on when to use each, sanitization, or aria-live conflict.
2. **\"Extract-to-hook-to-test\" anti-pattern** — PR #37's `2ca9d951` commit (subsequently reverted) extracted a 30-line `useCallback` into a custom hook + pure helper purely to reach a test seam, bypassing the canonical VM write path. Worth codifying so the next person doesn't repeat it.

Mirrors the existing precedent of `dev/active/remediate-frontend-guidelines-seed.md` — single file, no full card scaffolding for short documentation work.

## Files

- New: `dev/active/codify-frontend-feedback-and-testing-standards-seed.md`

## What's in the seed

For each item:
- Source ([architect comment link](https://github.com/Analytics4Change/A4C-AppSuite/pull/37#issuecomment-4316544213))
- Pattern + current evidence (file paths, line numbers)
- Target document (`frontend/CLAUDE.md` and/or `documentation/frontend/patterns/command-feedback.md`)
- Proposed content sketch — so the codification PR is mostly assembly, not investigation
- Effort estimate (~30–60 min for both)

## Test plan

- [x] Single new `.md` file under `dev/active/`; no code touched.
- [x] No further verification required — this is a tracking artifact, not a behavior change.

## Out of scope (next PR)

The actual codification PR will land the `frontend/CLAUDE.md` / `documentation/frontend/patterns/command-feedback.md` content per the sketches in this seed file, and move this seed to `dev/archived/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)