### PR TITLE
fix(invitation): resolve invitation-phone-N placeholder to real UUID before emit

### DIFF
--- a/dev/active/fix-invitation-phone-id-resolution/plan.md
+++ b/dev/active/fix-invitation-phone-id-resolution/plan.md
@@ -28,3 +28,41 @@
 - Re-run invitation acceptance with SMS=on for a fresh test user.
 - Query `user_notification_preferences_projection` for the new user; expect `sms_enabled = true, sms_phone_id = <real UUID>`.
 - Query `domain_events WHERE event_type = 'user.notification_preferences.updated' AND processing_error IS NOT NULL` for the test user; expect zero rows.
+
+## Phase 0 Findings + Resolution (2026-04-29)
+
+### Empirical answers to Phase 0 open questions
+
+- **Q1 (single emission site)**: Confirmed. Only `accept-invitation/index.ts:682-705` emits `user.notification_preferences.updated` during invitation acceptance. No other paths.
+- **Q2 (index-based mapping reliability)**: Currently safe. `createdPhoneIds` is built in array iteration order at line 615. No reordering applied. Future risk if sorting is introduced; not blocking for this fix.
+- **Q3 (other placeholder patterns)**: None. Grep confirmed `invitation-phone-${index}` is the only placeholder type. No equivalent bugs for emails, addresses, or other fields.
+
+### Decision: Approach A (substitute-before-emit) was the actual fix
+
+Phase 0 revealed that "Approach B" (emit-after-phones) is what the code already does — phone events fire at lines 610-650, then notification_preferences at 682-705. The missing piece was the substitution step. So Approach A is the surgical fix: a small helper that resolves the placeholder against the already-populated `createdPhoneIds` array.
+
+### Implementation
+
+Added `resolveInvitationPhonePlaceholder` helper (`accept-invitation/index.ts:50-89`); applied at line 728 BEFORE the existing auto-select fallback (so out-of-range placeholders gracefully fall through to "first SMS-capable phone"). Bumped `DEPLOY_VERSION` from `v17-phase6-phones-prefs` to `v18-phone-id-resolution`.
+
+### Affected historical events (pre-fix regression query)
+
+Two on dev — both this session's smoke-test users:
+- `de999f60-3e14-41e4-9d26-748f21927360` for `lars.tice+test@gmail.com` (61cbb03f-..., currently deactivated)
+- `edc2c08e-d8ef-486c-911f-75fcb1e2a2d4` for `lars.tice+test1@gmail.com` (86885a4f-..., deleted in PR #40 smoke testing)
+
+Production count unknown. Backfill posture per plan: document, do not auto-correct. Failed events preserved with `processing_error` for compliance audit. Recommended ops follow-up post-deploy: invoke `api.retry_failed_event(<event_id>)` for the two affected events so the projection self-heals from the audit row.
+
+## Architect Review Responses (2026-04-29, software-architect-dbc verdict: APPROVE WITH CHANGES)
+
+Five concrete change requests. Five resolutions:
+
+- **C1 — Named type for `Array<{phoneId: string}>`**: addressed. Hoisted `InvitationPhone` to module level (preserving the tight `'mobile' | 'office' | 'fax' | 'emergency'` union type) and added `interface CreatedInvitationPhone { phoneId: string; phone: InvitationPhone }` alongside it. Both used in helper signature, in `createdPhoneIds` declaration, and removed inline duplicate at the request handler.
+- **C2 — Correlation context in warn logs**: addressed. Helper now takes a `context: { correlationId?, userId, invitationId }` parameter; all three `console.warn` calls include the context as a structured object. Call site at line 807 passes `{ correlationId, userId, invitationId: invitation.id }` — joinable to the surrounding event chain in production logs.
+- **C3 — DbC clarity for `enabled=false + placeholder` case**: documented in helper docblock. Decision: resolve regardless of `enabled` state (call site is unconditional under `if (prefs.sms)`). Rationale: the handler's `::UUID` cast doesn't gate on enabled, so a placeholder must be normalized to UUID-or-null regardless. Resulting projection state (`sms_enabled=false, sms_phone_id=<uuid>`) is consistent with `api.update_user_notification_preferences` read-back contract — a harmless tombstone of inviter intent.
+- **C4 — Trust-boundary on UUID pass-through**: implemented option (b) defense-in-depth. Helper now validates that any UUID input matches an entry in `createdPhoneIds` before passing through; foreign UUIDs normalize to null + warn. This prevents a hand-crafted invitation payload from setting `sms_phone_id` to another user's phone or a fabricated UUID. Cost: O(n) check, n bounded by `phones.length` (small). Documented in helper docblock under "Cases".
+- **C5 — Backfill ops note**: added to plan above (Recommended ops follow-up). Will also include in PR body.
+
+Plus an invariant comment at the call site (line 727-735) marking that `createdPhoneIds` MUST NOT be reordered, since `resolveInvitationPhonePlaceholder` depends on insertion-order index correspondence with the frontend's `phones[]` array.
+
+DEPLOY_VERSION bumped from `v18-phone-id-resolution` → `v19-phone-id-resolution-hardened` to differentiate the v18 deploy (review-pre) from the v19 deploy (review-incorporated) in production logs.

--- a/dev/active/fix-invitation-phone-id-resolution/tasks.md
+++ b/dev/active/fix-invitation-phone-id-resolution/tasks.md
@@ -2,20 +2,21 @@
 
 ## Current Status
 
-**Phase**: 0 — locating emission site
-**Status**: 🟢 ACTIVE
+**Phase**: IMPLEMENTATION COMPLETE — awaiting commit + PR + smoke test
+**Status**: 🟢 READY-FOR-PR
 **Priority**: Medium
 
 ## Tasks
 
-- [ ] Phase 0 — Locate emission site for `user.notification_preferences.updated` during invitation acceptance (likely `accept-invitation/index.ts`)
-- [ ] Phase 0 — Read `handle_user_notification_preferences_updated` handler source; confirm the failing `::uuid` cast site
-- [ ] Phase 0 — Grep for any other `invitation-<thing>-N` placeholder patterns that might leak similarly
-- [ ] Phase 1 — Decide: substitute-before-emit vs emit-after-phones
-- [ ] Phase 2 — Implement chosen approach; add unit test for multi-phone case
-- [ ] Phase 3 — Identify affected historical users (`domain_events.processing_error LIKE '%invitation-phone-%'`); decide on backfill vs document
-- [ ] Phase 4 — Verify with fresh invitation acceptance test
-- [ ] Phase 5 — Open PR + verify CI green
+- [x] Phase 0 — Locate emission site (`accept-invitation/index.ts:682-705`); single emission point
+- [x] Phase 0 — Read `handle_user_notification_preferences_updated.sql:29-32`; confirm `::UUID` cast at COALESCE
+- [x] Phase 0 — Grep for placeholders: only `invitation-phone-${index}` exists; no equivalent emails/addresses
+- [x] Phase 1 — Approach A confirmed (substitute-before-emit; B is moot since phones already emit before prefs)
+- [x] Phase 2 — Implemented `resolveInvitationPhonePlaceholder` helper + applied at emission site; DEPLOY_VERSION → v18-phone-id-resolution
+- [x] Phase 3 — Pre-deploy regression query: 2 affected historical events on dev (test1 + test users from PR #40 smoke testing); backfill posture: document
+- [ ] Phase 4 — Manual deploy + functional verify with fresh invitation
+- [ ] Phase 5 — Commit + push + open PR
+- [ ] Post-merge — Archive card to `dev/archived/`
 
 ## Cross-references
 

--- a/dev/active/fix-phone-emit-index-preservation/context.md
+++ b/dev/active/fix-phone-emit-index-preservation/context.md
@@ -1,0 +1,67 @@
+# Fix: phone emit failure should not silently shift placeholder index correspondence
+
+**Type**: Bug fix (defense-in-depth)
+**Status**: 🟢 ACTIVE
+**Priority**: Medium — silent wrong-phone selection is the same bug class PR #41 closed for `::UUID` cast failures
+**Discovered**: 2026-04-29 during PR #41 architect review (Issue 2)
+
+## Symptom
+
+When the `accept-invitation` Edge Function emits `user.phone.added` events in a loop, per-phone emit failures are non-fatal: the loop continues with remaining phones but does NOT push the failed phone into `createdPhoneIds`. This breaks the index correspondence that `resolveInvitationPhonePlaceholder` relies on.
+
+## Concrete failure mode
+
+Frontend sends phones `[A, B, C]` (Office, Mobile-A, Mobile-B). Inviter selects Mobile-A → `prefs.sms.phoneId = "invitation-phone-1"`.
+
+If B's emit transiently fails (network blip, RLS hiccup, handler exception), `createdPhoneIds` becomes `[A_uuid, C_uuid]`. The placeholder resolution in PR #41:
+- Index 1 = `C_uuid` (Mobile-B)
+- Inviter wanted Mobile-A
+- Helper returns `C_uuid` with no error surface beyond a `console.warn`
+
+Result: SMS notifications go to the wrong phone, sms_phone_id is set to a UUID that doesn't match inviter intent, no `processing_error` lands in `domain_events`. **Silent corruption of the inviter's intent.**
+
+This is the same compliance-relevant silent-failure class that PR #41 was filed to close (the `::UUID` cast bug). PR #41 closed the cast-failure path; this card closes the index-shift path.
+
+## Severity
+
+- **Probability**: Low — phone emits rarely fail in steady state
+- **Impact**: High when it happens — silent mis-routed SMS in a medication-management platform
+
+## Resolution candidates
+
+### A. Push a sentinel into `createdPhoneIds` on failure
+Reserve the slot with `{ phoneId: null, phone }`. The helper at PR #41 then sees `null` for that slot and treats out-of-range or null entries identically (returns null + warns). Index correspondence preserved.
+
+```typescript
+} else {
+  console.error(`[accept-invitation v${DEPLOY_VERSION}] Failed to emit user.phone.added for ${phone.label}:`, phoneError);
+  createdPhoneIds.push({ phoneId: null, phone });  // preserve index
+}
+```
+
+Helper signature would change from `CreatedInvitationPhone[]` (where `phoneId: string`) to a discriminated union or `phoneId: string | null`. Helper would treat null entries as "out of range" → null + warn.
+
+### B. Make `phoneError` fatal
+Return error to the user; rollback or compensate (the `auth.users` row already exists at this point — partial state).
+
+More invasive; user creation is a saga; rolling back invokes complex compensation logic that doesn't exist for this flow. Not recommended.
+
+### C. Hybrid: emit a `user.phone.add_failed` event and proceed
+Preserve the audit trail of the failure. Helper still has shifted indexes; same bug. Not sufficient on its own.
+
+### Recommendation: A
+
+Pushing a sentinel is the minimal-blast-radius fix that preserves indexing without changing the user-creation contract.
+
+## Out of scope
+
+- Frontend-side prevention (the frontend will continue sending placeholders; backend is the resolution authority).
+- Retry logic for failed `user.phone.added` emits (separate concern; saga-level decision).
+- Refactoring `accept-invitation` to a transaction (architectural; out of scope for this fix).
+
+## References
+
+- PR #41 architect review (Issue 2): `software-architect-dbc` adjudication "Issue 2 Risk Re-check"
+- `accept-invitation/index.ts:771-777` — current non-fatal `phoneError` handling
+- `accept-invitation/index.ts:58-163` — `resolveInvitationPhonePlaceholder` (consumer of the indexed `createdPhoneIds`)
+- `accept-invitation/index.ts:806-822` — placeholder resolution + auto-select call sites

--- a/dev/active/fix-phone-emit-index-preservation/plan.md
+++ b/dev/active/fix-phone-emit-index-preservation/plan.md
@@ -1,0 +1,30 @@
+# Plan — Preserve placeholder index correspondence on phone emit failure
+
+## Phases
+
+| Phase | Description |
+|-------|-------------|
+| 0 | Confirm Resolution A (sentinel) is the right approach. Read `handle_user_phone_added` to ensure no consumer of `user.phone.added` events depends on assumptions Resolution A would break. |
+| 1 | Implement: change `createdPhoneIds` element type to `{ phoneId: string \| null; phone: InvitationPhone }`. On failure, push `{ phoneId: null, phone }`. Update `resolveInvitationPhonePlaceholder` to treat `null` slots as out-of-range (null + warn). |
+| 2 | Update auto-select fallback at `accept-invitation/index.ts:817` to filter `phoneId !== null && phone.smsCapable`. |
+| 3 | Optionally: emit a `user.phone.add_failed` event (or expand `processing_error` on the original event) to preserve the audit trail of the failure. Decide based on whether the existing `console.error` is sufficient observability. |
+| 4 | Add Deno unit tests for `resolveInvitationPhonePlaceholder` with the new null-slot case (depends on `dev/parked/edge-function-deno-test-harness/` — could land first or be deferred). |
+| 5 | Smoke test: artificially fail one phone emit (e.g., temporarily bypass the RLS policy or inject a SQL error) and confirm: (a) inviter-selected phone resolves correctly when index lands on a successful slot, (b) inviter-selected phone resolves to null + auto-selects when index lands on a failed slot. |
+
+## Open questions
+
+- **Q1**: Should `user.phone.add_failed` events be emitted, or is `console.error` sufficient? Lean toward console.error for now; expand if observability requirements surface.
+- **Q2**: How to artificially trigger a `phoneError` for smoke testing? Options: (a) temporarily revoke RLS on `user_phones`, (b) inject a fault via a feature flag, (c) skip and rely on unit tests. Lean (c) once the test harness lands.
+
+## Critical files
+
+- `infrastructure/supabase/supabase/functions/accept-invitation/index.ts:58-163` (helper)
+- `infrastructure/supabase/supabase/functions/accept-invitation/index.ts:743-778` (phone loop)
+- `infrastructure/supabase/supabase/functions/accept-invitation/index.ts:806-822` (placeholder resolution + auto-select)
+- `infrastructure/supabase/handlers/user/handle_user_phone_added.sql` (handler — read-only check)
+
+## Verification
+
+- Unit tests cover the null-slot case for `resolveInvitationPhonePlaceholder`.
+- Manual smoke test (or fault injection) confirms inviter intent is honored when adjacent phones fail to emit.
+- No regression in steady-state path (all phones emit successfully).

--- a/dev/active/fix-phone-emit-index-preservation/tasks.md
+++ b/dev/active/fix-phone-emit-index-preservation/tasks.md
@@ -1,0 +1,24 @@
+# Tasks — Fix phone emit index preservation
+
+## Current Status
+
+**Phase**: 0 — pending prioritization
+**Status**: 🟢 ACTIVE
+**Priority**: Medium
+
+## Tasks
+
+- [x] Card filed (2026-04-29) — origin: PR #41 architect review Issue 2
+- [ ] Phase 0 — Read `handle_user_phone_added` to confirm Resolution A doesn't break consumers
+- [ ] Phase 1 — Implement sentinel on phone emit failure; update helper to handle null slots
+- [ ] Phase 2 — Update auto-select fallback to filter null slots
+- [ ] Phase 3 — Decide on `user.phone.add_failed` event emission (optional)
+- [ ] Phase 4 — Add Deno unit tests (depends on `dev/parked/edge-function-deno-test-harness/`)
+- [ ] Phase 5 — Smoke test or fault injection
+- [ ] Phase 6 — Open PR + verify CI green
+
+## Cross-references
+
+- Origin: PR #41 architect review Issue 2 (`software-architect-dbc` adjudication "Issue 2 Risk Re-check")
+- Related: `dev/parked/edge-function-deno-test-harness/` (test harness; soft dependency for Phase 4)
+- Related: `dev/active/fix-invitation-phone-id-resolution/` (PR #41; introduced the helper that this card extends)

--- a/dev/parked/edge-function-ci-preview-deploy/context.md
+++ b/dev/parked/edge-function-ci-preview-deploy/context.md
@@ -1,0 +1,33 @@
+# Edge Function CI Preview Deploy — Context
+
+**Type**: CI / tooling
+**Status**: 🅿️ PARKED — awaiting prioritization
+**Priority**: Low-Medium — improves PR feedback velocity
+**Origin**: Recommended by `software-architect-dbc` during PR #41 review (Issue 5).
+
+## Capability target
+
+Allow Edge Function PRs to deploy to a preview environment automatically (or behind a label) so that smoke testing can happen against the PR's code without requiring a manual `supabase functions deploy` invocation by the developer.
+
+## Why now (concrete trigger)
+
+PR #40 and PR #41 both required manual `supabase functions deploy --project-ref tmrjlswbsxmbglmaclxu` invocations during smoke testing because the existing "Deploy Edge Functions" CI workflow only fires on `main` push. This created a brief window where dev's deployed Edge Function diverged from `main`'s expected state.
+
+Architect's framing in PR #41 review: "the manual deploy state is bounded and acceptable for this PR; CI preview-deploy is a real engineering investment that deserves its own scoped card."
+
+## Trigger to start
+
+- A third Edge Function PR pattern repeats the manual-deploy workaround, OR
+- Supabase preview branches feature reaches GA, OR
+- Compliance / process drives a "no manual production-tier deploys" policy
+
+## Out of scope
+
+- Migration deploys (the existing "Deploy Database Migrations" workflow already covers PR validation).
+- Frontend deploys (the existing "Deploy Frontend" workflow + its main-only trigger is acceptable; frontend changes are reverted-by-deploy in <1 minute typically).
+
+## References
+
+- PR #41 review: software-architect-dbc Issue 5 adjudication.
+- `.github/workflows/edge-function-deploy.yml` (or whichever workflow deploys Edge Functions on main push)
+- Supabase Branches feature docs: https://supabase.com/docs/guides/platform/branching

--- a/dev/parked/edge-function-ci-preview-deploy/plan.md
+++ b/dev/parked/edge-function-ci-preview-deploy/plan.md
@@ -1,0 +1,20 @@
+# Plan — Edge Function CI Preview Deploy
+
+## Design space (high-level; resume when prioritized)
+
+| Option | Mechanism | Cost |
+|---|---|---|
+| **A — Supabase preview branches** | Use Supabase's built-in branching feature; CI creates a preview branch on PR open and deploys there | Lowest engineering cost; depends on Supabase Branches GA / pricing |
+| **B — Dedicated preview project** | Maintain a separate Supabase project for PRs; CI deploys there on PR open | Higher operational cost; full env isolation |
+| **C — Deploy-on-label** | CI deploys to the dev project on PR when a `deploy-preview` label is applied; no automatic divergence | Lowest infrastructure cost; reintroduces manual gating |
+
+## Open questions (when activated)
+
+- **Q1**: Which projects need preview deploys? (Edge Functions yes; frontend / workers separate)
+- **Q2**: How to reconcile preview deploys with the dev project's role as the smoke-test environment?
+- **Q3**: How to handle JWT / auth secrets in preview environments without leaking dev credentials?
+
+## Verification (when activated)
+
+- A representative Edge Function PR triggers preview deploy automatically; smoke testing proceeds without local CLI invocations.
+- Merging the PR replaces the preview deploy with the main-deployed version cleanly.

--- a/dev/parked/edge-function-ci-preview-deploy/tasks.md
+++ b/dev/parked/edge-function-ci-preview-deploy/tasks.md
@@ -1,0 +1,20 @@
+# Tasks — Edge Function CI Preview Deploy
+
+## Current Status
+
+**Phase**: PARKED (2026-04-29)
+**Status**: 🅿️ DEFERRED — awaiting prioritization
+**Priority**: Low-Medium
+
+## Tasks
+
+- [x] Card filed (2026-04-29) — origin: PR #41 architect review Issue 5
+- [ ] Decide preview-deploy mechanism (Supabase Branches vs dedicated project vs label-triggered)
+- [ ] Decide projects in scope (Edge Functions only? + frontend? + workers?)
+- [ ] Implement chosen approach
+- [ ] Document the new pattern in `infrastructure/supabase/CLAUDE.md`
+
+## Cross-references
+
+- Origin: PR #41 architect review Issue 5
+- Related: `dev/parked/edge-function-deno-test-harness/` (also unblocks better PR feedback)

--- a/dev/parked/edge-function-deno-test-harness/context.md
+++ b/dev/parked/edge-function-deno-test-harness/context.md
@@ -1,0 +1,35 @@
+# Edge Function Deno Test Harness — Context
+
+**Type**: Tooling / test infrastructure
+**Status**: 🅿️ PARKED — awaiting prioritization
+**Priority**: Medium — unblocks unit testing of pure helpers in Edge Functions
+**Origin**: Recommended by `software-architect-dbc` during PR #41 review (`fix-invitation-phone-id-resolution`).
+
+## Capability target
+
+Establish a Deno test harness for `infrastructure/supabase/supabase/functions/` so that pure helpers extracted in Edge Function fixes can ship with unit tests instead of relying on manual UI smoke tests for verification.
+
+## Why now (concrete trigger)
+
+PR #41's `resolveInvitationPhonePlaceholder` is a perfectly pure function with a docblock that enumerates 6 cases. Each case maps 1:1 to a unit test. PR #41 shipped without those tests because the harness doesn't exist; the architect explicitly flagged this as "should not be optional" — track explicitly so the next Edge Function fix lands with tests.
+
+The PR #39 precedent for SQL RPCs (precedents 8-11 in `~/.claude/projects/-home-lars-dev-A4C-AppSuite/memory/edge-function-sql-rpc-backlog.md`: "envelope-contract unit tests, minimum three cases per extraction") set a 3-case-minimum bar for RPCs. The spirit applies to Edge Function pure helpers — and PR #41's helper enumerates 6 cases that should be tests.
+
+## Trigger to start
+
+Start when:
+- A second Edge Function fix is in flight that would benefit from test coverage on a pure helper, OR
+- Someone has bandwidth to invest a half-day in tooling that pays off across all subsequent Edge Function PRs
+
+## Out of scope
+
+- Integration tests against a running Supabase project (different concern; the existing `infrastructure/supabase/supabase/migrations/`-style local-supabase + plpgsql_check pattern covers DB-side; this card is for Edge Function helpers only).
+- Refactoring existing Edge Functions to be more testable (separate exercise).
+- Mocking the Supabase admin client / fetch APIs (separate exercise; pure helpers are the highest-leverage target first).
+
+## References
+
+- PR #41 architect review: identifies `resolveInvitationPhonePlaceholder` as the first target.
+- `~/.claude/projects/-home-lars-dev-A4C-AppSuite/memory/edge-function-sql-rpc-backlog.md` precedents (8)-(11) for the 3-case-minimum convention for envelope-contract tests.
+- `infrastructure/supabase/supabase/functions/_shared/` — most-leverage targets for the harness (any future shared helper benefits from tests).
+- `infrastructure/supabase/supabase/functions/accept-invitation/index.ts:58-163` — `resolveInvitationPhonePlaceholder` first-target helper.

--- a/dev/parked/edge-function-deno-test-harness/plan.md
+++ b/dev/parked/edge-function-deno-test-harness/plan.md
@@ -1,0 +1,29 @@
+# Plan — Edge Function Deno Test Harness
+
+## Phases
+
+| Phase | Description |
+|-------|-------------|
+| 0 | Decide test runner: built-in `Deno.test` (zero dep, native to deno.land) vs `@std/testing/bdd` (Jest-style). Lean: `Deno.test` to start; minimize tooling spread. |
+| 1 | Decide CI integration: extend `.github/workflows/supabase-edge-functions-lint.yml` to also run tests, OR create `supabase-edge-functions-test.yml`. Lean: extend the existing workflow to keep the Edge Function CI surface unified. |
+| 2 | Establish a `infrastructure/supabase/supabase/functions/_shared/__tests__/` directory convention (or per-function colocated `*.test.ts`). Lean: per-function colocation matches the project's other test conventions (`SupabaseUserCommandService.mapping.test.ts` et al.). |
+| 3 | Author tests for `resolveInvitationPhonePlaceholder` (6 cases per its docblock — first target). |
+| 4 | Document the pattern in `infrastructure/supabase/CLAUDE.md` § Edge Function testing. Make it the new floor: pure helpers extracted in future Edge Function fixes ship with tests. |
+
+## Open questions
+
+- **Q1**: Should tests run against the `_shared/` modules first (most leverage), or per-function helpers (closer to active code)? Lean: `_shared/` first — establishes the harness with the highest-reuse code.
+- **Q2**: How to handle helpers that take Supabase client mocks? Lean: defer; pure helpers are sufficient first target.
+- **Q3**: How to handle helpers that import from `https://deno.land/...`? Lean: tests use the same imports; CI runs `deno test --no-check` to skip type-checking remote modules.
+
+## Critical files (read-only until Phase 1)
+
+- `.github/workflows/supabase-edge-functions-lint.yml` — existing CI workflow to extend.
+- `infrastructure/supabase/supabase/functions/accept-invitation/index.ts:58-163` — first target helper.
+- `infrastructure/supabase/CLAUDE.md` — destination for the new pattern documentation.
+
+## Verification
+
+- `deno test` runs locally and passes 6/6 cases for `resolveInvitationPhonePlaceholder`.
+- CI workflow runs the tests on PR open/push to `infrastructure/supabase/supabase/functions/**`.
+- A future Edge Function PR uses the harness to ship a pure-helper fix with tests, confirming the pattern is self-serviceable.

--- a/dev/parked/edge-function-deno-test-harness/tasks.md
+++ b/dev/parked/edge-function-deno-test-harness/tasks.md
@@ -1,0 +1,24 @@
+# Tasks — Edge Function Deno Test Harness
+
+## Current Status
+
+**Phase**: PARKED (2026-04-29)
+**Status**: 🅿️ DEFERRED — awaiting prioritization
+**Priority**: Medium
+
+## Tasks
+
+- [x] Card filed (2026-04-29) — surfaced by software-architect-dbc during PR #41 review
+- [ ] Decide test runner (Deno.test vs @std/testing/bdd)
+- [ ] Decide CI integration approach (extend existing workflow vs new workflow)
+- [ ] Establish test file location convention (colocated *.test.ts vs __tests__/ dir)
+- [ ] Author tests for `resolveInvitationPhonePlaceholder` (6 cases per docblock)
+- [ ] Document pattern in `infrastructure/supabase/CLAUDE.md` § Edge Function testing
+- [ ] Verify a future Edge Function PR can self-serve via the harness
+
+## Cross-references
+
+- Origin: PR #41 (`fix-invitation-phone-id-resolution`) architect review
+- First-target helper: `accept-invitation/index.ts:58-163` (`resolveInvitationPhonePlaceholder`)
+- CI workflow to extend: `.github/workflows/supabase-edge-functions-lint.yml`
+- Convention precedent (3-case minimum): memory `edge-function-sql-rpc-backlog.md` precedents (8)-(11)

--- a/infrastructure/supabase/supabase/functions/accept-invitation/index.ts
+++ b/infrastructure/supabase/supabase/functions/accept-invitation/index.ts
@@ -98,6 +98,32 @@ interface CreatedInvitationPhone {
  *   sms_enabled=false and sms_phone_id=<resolved UUID> — consistent with the
  *   read-back contract of api.update_user_notification_preferences and a
  *   harmless tombstone of the inviter's intent.
+ *
+ * Edge case — phone emit failure shifts index correspondence:
+ *   The phone-loop at the call site treats per-phone emit failures as
+ *   non-fatal (continues with remaining phones, does NOT push to
+ *   createdPhoneIds). If the frontend sends phones [A, B, C] with
+ *   prefs.sms.phoneId = "invitation-phone-2" pointing at C, and B's emit
+ *   fails, then createdPhoneIds becomes [A_uuid, C_uuid]. Resolving
+ *   index 2 falls out of range → null → auto-select fallback fires.
+ *   Worse: if the inviter selected "invitation-phone-1" (B), the helper
+ *   resolves to C_uuid — a SILENT WRONG-PHONE SELECTION with only a
+ *   console.warn surface. The graceful-degradation path is acceptable
+ *   for now (steady-state phone emits rarely fail), but is exactly the
+ *   silent-mis-routed-SMS class this fix exists to close. Tracked in
+ *   `dev/active/fix-phone-emit-index-preservation/` for behavioral fix.
+ *
+ * Edge case — smsCapable mismatch on placeholder path:
+ *   The helper passes through a placeholder-resolved UUID even if the
+ *   underlying phone has smsCapable=false. The auto-select branch at
+ *   the call site explicitly filters smsCapable=true; the placeholder
+ *   path does not. This is intentional — the placeholder represents the
+ *   inviter's stated intent ("send SMS to phone N"), and the helper
+ *   honors it. If the inviter chose a non-SMS-capable phone, the
+ *   resulting projection state (sms_enabled=true, sms_phone_id=<non-sms
+ *   capable phone>) reflects their decision; downstream notification
+ *   delivery (in workflows/) is responsible for skipping or escalating
+ *   based on phone capability.
  */
 function resolveInvitationPhonePlaceholder(
   rawPhoneId: string | null | undefined,

--- a/infrastructure/supabase/supabase/functions/accept-invitation/index.ts
+++ b/infrastructure/supabase/supabase/functions/accept-invitation/index.ts
@@ -26,10 +26,141 @@ import {
 import { buildEventMetadata } from '../_shared/emit-event.ts';
 
 // Deployment version tracking
-const DEPLOY_VERSION = 'v17-phase6-phones-prefs';
+const DEPLOY_VERSION = 'v19-phone-id-resolution-hardened';
 
 // CORS headers for frontend requests
 const corsHeaders = standardCorsHeaders;
+
+/**
+ * Phone shape carried in the invitation envelope. Mirrors the frontend's
+ * InvitationPhone type at `frontend/src/pages/users/UsersManagePage.tsx`.
+ */
+interface InvitationPhone {
+  label: string;
+  type: 'mobile' | 'office' | 'fax' | 'emergency';
+  number: string;
+  countryCode?: string;
+  smsCapable?: boolean;
+  isPrimary?: boolean;
+}
+
+/**
+ * Pairing of a freshly-minted phone UUID with the InvitationPhone payload it
+ * was created from. The accept-invitation handler builds this array in
+ * iteration order from the invitation's `phones[]`; the index correspondence
+ * is load-bearing for `resolveInvitationPhonePlaceholder` (do NOT reorder).
+ */
+interface CreatedInvitationPhone {
+  phoneId: string;
+  phone: InvitationPhone;
+}
+
+/**
+ * Resolve an `invitation-phone-N` placeholder phoneId to the real phone UUID
+ * created earlier in this invitation-acceptance flow.
+ *
+ * The frontend invitation form (`UsersManagePage.tsx:847`) generates
+ * placeholders of the form `invitation-phone-${index}` because it doesn't
+ * yet know the real UUIDs that will be minted at acceptance time. The
+ * backend is responsible for substituting the real UUID once phones exist.
+ *
+ * Pre-conditions:
+ *   - createdPhoneIds is in the same iteration order as the frontend's
+ *     phones[] array (stable insertion-order index correspondence). The
+ *     accept-invitation handler at the call site iterates phones in array
+ *     order and pushes into createdPhoneIds without reordering.
+ *   - rawPhoneId is one of: null, undefined, an `invitation-phone-N` string,
+ *     or a UUID belonging to this user's createdPhoneIds. Any other input
+ *     is normalized to null + warn.
+ *   - context: correlationId/userId/invitationId for joinable structured logs.
+ *
+ * Post-conditions:
+ *   - Returns either null or a string that is byte-identical to one of the
+ *     UUIDs in createdPhoneIds. Never returns a placeholder. Never throws.
+ *   - For input `invitation-phone-N` with N in [0, createdPhoneIds.length),
+ *     output === createdPhoneIds[N].phoneId.
+ *
+ * Cases:
+ *   - null/undefined input → null (no SMS phone selected; auto-select may fire)
+ *   - "invitation-phone-N" with N in range → createdPhoneIds[N].phoneId
+ *   - "invitation-phone-N" with N out of range → null + warn (auto-select may fire)
+ *   - Valid UUID matching an entry in createdPhoneIds → pass through
+ *   - Valid UUID NOT in createdPhoneIds → null + warn (defense in depth: prevents
+ *     a hand-crafted invitation payload from pointing this user's
+ *     sms_phone_id at another user's phone or a fabricated UUID)
+ *   - Other malformed string → null + warn (avoids silent handler ::UUID cast failure)
+ *
+ * Behavior with sms.enabled=false:
+ *   The helper is invoked unconditionally (regardless of prefs.sms.enabled)
+ *   so that any placeholder is always normalized to a clean UUID-or-null
+ *   before reaching the handler's ::UUID cast. If the inviter set SMS off
+ *   but left a placeholder selected, the projection will end up with
+ *   sms_enabled=false and sms_phone_id=<resolved UUID> — consistent with the
+ *   read-back contract of api.update_user_notification_preferences and a
+ *   harmless tombstone of the inviter's intent.
+ */
+function resolveInvitationPhonePlaceholder(
+  rawPhoneId: string | null | undefined,
+  createdPhoneIds: CreatedInvitationPhone[],
+  context: { correlationId?: string; userId: string; invitationId: string }
+): string | null {
+  if (!rawPhoneId) return null;
+
+  const placeholderMatch = rawPhoneId.match(/^invitation-phone-(\d+)$/);
+  if (placeholderMatch) {
+    const index = parseInt(placeholderMatch[1], 10);
+    if (index >= 0 && index < createdPhoneIds.length) {
+      return createdPhoneIds[index].phoneId;
+    }
+    console.warn(
+      `[accept-invitation v${DEPLOY_VERSION}] Placeholder phoneId out of range; falling back to null`,
+      {
+        rawPhoneId,
+        createdPhoneIdsLength: createdPhoneIds.length,
+        correlationId: context.correlationId,
+        userId: context.userId,
+        invitationId: context.invitationId,
+      }
+    );
+    return null;
+  }
+
+  // Validate it looks like a UUID; if not, refuse to pass through to avoid
+  // silent handler ::UUID cast failures (the bug this function exists to prevent).
+  const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  if (uuidPattern.test(rawPhoneId)) {
+    // Defense in depth: a UUID must correspond to a phone we just created
+    // for this user. Reject anything else — prevents a hand-crafted invitation
+    // payload from setting sms_phone_id to another user's phone or a
+    // fabricated UUID.
+    const isOwnedPhone = createdPhoneIds.some((p) => p.phoneId === rawPhoneId);
+    if (isOwnedPhone) {
+      return rawPhoneId;
+    }
+    console.warn(
+      `[accept-invitation v${DEPLOY_VERSION}] phoneId is a UUID but not in createdPhoneIds; falling back to null`,
+      {
+        rawPhoneId,
+        createdPhoneIdsLength: createdPhoneIds.length,
+        correlationId: context.correlationId,
+        userId: context.userId,
+        invitationId: context.invitationId,
+      }
+    );
+    return null;
+  }
+
+  console.warn(
+    `[accept-invitation v${DEPLOY_VERSION}] phoneId is neither a placeholder nor a UUID; falling back to null`,
+    {
+      rawPhoneId,
+      correlationId: context.correlationId,
+      userId: context.userId,
+      invitationId: context.invitationId,
+    }
+  );
+  return null;
+}
 
 /**
  * Supported OAuth providers (matches frontend OAuthProvider type)
@@ -596,21 +727,18 @@ serve(async (req) => {
     // ==========================================================================
     // PHASE 6: EMIT user.phone.added EVENTS FOR PHONES FROM INVITATION
     // This populates user_phones via process_user_event() trigger
+    //
+    // INVARIANT: createdPhoneIds is built in iteration order from phones[]
+    // and MUST NOT be reordered (e.g., do not sort by is_primary first).
+    // resolveInvitationPhonePlaceholder depends on stable insertion-order
+    // index correspondence with the frontend's phones[] array to map
+    // `invitation-phone-N` placeholders to real UUIDs.
     // ==========================================================================
-    interface InvitationPhone {
-      label: string;
-      type: 'mobile' | 'office' | 'fax' | 'emergency';
-      number: string;
-      countryCode?: string;
-      smsCapable?: boolean;
-      isPrimary?: boolean;
-    }
-
     const phones: InvitationPhone[] = invitation.phones || [];
     console.log(`[accept-invitation v${DEPLOY_VERSION}] Processing ${phones.length} phone(s) from invitation`);
 
-    // Track created phone IDs for potential SMS phone selection
-    const createdPhoneIds: { phoneId: string; phone: InvitationPhone }[] = [];
+    // Track created phone IDs for SMS phone selection + placeholder resolution
+    const createdPhoneIds: CreatedInvitationPhone[] = [];
 
     for (const phone of phones) {
       const phoneId = crypto.randomUUID();
@@ -668,7 +796,23 @@ serve(async (req) => {
       inApp: false,
     };
 
-    // If SMS is enabled but no phoneId specified, use first SMS-capable phone
+    // Resolve any `invitation-phone-N` placeholder phoneId to the real UUID
+    // created above. The frontend generates these placeholders at form-fill time
+    // because it doesn't yet know the real UUIDs; the backend must substitute
+    // them here, before emitting `user.notification_preferences.updated` (the
+    // handler casts phoneId to UUID and would otherwise fail). Out-of-range
+    // placeholders, foreign UUIDs, and malformed strings normalize to null,
+    // which triggers the existing auto-select fallback below.
+    if (prefs.sms) {
+      prefs.sms.phoneId = resolveInvitationPhonePlaceholder(prefs.sms.phoneId, createdPhoneIds, {
+        correlationId,
+        userId,
+        invitationId: invitation.id,
+      });
+    }
+
+    // If SMS is enabled but no phoneId specified (or placeholder normalized to null),
+    // use first SMS-capable phone
     if (prefs.sms?.enabled && !prefs.sms?.phoneId) {
       const smsCapablePhone = createdPhoneIds.find(p => p.phone.smsCapable);
       if (smsCapablePhone) {


### PR DESCRIPTION
## Summary

Fixes a silent data-corruption bug in the invitation acceptance flow: when a new user accepts an invitation that includes SMS notification preferences, the `accept-invitation` Edge Function previously passed the frontend's placeholder `phoneId` (`\"invitation-phone-0\"`) through verbatim into the `user.notification_preferences.updated` event. The handler's `::UUID` cast failed silently, leaving `user_notification_preferences_projection.sms_enabled = false` regardless of inviter intent.

In a medication-management platform where SMS is the operational alert channel, this is a compliance-relevant data integrity bug.

## Empirical reproduction (pre-fix)

Two affected historical events on dev:
- `de999f60-3e14-41e4-9d26-748f21927360` (`lars.tice+test@gmail.com`)
- `edc2c08e-d8ef-486c-911f-75fcb1e2a2d4` (`lars.tice+test1@gmail.com`)

Both carry `processing_error: 'invalid input syntax for type uuid: \"invitation-phone-0\"'`.

## What ships

- New helper `resolveInvitationPhonePlaceholder` at `accept-invitation/index.ts` resolves placeholders by index against the freshly-minted phone UUIDs.
- Helper applied **before** the existing auto-select fallback so out-of-range placeholders gracefully fall through to \"first SMS-capable phone\".
- Defense-in-depth: foreign UUIDs (not in `createdPhoneIds`) normalize to null + warn — prevents a hand-crafted invitation payload from setting `sms_phone_id` to another user's phone or a fabricated UUID.
- Hoisted `InvitationPhone` and added `CreatedInvitationPhone` interfaces to module level (no anonymous-shape contracts per project type-gen rule).
- Structured warn logs include `correlationId`, `userId`, `invitationId` for production log joinability.
- Invariant comment at `createdPhoneIds` construction site: array MUST NOT be reordered.
- `DEPLOY_VERSION`: `v17-phase6-phones-prefs` → `v19-phone-id-resolution-hardened`.

## Architect review (`software-architect-dbc`, verdict: APPROVE WITH CHANGES — all 5 incorporated)

- **C1**: Named type for `createdPhoneIds` (was anonymous `Array<{phoneId: string}>`).
- **C2**: Correlation/user/invitation context in helper warn logs.
- **C3**: Documented behavior for `sms.enabled=false + placeholder` case (resolve regardless; harmless tombstone consistent with read-back contract).
- **C4**: Defense-in-depth on UUID pass-through (validate against `createdPhoneIds`).
- **C5**: Backfill ops note (below).

## Smoke test (against live dev `tmrjlswbsxmbglmaclxu`, with v19 manually deployed)

Fresh user `lars.tice+test2@gmail.com` (`093c0e7b-5ace-49df-9632-d49858d54ef5`) created and accepted invitation 2026-04-29 21:42:

| Check | Expected | Got |
|---|---|---|
| `user.notification_preferences.updated` `processing_error` | `IS NULL` | **null** ✅ |
| `phoneId` in event_data | Real UUID (not placeholder) | `9f5a60cb-...` ✅ |
| `sms.enabled` in event_data | `true` | `true` ✅ |
| `user_notification_preferences_projection.sms_enabled` | `true` | `true` ✅ |
| `user_notification_preferences_projection.sms_phone_id` | UUID matching `user_phones` row | `9f5a60cb-...` ✅ |

End-to-end fix proven. Placeholder `invitation-phone-0` correctly resolved to `9f5a60cb-a6cd-4d7c-b2c6-837dfb1128d9`.

## Backfill posture

**Document, do not auto-correct.** Failed events preserved with `processing_error` for compliance audit. Affected users self-correct via notification preferences UI post-fix (requires `user.update` permission per PR #40's self-bypass removal).

**Recommended ops follow-up post-deploy verification** — invoke `api.retry_failed_event(<event_id>)` for the two affected events so the projection self-heals from the audit row:

```sql
SELECT api.retry_failed_event('de999f60-3e14-41e4-9d26-748f21927360');
SELECT api.retry_failed_event('edc2c08e-d8ef-486c-911f-75fcb1e2a2d4');
```

(Note: the test1 user is currently deleted, so the retry will fail or no-op for them; safe to run anyway. The test user is currently deactivated; the retry will succeed and their projection will reflect the originally-intended SMS preferences.)

## Manual deploy state

Edge Function v19 was manually deployed to `tmrjlswbsxmbglmaclxu` for smoke testing (Edge Function version 127). When this PR merges, \"Deploy Edge Functions\" CI will redeploy from main; final state aligns to v19.

## Out of scope

- Handler-side defensive UUID validation (separate hardening item).
- Frontend's continued generation of `invitation-phone-N` placeholders (intentional contract; backend is the resolution authority).
- Deno test harness for Edge Function helpers — filed as a parked card at `dev/parked/edge-function-deno-test-harness/` with concrete scope (first-target helper: `resolveInvitationPhonePlaceholder`, 6 cases per its docblock).

## Test plan

- [x] Pre-deploy regression query — 2 affected historical events identified
- [x] Manual deploy to dev — Edge Function v127 with `DEPLOY_VERSION = v19-phone-id-resolution-hardened`
- [x] Source verification via `mcp__supabase__get_edge_function`
- [x] Functional smoke test (live UI flow with new test user, SMS preferences enabled)
- [x] Architect review (all 5 change requests incorporated)
- [ ] CI green
- [ ] Post-merge: `api.retry_failed_event` for the 2 historical affected events
- [ ] Post-merge: re-verify `mcp__supabase__get_edge_function` shows v19 still deployed after CI redeploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Review response (commit `56dc79f4`)

Per architect-dbc adjudication of the issue-comment review (verdict: APPROVE WITH MINOR FOLLOW-UPS), this PR now also includes:
- Docblock notes for Issue 2 (mid-loop phone emit failure index shift) and Issue 3 (smsCapable mismatch on placeholder path).
- Three new cards: `dev/parked/edge-function-deno-test-harness/`, `dev/active/fix-phone-emit-index-preservation/` (Issue 2 behavior fix), `dev/parked/edge-function-ci-preview-deploy/` (Issue 5).
- Issue 4 (regex laxness) — NO-OP per architect; the `createdPhoneIds` membership check makes it moot.
