### PR TITLE
refactor(invitation): extract invite-user revoke → api.revoke_invitation RPC

### DIFF
--- a/dev/active/invite-user-revoke-to-sql-rpc/plan.md
+++ b/dev/active/invite-user-revoke-to-sql-rpc/plan.md
@@ -2,23 +2,63 @@
 
 ## Executive Summary
 
-Extract `revoke` operation from `invite-user` Edge Function. Investigation phase first: determine whether this reduces to a frontend-only change (pointing at the existing `api.revoke_invitation` RPC) or requires new RPC work.
+Extract `revoke` operation from the `invite-user` Edge Function. Phase 0 (2026-04-24) confirmed this is **not** a pure RPC forward — the Edge Function carries permission and access-blocked gates that the existing `api.revoke_invitation` RPC does not. Path is **Phase 1'**: modify the existing RPC in place to absorb the Edge Function's gates, grant EXECUTE to `authenticated`, cut the frontend over to direct RPC calls, and remove the Edge Function case.
+
+## Phase 0 Findings (2026-04-24)
+
+**Edge Function `revoke` case** (`infrastructure/supabase/supabase/functions/invite-user/index.ts:538–578`):
+- Above op switch: JWT decode → `access_blocked` guard → `org_id` extraction → `user.create` permission check via `hasPermission(effectivePermissions, ...)`.
+- Op body: `supabaseAdmin.rpc('revoke_invitation', { p_invitation_id, p_reason: 'Revoked by administrator' })` — **service-role** call (so `auth.uid()` is null inside the RPC, leaving `event_metadata->>'user_id'` null today — a latent audit-trail gap that this extraction *fixes*).
+- Hardcoded reason: `'Revoked by administrator'`.
+- Response: `{ success: true, invitationId }`.
+
+**Existing `api.revoke_invitation`** (`baseline_v4.sql:5337–5371`):
+- `(p_invitation_id uuid, p_reason text DEFAULT 'manual_revocation') RETURNS boolean`, `SECURITY DEFINER`.
+- Existence check (status = 'pending') → emits `invitation.revoked` with `auth.uid()` in metadata.
+- **No permission check, no `access_blocked` check.**
+- Grant: `GRANT ALL ... TO service_role` only.
+- Single signature — no overloads (Rule 15 baseline-overload audit confirmed).
+
+**Caller audit (O2)**:
+- Frontend: `UserListPage.tsx:210`, `UsersManagePage.tsx:480` → ViewModel → `SupabaseUserCommandService.revokeInvitation` (line 234) → `invite-user` Edge Function.
+- Workflows: no callers (only type-definition reference).
+- Direct callers of `api.revoke_invitation`: none.
+
+## Locked Design Decisions (D1–D5, 2026-04-24)
+
+- **D1 — Modify in-place vs new RPC**: Modify `api.revoke_invitation` in place. The only existing caller is the Edge Function we are removing. Per PR #36 Rule 15 audit, no overloads — safe to mutate. (Avoids a `_v2` proliferation.)
+- **D2 — Permission gate**: Keep `user.create` to match current Edge semantics. Use `public.has_permission('user.create')` (presence-only, unscoped) per PR #36 precedent.
+- **D3 — `access_blocked` guard**: Port into the RPC. Read `current_setting('request.jwt.claims', true)::jsonb ->> 'access_blocked'`; if `'true'`, return error envelope.
+- **D4 — Reason argument**: Keep RPC default `'manual_revocation'`. Frontend passes `'Revoked by administrator'` exactly (preserves current event-data shape byte-for-byte).
+- **D5 — Response shape**: Migrate from `boolean` → `jsonb` envelope `{ success, error? }`. Breaking change to a function with no other callers. Aligns with PR #36 precedent and lets us surface distinct error reasons (`access_blocked`, `permission_denied`, `not_found_or_not_pending`) without overloading a boolean.
 
 ## Phases
 
 | Phase | Description |
 |-------|-------------|
-| 0 | Inspect `invite-user` v15 `revoke` case body; determine if it's a pure RPC forward or has additional logic |
-| 1 | (If pure forward) Frontend service cutover only — no migration needed |
-| 1' | (If wrapping logic) Migration creating `api.<wrapper>` RPC that captures the pre/post logic |
-| 2 | Remove `revoke` case from Edge Function |
-| 3 | Verification + PR |
+| 0 | ✅ Complete — Phase 0 findings above. |
+| 1' | Migration: modify `api.revoke_invitation` to absorb gates, change return type to `jsonb`, GRANT EXECUTE to `authenticated`, REVOKE from `service_role`. Add DbC `COMMENT ON FUNCTION` block. |
+| 2 | Frontend cutover: `SupabaseUserCommandService.revokeInvitation` calls `client.schema('api').rpc('revoke_invitation', ...)` directly. Service result-shape mapping unchanged externally. |
+| 3 | Edge Function: remove `revoke` case + bump `DEPLOY_VERSION` to `v17-revoke-extracted`. Remove `'revoke'` from `Operation` type union. |
+| 4 | Type regen: `supabase gen types typescript --linked` → both `frontend/` + `workflows/` `database.types.ts` byte-identical. Typecheck both. |
+| 5 | Verification: lint, typecheck, build, manual revoke flow check. PR. |
+| 6 | Post-merge: archive folder, append ADR Rollout history (inventory row #7 → extracted), update `memory/edge-function-sql-rpc-backlog.md` chain. |
 
 ## Open Questions
 
-- **O1** — Does the Edge Function's `revoke` case add auth-token-shaped logic beyond what `api.revoke_invitation` already does?
-- **O2** — Are there non-frontend callers of the Edge Function's revoke case? (workflows/, admin scripts)
+All Phase 0 questions resolved. None remain.
 
 ## Risks
 
-- **R1** — Low. Simple extraction if Phase 0 confirms pure-forward.
+- **R1 — Pattern A v2 read-back**: NOT applicable here. The RPC returns *outcome* (`success`), not a projection entity. The handler updating `invitations_projection.status` runs synchronously in-trigger; there's no projection field in the response to read back. Skip Pattern A v2; the existing-row-existence check (`SELECT EXISTS ... WHERE status='pending'`) is the equivalent guard.
+- **R2 — Auth context shift**: Frontend cutover changes the call from service-role (Edge) → authenticated (direct RPC). `auth.uid()` will populate inside the RPC. Event metadata gains accurate `user_id` (improvement). RLS implications: the RPC is `SECURITY DEFINER`, so no RLS exposure on the projection read. ✅ Safe.
+- **R3 — Breaking RPC return type**: `boolean → jsonb` is a wire-level breaking change. Mitigated by the no-other-callers verification in Phase 0; both type-regen and frontend cutover land in the same PR.
+
+## Reference Materials
+
+- [adr-edge-function-vs-sql-rpc.md](../../../documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md) — Inventory row #7
+- [adr-rpc-readback-pattern.md](../../../documentation/architecture/decisions/adr-rpc-readback-pattern.md) — Pattern A v2 (R1 above explains why N/A)
+- PR #36 (commit `4037f320`) — Precedent for snake_case wire, `has_permission()`, DbC COMMENT block, type-regen-both-copies, baseline-overload audit
+- `infrastructure/supabase/supabase/functions/invite-user/index.ts` (v16)
+- `frontend/src/services/users/SupabaseUserCommandService.ts:234`
+- `infrastructure/supabase/supabase/migrations/20260212010625_baseline_v4.sql:5337–5377`

--- a/dev/active/invite-user-revoke-to-sql-rpc/tasks.md
+++ b/dev/active/invite-user-revoke-to-sql-rpc/tasks.md
@@ -2,14 +2,17 @@
 
 ## Current Status
 
-**Phase**: SEEDED — awaiting activation after `edge-function-vs-sql-rpc-adr` PR merges
-**Status**: 🟢 ACTIVE (scaffold only)
+**Phase**: Phase 0 complete (2026-04-24); D1–D5 locked; Phase 1' in progress
+**Status**: 🟢 ACTIVE
 **Priority**: Medium
+**Branch**: `invite-user-revoke-to-sql-rpc`
 
-## Tasks
+## Tasks (tracked via TaskCreate; see `plan.md` for full context)
 
-- [ ] Phase 0 — Inspect v15 revoke case body (5 min)
-- [ ] Phase 1 or 1' — Frontend cutover OR migration (per Phase 0 outcome)
-- [ ] Phase 2 — Remove Edge Function case + bump DEPLOY_VERSION
-- [ ] Phase 3 — Verification + PR
-- [ ] Post-merge — Archive + append ADR Rollout history
+- [x] Phase 0 — Inspect v16 revoke case body + existing RPC + caller audit (2026-04-24)
+- [ ] Phase 1' — Draft migration modifying `api.revoke_invitation` (gates + jsonb envelope + DbC)
+- [ ] Phase 1'/4 — Apply migration + regen TS types in both consumer files; typecheck
+- [ ] Phase 2 — Frontend service cutover (`SupabaseUserCommandService.revokeInvitation`)
+- [ ] Phase 3 — Remove `revoke` case from Edge Function + bump `DEPLOY_VERSION` → v17
+- [ ] Phase 5 — Verify (lint, typecheck, build, manual smoke of revoke flow)
+- [ ] Phase 6 — PR + post-merge archive + ADR Rollout history + memory backlog update

--- a/frontend/src/services/users/SupabaseUserCommandService.ts
+++ b/frontend/src/services/users/SupabaseUserCommandService.ts
@@ -255,11 +255,18 @@ export class SupabaseUserCommandService implements IUserCommandService {
 
       if (error) {
         log.error('RPC error in revokeInvitation', { error });
+        if (error.code === '42501') {
+          return {
+            success: false,
+            error: 'Access denied - insufficient permissions',
+            errorDetails: { code: 'FORBIDDEN', message: error.message },
+          };
+        }
         return {
           success: false,
           error: error.message,
           errorDetails: {
-            code: 'UNKNOWN' as UserOperationErrorCode,
+            code: 'UNKNOWN',
             message: error.message,
             context: { postgresCode: error.code, hint: error.hint },
           },

--- a/frontend/src/services/users/SupabaseUserCommandService.ts
+++ b/frontend/src/services/users/SupabaseUserCommandService.ts
@@ -227,9 +227,13 @@ export class SupabaseUserCommandService implements IUserCommandService {
   }
 
   /**
-   * Revoke a pending invitation
+   * Revoke a pending invitation.
    *
-   * Calls the invite-user Edge Function with revoke operation
+   * Calls `api.revoke_invitation` SQL RPC. Extracted from the `invite-user`
+   * Edge Function per `adr-edge-function-vs-sql-rpc.md` — see migration
+   * `20260424221149_extract_revoke_invitation_rpc.sql`. The RPC sources
+   * `org_id` from the JWT, enforces `user.create` permission and the
+   * access-blocked guard server-side, and emits `invitation.revoked`.
    */
   async revokeInvitation(invitationId: string): Promise<UserVoidResult> {
     // Set up tracing context for this operation
@@ -239,29 +243,25 @@ export class SupabaseUserCommandService implements IUserCommandService {
     try {
       log.info('Revoking invitation', { invitationId });
 
-      const client = supabaseService.getClient();
-      const headers = buildHeadersFromContext(tracingContext);
-      const { data, error } = await client.functions.invoke(EDGE_FUNCTIONS.INVITE_USER, {
-        body: {
-          operation: 'revoke',
-          invitationId,
-        },
-        headers,
+      const { data, error } = await supabaseService.apiRpc<{
+        success: boolean;
+        error?: string;
+        eventId?: string;
+        invitationId?: string;
+      }>('revoke_invitation', {
+        p_invitation_id: invitationId,
+        p_reason: 'Revoked by administrator',
       });
 
       if (error) {
-        const errorInfo = await extractEdgeFunctionError(error, 'Revoke invitation');
-        const errorMessage = errorInfo.correlationId
-          ? `${errorInfo.message} (Ref: ${errorInfo.correlationId})`
-          : errorInfo.message;
+        log.error('RPC error in revokeInvitation', { error });
         return {
           success: false,
-          error: errorMessage,
+          error: error.message,
           errorDetails: {
-            code: (errorInfo.code ?? 'UNKNOWN') as UserOperationErrorCode,
-            message: errorInfo.message,
-            context: errorInfo.details ? { details: errorInfo.details } : undefined,
-            correlationId: errorInfo.correlationId,
+            code: 'UNKNOWN' as UserOperationErrorCode,
+            message: error.message,
+            context: { postgresCode: error.code, hint: error.hint },
           },
         };
       }
@@ -273,7 +273,10 @@ export class SupabaseUserCommandService implements IUserCommandService {
         };
       }
 
-      log.info('Invitation revoked successfully', { invitationId });
+      log.info('Invitation revoked successfully', {
+        invitationId,
+        eventId: data.eventId,
+      });
       return { success: true };
     } catch (error) {
       log.error('Error in revokeInvitation', error);

--- a/frontend/src/services/users/__tests__/SupabaseUserCommandService.mapping.test.ts
+++ b/frontend/src/services/users/__tests__/SupabaseUserCommandService.mapping.test.ts
@@ -454,4 +454,73 @@ describe('SupabaseUserCommandService — snake_case → camelCase mapping', () =
       );
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // revokeInvitation — RPC envelope contract
+  // (api.revoke_invitation, second Edge→RPC extraction — PR #39)
+  // Mirrors the updateNotificationPreferences template above with the
+  // outcome-only response variant (no projection entity in the envelope).
+  // Also exercises the 42501 → 'FORBIDDEN' mapping (in-file precedent at
+  // SupabaseUserCommandService.ts:848/955/1052/1115).
+  // ---------------------------------------------------------------------------
+  describe('revokeInvitation — RPC envelope contract', () => {
+    it('returns success when the RPC envelope reports success', async () => {
+      mockApiRpc.mockResolvedValueOnce({
+        data: {
+          success: true,
+          eventId: '11111111-2222-3333-4444-555555555555',
+          invitationId: 'inv-1',
+        },
+        error: null,
+      });
+
+      const result = await service.revokeInvitation('inv-1');
+
+      expect(mockApiRpc).toHaveBeenCalledWith(
+        'revoke_invitation',
+        expect.objectContaining({
+          p_invitation_id: 'inv-1',
+          p_reason: 'Revoked by administrator',
+        })
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it('surfaces handler-failure envelope through result.error', async () => {
+      mockApiRpc.mockResolvedValueOnce({
+        data: {
+          success: false,
+          error: 'Invitation not found or not revocable',
+        },
+        error: null,
+      });
+
+      const result = await service.revokeInvitation('inv-missing');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Invitation not found or not revocable');
+    });
+
+    it('maps PostgREST 42501 to FORBIDDEN via the in-file precedent', async () => {
+      // The RPC raises ERRCODE 42501 for caller auth missing, access_blocked,
+      // or permission denied (per the migration's DbC COMMENT). The service
+      // matches the in-file precedent (lines 848/955/1052/1115) and surfaces
+      // {code: 'FORBIDDEN', message: 'Access denied - insufficient permissions'}.
+      mockApiRpc.mockResolvedValueOnce({
+        data: null,
+        error: {
+          code: '42501',
+          message: 'Permission denied',
+          hint: null,
+        },
+      });
+
+      const result = await service.revokeInvitation('inv-1');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Access denied - insufficient permissions');
+      expect(result.errorDetails?.code).toBe('FORBIDDEN');
+      expect(result.errorDetails?.message).toBe('Permission denied');
+    });
+  });
 });

--- a/frontend/src/types/database.types.ts
+++ b/frontend/src/types/database.types.ts
@@ -1306,7 +1306,7 @@ export type Database = {
       retry_failed_event: { Args: { p_event_id: string }; Returns: Json }
       revoke_invitation: {
         Args: { p_invitation_id: string; p_reason?: string }
-        Returns: boolean
+        Returns: Json
       }
       safety_net_deactivate_organization: {
         Args: { p_org_id: string }
@@ -1585,6 +1585,31 @@ export type Database = {
       }
       validate_role_assignment: {
         Args: { p_role_ids: string[] }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
         Returns: Json
       }
     }
@@ -5859,6 +5884,9 @@ export type CompositeTypes<
 
 export const Constants = {
   api: {
+    Enums: {},
+  },
+  graphql_public: {
     Enums: {},
   },
   public: {

--- a/infrastructure/supabase/supabase/functions/invite-user/index.ts
+++ b/infrastructure/supabase/supabase/functions/invite-user/index.ts
@@ -33,7 +33,7 @@ import {
 import { buildEventMetadata } from '../_shared/emit-event.ts';
 
 // Deployment version tracking
-const DEPLOY_VERSION = 'v16-access-blocked-guard';
+const DEPLOY_VERSION = 'v17-revoke-extracted';
 
 // CORS headers for frontend requests
 const corsHeaders = standardCorsHeaders;
@@ -75,15 +75,19 @@ interface InvitationPhone {
 
 /**
  * Supported operations
+ *
+ * Note: `revoke` was extracted to `api.revoke_invitation` RPC in PR
+ * (migration `20260424221149_extract_revoke_invitation_rpc.sql`) per
+ * adr-edge-function-vs-sql-rpc.md; frontend calls the RPC directly.
  */
-type Operation = 'create' | 'resend' | 'revoke';
+type Operation = 'create' | 'resend';
 
 /**
  * Request format from frontend
  */
 interface InviteUserRequest {
   operation?: Operation;              // Default: 'create'
-  invitationId?: string;              // Required for resend/revoke operations
+  invitationId?: string;              // Required for resend operation
   email?: string;                     // Required for create operation
   firstName?: string;                 // Required for create operation
   lastName?: string;                  // Required for create operation
@@ -531,51 +535,6 @@ serve(async (req) => {
     const operation = requestData.operation || 'create';
 
     console.log(`[invite-user v${DEPLOY_VERSION}] Operation: ${operation}`);
-
-    // ==========================================================================
-    // REVOKE OPERATION
-    // ==========================================================================
-    if (operation === 'revoke') {
-      if (!requestData.invitationId) {
-        return new Response(
-          JSON.stringify({ error: 'Missing invitationId for revoke operation' }),
-          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-        );
-      }
-
-      console.log(`[invite-user v${DEPLOY_VERSION}] Revoking invitation ${requestData.invitationId}`);
-
-      // Call existing api.revoke_invitation RPC (validates status=pending, emits event)
-      // Note: RPC uses auth.uid() internally for metadata; service_role has no uid,
-      // but the revocation reason and invitation_id provide sufficient audit trail
-      const { data: revokeResult, error: revokeError } = await supabaseAdmin
-        .rpc('revoke_invitation', {
-          p_invitation_id: requestData.invitationId,
-          p_reason: 'Revoked by administrator',
-        });
-
-      if (revokeError) {
-        console.error(`[invite-user v${DEPLOY_VERSION}] Revoke failed:`, revokeError);
-        return handleRpcError(revokeError, correlationId, corsHeaders, 'revoke invitation');
-      }
-
-      if (revokeResult === false) {
-        return new Response(
-          JSON.stringify({ error: 'Invitation not found or not revocable' }),
-          { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-        );
-      }
-
-      console.log(`[invite-user v${DEPLOY_VERSION}] Invitation revoked successfully: ${requestData.invitationId}`);
-
-      return new Response(
-        JSON.stringify({
-          success: true,
-          invitationId: requestData.invitationId,
-        }),
-        { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      );
-    }
 
     // ==========================================================================
     // RESEND OPERATION

--- a/infrastructure/supabase/supabase/functions/invite-user/index.ts
+++ b/infrastructure/supabase/supabase/functions/invite-user/index.ts
@@ -76,8 +76,8 @@ interface InvitationPhone {
 /**
  * Supported operations
  *
- * Note: `revoke` was extracted to `api.revoke_invitation` RPC in PR
- * (migration `20260424221149_extract_revoke_invitation_rpc.sql`) per
+ * Note: `revoke` was extracted to `api.revoke_invitation` (migration
+ * `20260424221149_extract_revoke_invitation_rpc.sql`) per
  * adr-edge-function-vs-sql-rpc.md; frontend calls the RPC directly.
  */
 type Operation = 'create' | 'resend';

--- a/infrastructure/supabase/supabase/migrations/20260424221149_extract_revoke_invitation_rpc.sql
+++ b/infrastructure/supabase/supabase/migrations/20260424221149_extract_revoke_invitation_rpc.sql
@@ -1,0 +1,175 @@
+-- Migration: extract `invite-user revoke` op from Edge Function into api.revoke_invitation
+--
+-- Part of the Edge Function → SQL RPC extraction backlog seeded by PR #33
+-- (adr-edge-function-vs-sql-rpc.md). Inventory row #7 moves `candidate` →
+-- `extracted`. `invite-user` Edge Function `DEPLOY_VERSION` bumps to
+-- `v17-revoke-extracted` in the same PR (Edge Function `revoke` case deleted).
+--
+-- Why a DROP + CREATE (not CREATE OR REPLACE): the return type changes from
+-- boolean → jsonb. PostgreSQL rejects CREATE OR REPLACE when the return type
+-- changes, so the old signature is dropped and the new one is created. The
+-- only existing caller was the Edge Function (`supabaseAdmin.rpc('revoke_invitation', ...)`)
+-- which is removed in the same PR — no external breakage.
+--
+-- Changes vs prior `api.revoke_invitation` (baseline_v4:5337-5371):
+--   1. Return type: boolean → jsonb envelope {success, error?} (D5).
+--   2. Added `public.has_permission('user.create')` gate (D2) —
+--      absorbs Edge Function's permission check, preserves current semantics.
+--   3. Added `access_blocked` JWT-claim guard (D3) —
+--      absorbs Edge Function's access-block guard (parity with invite-user/index.ts:481-487).
+--   4. Caller identity via `public.get_current_user_id()` (PR #36 precedent)
+--      instead of `auth.uid()` — preserves testing override.
+--   5. Post-emit `processing_error` check on captured event_id (handler-failure
+--      surfacing) — matches adr-rpc-readback-pattern.md guidance for the
+--      outcome-only (no projection entity in response) variant.
+--   6. GRANT EXECUTE to `authenticated` (new caller); the prior
+--      `GRANT ALL TO service_role` is intentionally not re-granted (the service-role
+--      caller — the Edge Function `revoke` case — is deleted in this PR).
+--
+-- Baseline-overload audit (Rule 15): confirmed single signature, no overloads.
+--   grep -n 'FUNCTION "api"\."revoke_invitation"' 20260212010625_baseline_v4.sql
+--   → one match (line 5337).
+
+DROP FUNCTION IF EXISTS api.revoke_invitation(uuid, text);
+
+CREATE FUNCTION api.revoke_invitation(
+    p_invitation_id uuid,
+    p_reason text DEFAULT 'manual_revocation'
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $$
+DECLARE
+    v_claims jsonb := current_setting('request.jwt.claims', true)::jsonb;
+    v_caller_id uuid := public.get_current_user_id();
+    v_org_id uuid := NULLIF(v_claims ->> 'org_id', '')::uuid;
+    v_access_blocked boolean := COALESCE((v_claims ->> 'access_blocked')::boolean, false);
+    v_exists boolean;
+    v_event_id uuid;
+    v_processing_error text;
+BEGIN
+    -- Caller auth + tenant context required (parity with Edge Function's JWT
+    -- decode + org_id presence check).
+    IF v_caller_id IS NULL OR v_org_id IS NULL THEN
+        RAISE EXCEPTION 'Access denied' USING ERRCODE = '42501';
+    END IF;
+
+    -- Access-blocked guard (parity with invite-user/index.ts:481-487).
+    -- Pre-emit, so RAISE is appropriate (no audit row to preserve).
+    IF v_access_blocked THEN
+        RAISE EXCEPTION 'Access blocked: organization is deactivated' USING ERRCODE = '42501';
+    END IF;
+
+    -- Permission port: `user.create` matches Edge Function gate exactly
+    -- (invite-user/index.ts:501-508). Unscoped presence check.
+    IF NOT public.has_permission('user.create') THEN
+        RAISE EXCEPTION 'Permission denied' USING ERRCODE = '42501';
+    END IF;
+
+    -- Existence + status guard (preserved from prior RPC body).
+    SELECT EXISTS(
+        SELECT 1 FROM invitations_projection
+        WHERE id = p_invitation_id AND status = 'pending'
+    ) INTO v_exists;
+
+    IF NOT v_exists THEN
+        RETURN jsonb_build_object(
+            'success', false,
+            'error', 'Invitation not found or not revocable'
+        );
+    END IF;
+
+    -- Emit domain event; handler (process_invitation_event → handle_invitation_revoked)
+    -- flips invitations_projection.status to 'revoked' synchronously in-trigger.
+    v_event_id := api.emit_domain_event(
+        p_stream_id := p_invitation_id,
+        p_stream_type := 'invitation',
+        p_event_type := 'invitation.revoked',
+        p_event_data := jsonb_build_object(
+            'invitation_id', p_invitation_id,
+            'reason', p_reason
+        ),
+        p_event_metadata := jsonb_build_object(
+            'user_id', v_caller_id,
+            'organization_id', v_org_id,
+            'source', 'api.revoke_invitation',
+            'reason', p_reason
+        )
+    );
+
+    -- Handler-failure surfacing: captured-event_id processing_error check.
+    -- No projection read-back needed — response envelope is outcome-only,
+    -- no entity payload (see plan R1).
+    SELECT processing_error INTO v_processing_error
+    FROM public.domain_events WHERE id = v_event_id;
+
+    IF v_processing_error IS NOT NULL THEN
+        RETURN jsonb_build_object(
+            'success', false,
+            'error', 'Event processing failed: ' || v_processing_error
+        );
+    END IF;
+
+    RETURN jsonb_build_object(
+        'success', true,
+        'eventId', v_event_id,
+        'invitationId', p_invitation_id
+    );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION
+    api.revoke_invitation(uuid, text)
+    TO authenticated;
+
+COMMENT ON FUNCTION api.revoke_invitation(uuid, text) IS
+$$Revokes a pending invitation for the caller's JWT org context.
+
+Preconditions:
+  - JWT must supply `sub` (caller id) and `org_id` claim.
+  - `access_blocked` claim must be absent or false.
+  - Caller must hold `user.create` via public.has_permission() on the
+    `effective_permissions` JWT claim (unscoped presence check).
+  - p_invitation_id must reference an invitation with status = 'pending'.
+
+Postconditions:
+  - On success: exactly one `invitation.revoked` event is appended to
+    `domain_events` with stream_id = p_invitation_id, stream_type = 'invitation',
+    carrying {invitation_id, reason} in event_data and
+    {user_id, organization_id, source, reason} in event_metadata.
+  - On success: `invitations_projection.status` for p_invitation_id reflects
+    'revoked' (handler `handle_invitation_revoked` UPDATE).
+  - On handler failure: `domain_events` row is preserved with populated
+    `processing_error` (audit trail intact); return envelope has
+    `success: false, error: 'Event processing failed: ...'`.
+  - Never `RAISE EXCEPTION` post-emit (would roll back the audit row — see
+    adr-rpc-readback-pattern.md Decision 2).
+
+Invariants:
+  - `org_id` is ALWAYS sourced from the JWT; NEVER accepted as input. Breaking
+    this invariant is a multi-tenancy bypass.
+  - Pre-emit failures (auth, access_blocked, permission) use `RAISE EXCEPTION`
+    with ERRCODE 42501 — PostgREST maps to HTTP 403.
+  - Business-logic failures (not-pending, handler-error) use success:false
+    envelope — preserves audit trail per adr-rpc-readback-pattern.md.
+  - Response shape stable: `{success, eventId, invitationId}` on success;
+    `{success: false, error}` on failure. Keys are contract.
+
+Error envelope:
+  42501 (RAISE) — caller auth missing, access_blocked, or permission denied (pre-emit).
+  success:false envelope — invitation not pending OR handler-driven failure.
+
+Notes:
+  - Metadata parity trade-off vs. Edge Function: RPC cannot populate
+    `ip_address`, `user_agent`, `request_id` in event_metadata (request
+    headers not accessible in PL/pgSQL). Audit queries on this event type
+    will see nulls for those fields post-cutover. Compliant with
+    infrastructure/CLAUDE.md which scopes those fields to Edge Functions.
+  - Improvement over prior Edge-service-role path: `event_metadata->>'user_id'`
+    is now populated (was null under service-role), closing a latent audit gap.
+
+Reference: adr-edge-function-vs-sql-rpc.md (LB0 extraction, inventory row #7);
+           adr-rpc-readback-pattern.md (outcome-only variant rationale).
+$$;

--- a/infrastructure/supabase/supabase/migrations/20260424221149_extract_revoke_invitation_rpc.sql
+++ b/infrastructure/supabase/supabase/migrations/20260424221149_extract_revoke_invitation_rpc.sql
@@ -25,6 +25,10 @@
 --   6. GRANT EXECUTE to `authenticated` (new caller); the prior
 --      `GRANT ALL TO service_role` is intentionally not re-granted (the service-role
 --      caller — the Edge Function `revoke` case — is deleted in this PR).
+--   7. Reuse `invitations_projection.correlation_id` on the emit (lookup-and-reuse
+--      pattern per `infrastructure/CLAUDE.md` § Correlation ID Pattern; precedent:
+--      `accept-invitation/index.ts:180-188`). Schema-level commitment at
+--      baseline_v4:12954 names `revoke` as a reuse site explicitly.
 --
 -- Baseline-overload audit (Rule 15): confirmed single signature, no overloads.
 --   grep -n 'FUNCTION "api"\."revoke_invitation"' 20260212010625_baseline_v4.sql
@@ -47,6 +51,7 @@ DECLARE
     v_org_id uuid := NULLIF(v_claims ->> 'org_id', '')::uuid;
     v_access_blocked boolean := COALESCE((v_claims ->> 'access_blocked')::boolean, false);
     v_exists boolean;
+    v_correlation_id uuid;
     v_event_id uuid;
     v_processing_error text;
 BEGIN
@@ -81,6 +86,12 @@ BEGIN
         );
     END IF;
 
+    -- Lookup-and-reuse pattern (infrastructure/CLAUDE.md § Correlation ID Pattern;
+    -- accept-invitation/index.ts:180-188 precedent). Schema commits to reuse at
+    -- baseline_v4:12954 ("reused for resend/revoke/accept/expire events").
+    SELECT correlation_id INTO v_correlation_id
+      FROM invitations_projection WHERE id = p_invitation_id;
+
     -- Emit domain event; handler (process_invitation_event → handle_invitation_revoked)
     -- flips invitations_projection.status to 'revoked' synchronously in-trigger.
     v_event_id := api.emit_domain_event(
@@ -95,7 +106,8 @@ BEGIN
             'user_id', v_caller_id,
             'organization_id', v_org_id,
             'source', 'api.revoke_invitation',
-            'reason', p_reason
+            'reason', p_reason,
+            'correlation_id', v_correlation_id
         )
     );
 
@@ -169,6 +181,19 @@ Notes:
     infrastructure/CLAUDE.md which scopes those fields to Edge Functions.
   - Improvement over prior Edge-service-role path: `event_metadata->>'user_id'`
     is now populated (was null under service-role), closing a latent audit gap.
+  - Correlation reuse: `event_metadata->>'correlation_id'` is now sourced from
+    `invitations_projection.correlation_id` (lookup-and-reuse pattern),
+    closing a second latent audit gap. Lifecycle queries
+    (`SELECT … FROM domain_events WHERE correlation_id = ?`) will now include
+    `invitation.revoked` events alongside `user.invited`, `invitation.resent`,
+    `invitation.accepted`. Schema commits to this at baseline_v4:12954.
+  - Concurrent revoke calls may produce duplicate `invitation.revoked`
+    events (classic TOCTOU between the EXISTS check and the emit). The
+    handler `handle_invitation_revoked` (baseline_v4:11124-11131) issues
+    an unconditional UPDATE, so duplicates are projection-idempotent
+    (status flips to 'revoked' once; subsequent UPDATEs are no-ops aside
+    from `updated_at`). Both events are intentionally preserved in
+    `domain_events` for forensic visibility into the race.
 
 Reference: adr-edge-function-vs-sql-rpc.md (LB0 extraction, inventory row #7);
            adr-rpc-readback-pattern.md (outcome-only variant rationale).

--- a/workflows/src/types/database.types.ts
+++ b/workflows/src/types/database.types.ts
@@ -1306,7 +1306,7 @@ export type Database = {
       retry_failed_event: { Args: { p_event_id: string }; Returns: Json }
       revoke_invitation: {
         Args: { p_invitation_id: string; p_reason?: string }
-        Returns: boolean
+        Returns: Json
       }
       safety_net_deactivate_organization: {
         Args: { p_org_id: string }
@@ -1585,6 +1585,31 @@ export type Database = {
       }
       validate_role_assignment: {
         Args: { p_role_ids: string[] }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
         Returns: Json
       }
     }
@@ -5859,6 +5884,9 @@ export type CompositeTypes<
 
 export const Constants = {
   api: {
+    Enums: {},
+  },
+  graphql_public: {
     Enums: {},
   },
   public: {


### PR DESCRIPTION
## Summary

- Second extraction under [adr-edge-function-vs-sql-rpc.md](documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md) — moves `invite-user revoke` op out of the Edge Function and onto a direct `api.revoke_invitation` SQL RPC call. Inventory row #7 moves `candidate` → `extracted`.
- Migration **DROP + CREATE** widens the return type `boolean → jsonb` and absorbs the Edge Function's gates (`user.create` permission, `access_blocked` JWT-claim guard, JWT-sourced `org_id`). `GRANT EXECUTE` to `authenticated` only.
- **Audit-trail improvements (two)**: prior service-role path emitted `invitation.revoked` events with `event_metadata.user_id = null` AND no correlation_id linkage to the original invitation. Direct authenticated RPC populates the actual revoker's id; lookup-and-reuse pattern propagates `correlation_id` from `invitations_projection` (per `infrastructure/CLAUDE.md` § Correlation ID Pattern + schema commitment at `baseline_v4:12954`).

## Why

`revoke` met none of LB1–LB6 (no auth-user minting, no external API, no workflow forwarding, no bespoke token validation, no cross-tier read orchestration, no pre-user-existence emission). Edge Function added a network hop with no value beyond what an in-DB `SECURITY DEFINER` RPC already provides.

Follows precedent patterns established by [#36](https://github.com/Analytics4Change/A4C-AppSuite/pull/36) (notification-preferences extraction): snake_case wire, `public.has_permission()` for unscoped ops, `public.get_current_user_id()` for caller identity, JWT-sourced `org_id`, DbC `COMMENT ON FUNCTION` block, post-emit `processing_error` check, both TS-types copies regen'd byte-identical.

## Files

- `infrastructure/supabase/supabase/migrations/20260424221149_extract_revoke_invitation_rpc.sql` — new
- `infrastructure/supabase/supabase/functions/invite-user/index.ts` — drop `revoke` case, bump `DEPLOY_VERSION` → `v17-revoke-extracted`
- `frontend/src/services/users/SupabaseUserCommandService.ts` — `revokeInvitation` cuts over to `supabaseService.apiRpc('revoke_invitation', ...)`; 42501 → `'FORBIDDEN'` mapping per in-file precedent (lines 848/955/1052/1115)
- `frontend/src/services/users/__tests__/SupabaseUserCommandService.mapping.test.ts` — 3 new envelope-contract tests for `revokeInvitation`, mirroring the explicit "template for the 4 follow-up extractions" at line 322
- `frontend/src/types/database.types.ts` + `workflows/src/types/database.types.ts` — regen, byte-identical
- `dev/active/invite-user-revoke-to-sql-rpc/{plan,tasks}.md` — Phase 0 findings, locked design decisions D1–D5

**Incidental regen drift**: this PR's `supabase gen types typescript --linked` also picks up a new `graphql_public` schema block in `database.types.ts` (both `frontend/` and `workflows/` copies, kept byte-identical per `infrastructure/supabase/CLAUDE.md`). This was added by an unrelated upstream extension enable — not by migration `20260424221149`. Mentioning here so future archeology with `git blame` on the `graphql_public` lines lands on the right context.

## Verification

**CLI**:
- [x] `npm run lint` (frontend) — clean
- [x] `npm run typecheck` (frontend + workflows) — clean
- [x] `npm run build` (frontend) — clean
- [x] `npx vitest run …mapping.test.ts` — 13/13 pass (10 prior + 3 new revokeInvitation cases)
- [x] TS types regen byte-identical in both consumer copies

**Live DB** (migration applied via `supabase migration repair` + re-push after review-fix amendment):
- [x] RPC shape: `(uuid, text DEFAULT 'manual_revocation') → jsonb`, `SECURITY DEFINER`, EXECUTE on `authenticated` only
- [x] Pre-emit gate: no-JWT call raises `42501 Access denied` (expected)

**UI**:
- [x] Revoke flow toast confirmed end-to-end on dev branch

## Test plan

- [ ] CI: lint + typecheck + plpgsql_check pass
- [ ] CI: Edge Function lint passes (no new files needing ADR citation; `invite-user` is an existing file)
- [ ] Reviewer: confirm migration is idempotent on re-run (DROP IF EXISTS + CREATE)
- [ ] Reviewer: confirm baseline-overload audit (Rule 15) — single signature, no overloads to coexist with

## Review-comment remediation (commit 062286a9)

All 5 review items addressed. Items 1–4 are code/doc changes; Item 5 is this PR description edit:

- **Item 1** (correlation_id reuse) — migration: lookup `invitations_projection.correlation_id`, propagate via `event_metadata.correlation_id`. Now matches `accept-invitation/index.ts:180-188` precedent.
- **Item 2** (TOCTOU acknowledgment) — migration: appended note to DbC `COMMENT` block. Declines reviewer's option 2 (handler tightening) as out of scope; handler is projection-idempotent and duplicate audit rows are intentionally preserved for forensic visibility.
- **Item 3** (hanging "PR" comment) — `invite-user/index.ts:79-81`: dropped the bare PR placeholder, kept the migration-filename + ADR reference.
- **Item 4** (error mapping + tests) — service: 42501 → `'FORBIDDEN'` per in-file precedent; tests: 3 new cases under `revokeInvitation — RPC envelope contract` mirroring the explicit template at `mapping.test.ts:322`.
- **Item 5** (graphql_public regen drift) — this paragraph in the PR description.

## Post-merge bookkeeping

- Archive `dev/active/invite-user-revoke-to-sql-rpc/` → `dev/archived/`
- Append ADR Rollout history entry (inventory row #7 candidate → extracted)
- Update `memory/edge-function-sql-rpc-backlog.md` dependency chain (remove from active list; remaining: `manage-user-delete`, `manage-user-reactivate`, `manage-user-modify-roles`, `manage-user-deactivate-pattern-a-v2-retrofit`)
- Note that PR #39 raises the floor for the remaining 3 candidate extractions: each is now expected to ship correlation reuse + 42501 → FORBIDDEN mapping + envelope-contract unit tests as standard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
