### PR TITLE
fix(security): sanitize processing_error PII (HIPAA, Hybrid Option 6)

### DIFF
--- a/.claude/skills/infrastructure-guidelines/SKILL.md
+++ b/.claude/skills/infrastructure-guidelines/SKILL.md
@@ -373,6 +373,30 @@ supabase gen types typescript --linked > ../../workflows/src/types/database.type
 
 ---
 
+## 16. Handler `RAISE EXCEPTION` Strings Must Not Interpolate Identifiers
+
+Handler/RPC `RAISE EXCEPTION` text is captured by the BEFORE INSERT dispatcher trigger and persisted into `domain_events.processing_error` (visible to platform admins via `api.get_failed_events`). Any user/client identifier interpolated via `%` (UUIDs, emails, names, phone numbers, ltree paths that include facility names) leaks into that audit-visible string — even after the persistence-layer trigger fix that drops `PG_EXCEPTION_DETAIL`. Use `USING ERRCODE = '<opaque>'` and a generic message instead; the caller already knows what they asked for, and the ERRCODE distinguishes the case for branching.
+
+```sql
+-- ✅ Correct
+IF v_role_name IS NULL THEN
+  RAISE EXCEPTION 'Role not found' USING ERRCODE = 'P0002';
+END IF;
+
+-- ❌ Wrong — leaks UUID into processing_error
+IF v_role_name IS NULL THEN
+  RAISE EXCEPTION 'Role not found: %', p_role_id USING ERRCODE = 'P0002';
+END IF;
+```
+
+**What counts as an identifier**: anything that names or addresses a tenant-scoped entity. UUIDs, emails, phone numbers, person names, ltree paths containing OU names. **What does not**: fixed enum values (`stream_type`, `event_type`, status strings) and `SQLERRM`/`SQLSTATE` (already opaque). When in doubt, prefer ERRCODE.
+
+**Audit pattern** when adding or modifying a handler/RPC: grep the file for `RAISE EXCEPTION '[^']*%[^']*'` and review each `%` placeholder's argument. Five baseline_v4 violations were remediated in migration `20260430002824_strip_processing_error_detail_with_admin_rpc.sql`; new violations land in this same shape and should be caught at PR review.
+
+**See**: `documentation/architecture/decisions/adr-rpc-readback-pattern.md` (PII handling section); migration `20260430002824` for the worked examples.
+
+---
+
 ## File Locations
 
 | What | Where |

--- a/.github/workflows/supabase-edge-functions-test.yml
+++ b/.github/workflows/supabase-edge-functions-test.yml
@@ -1,0 +1,41 @@
+name: Edge Function Deno Tests
+
+# Runs Deno unit tests for Edge Functions.
+#
+# Establishes the per-Edge-Function test pattern from PR #42 as a CI gate. Tests live
+# under either `_shared/__tests__/` (shared utilities) or `<function>/__tests__/`
+# (per-function helpers). All test files matching `__tests__/**/*.test.ts` under
+# `infrastructure/supabase/supabase/functions/` are picked up.
+#
+# Network access is allowed (--allow-net) because some tests mock `fetch` via global
+# patching, which Deno requires net permission to instantiate. No real network calls
+# should occur in tests; if one does, that's a test-quality bug.
+
+on:
+  pull_request:
+    paths:
+      - 'infrastructure/supabase/supabase/functions/**'
+  push:
+    branches:
+      - main
+    paths:
+      - 'infrastructure/supabase/supabase/functions/**'
+
+jobs:
+  deno-test:
+    name: Run Deno unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+
+      - name: Run all Deno tests under functions/
+        working-directory: infrastructure/supabase/supabase/functions
+        run: |
+          # Allow network because some tests mock fetch (Deno requires the permission to
+          # patch the global). No actual network calls should occur in tests.
+          deno test --allow-net --allow-env --reporter=pretty

--- a/dev/active/migrate-services-to-api-rpc-envelope/context.md
+++ b/dev/active/migrate-services-to-api-rpc-envelope/context.md
@@ -1,0 +1,62 @@
+# Migrate Services to apiRpcEnvelope + Ship ESLint Rule — Context
+
+**Type**: Defense-in-depth; codemod + lint enforcement
+**Status**: 🟢 ACTIVE — ready when bandwidth opens
+**Priority**: Medium — primary HIPAA leak vectors already closed by PR #43; this card hardens the SDK boundary
+**Origin**: Spun out of PR #43 (`fix(security): sanitize processing_error PII (HIPAA, Hybrid Option 6)`) when the v3 plan's "B2" service-migration scope ballooned beyond a single PR.
+
+## Capability target
+
+Migrate all envelope-shaped (Pattern A v2) `api.*` RPC call sites in `frontend/src/services/` from direct `supabase.schema('api').rpc(...)` invocations to `supabaseService.apiRpcEnvelope<T>(...)`. Ship the deferred ESLint `no-restricted-syntax` rule that blocks new direct callers. End state: no service file outside `frontend/src/services/auth/supabase.service.ts` and `frontend/src/services/api/envelope.ts` calls `.schema('api').rpc(` directly.
+
+## Why now (concrete trigger)
+
+PR #43 closed the persistence-layer leak (trigger drops PG_EXCEPTION_DETAIL into a gated column) and the Edge Function leak (3 chokepoint patches across 7 functions). The remaining defense-in-depth gap is the frontend SDK boundary: ~70 direct `.schema('api').rpc(...)` callers across 8 service files don't route through the new typed `unwrapApiEnvelope<T>` helper, so their `data.error` fields are not masked at the boundary. Today the underlying text is mostly safe because:
+
+1. The trigger only persists `MESSAGE_TEXT` (no `PG_EXCEPTION_DETAIL`) post-PR #43.
+2. The 6 known RAISE EXCEPTION identifier-leaks are remediated.
+3. New RAISE EXCEPTION violations are gated by SKILL.md Rule 16 and PR review.
+
+But these are preventive controls that depend on developer discipline. The structural fix is to route all envelope reads through the typed boundary helper so the masker fires regardless of source-side hygiene. Without the bulk migration, the ESLint rule cannot ship — the repo's `--max-warnings 0` policy means 89 existing warnings would break the lint gate.
+
+## Trigger to start
+
+Start when:
+- Bandwidth opens for ~2-3 days of mechanical edits (the codemod is repetitive but each file requires careful review of return-shape contracts), OR
+- A new RAISE EXCEPTION identifier-leak is discovered in production, raising the priority of structural prevention.
+
+## Scope
+
+**In scope**:
+- Migrate envelope-shaped writes in 8 services (~50-60 call sites) to `apiRpcEnvelope<T>`:
+  - `SupabaseUserCommandService` (audit + migrate envelope calls)
+  - `SupabaseRoleService`
+  - `SupabaseClientService`
+  - `SupabaseScheduleService`
+  - `SupabaseClientFieldService`
+  - `SupabaseOrganizationCommandService`
+  - `SupabaseOrganizationEntityService`
+  - `SupabaseOrganizationUnitService`
+- Migrate read-shaped reads (~10-20 call sites) in `SupabaseUserQueryService` and `SupabaseOrganizationQueryService` to `supabaseService.apiRpc<T>(...)` so `PostgrestError` surfaces are masked.
+- Re-enable the `no-restricted-syntax` rule in `frontend/eslint.config.js` (the placeholder comment is already in place from PR #43).
+- Confirm `npm run lint` passes with `--max-warnings 0` after migration.
+
+**Out of scope**:
+- Refactoring service return-shape contracts beyond what the migration mechanically requires.
+- Unit tests for the migrated services (they have integration-via-VM coverage today).
+- Migrating `SupabaseOrganizationQueryService.ts` calls that intentionally return raw arrays (those stay on `apiRpc<T>` for the masking; no envelope shape involved).
+
+## Constraints
+
+- Each service's existing return-shape contract MUST be preserved. The new helper returns `ApiEnvelope<T> = ApiEnvelopeSuccess<T> | ApiEnvelopeFailure` where `ApiEnvelopeSuccess<T>` is `{success: true} & T` (intersection type) — this matches existing flat-shape returns like `{success: true, role?: Role}`.
+- `--max-warnings 0` is the merge gate. The ESLint rule must ship in the same PR as the codemod; staging it as `warn` first is not viable.
+- The migration must NOT change any `await supabase.schema('api').rpc(...)` call inside the SDK helpers themselves (`supabase.service.ts`, `envelope.ts`). The ESLint rule will exclude those two files.
+
+## References
+
+- PR #43: `fix(security): sanitize processing_error PII (HIPAA, Hybrid Option 6)` — establishes the typed boundary and defers this migration.
+- `frontend/src/services/api/envelope.ts` — `unwrapApiEnvelope<T>` and `ApiEnvelope<T>` types.
+- `frontend/src/services/auth/supabase.service.ts` — `apiRpc<T>` (read shape) and `apiRpcEnvelope<T>` (envelope shape).
+- `frontend/src/services/CLAUDE.md` § 3 — documented usage of the two helpers.
+- `documentation/architecture/decisions/adr-rpc-readback-pattern.md` PII handling section — bulk migration / ESLint rule listed as deferred.
+- `frontend/eslint.config.js` — placeholder comment in the rules block citing this card.

--- a/dev/active/migrate-services-to-api-rpc-envelope/plan.md
+++ b/dev/active/migrate-services-to-api-rpc-envelope/plan.md
@@ -1,0 +1,123 @@
+# Plan — Migrate Services to apiRpcEnvelope + Ship ESLint Rule
+
+## Phases
+
+| Phase | Description |
+|-------|-------------|
+| 0 | Inventory — grep `frontend/src/services/` for `.schema('api').rpc(`. Categorize each call site as envelope-shaped (write) or read-shape (returns array/scalar/object). Record current return shape of each enclosing service method to confirm the intersection-type contract preserves it. |
+| 1 | Migrate one pilot service end-to-end: `SupabaseRoleService`. Smallest envelope-shape variation; serves as the reference for the codemod. Confirm `npm run typecheck` + Vitest pass after. |
+| 2 | Migrate the remaining 7 services in priority order: `SupabaseUserCommandService` (highest PHI), `SupabaseClientService` (PHI: addresses/names/DOB), `SupabaseClientFieldService`, `SupabaseScheduleService`, `SupabaseOrganizationCommandService`, `SupabaseOrganizationEntityService`, `SupabaseOrganizationUnitService`. Each migration is isolated; run typecheck after each to catch shape drift early. |
+| 3 | Migrate read-shape callers (`SupabaseUserQueryService`, `SupabaseOrganizationQueryService`) from direct `.rpc()` to `supabaseService.apiRpc<T>(...)`. These don't need `apiRpcEnvelope<T>` (no envelope shape) but DO benefit from the wrapper-level `PostgrestError` masking. |
+| 4 | Re-enable the ESLint rule in `frontend/eslint.config.js`. Replace the placeholder comment block (committed in PR #43) with the actual `no-restricted-syntax` rule. Add the file-level override that allow-lists `supabase.service.ts` and `envelope.ts`. |
+| 5 | Verify `npm run lint` passes with `--max-warnings 0`. Run full typecheck + build. Run all Vitest suites including any service tests. |
+
+## Mechanical pattern (per envelope-shaped call site)
+
+**Before**:
+```typescript
+const { data, error } = await supabase.schema('api').rpc('update_user', {
+  p_user_id: id,
+  p_email: email,
+});
+if (error) {
+  log.error('Failed to update user', { error });
+  return { success: false, error: error.message };
+}
+if (!data?.success) {
+  return { success: false, error: data?.error || 'Update failed' };
+}
+return { success: true, user: data.user };
+```
+
+**After**:
+```typescript
+const env = await supabaseService.apiRpcEnvelope<{ user: User; event_id: string }>(
+  'update_user',
+  { p_user_id: id, p_email: email },
+);
+if (!env.success) {
+  return { success: false, error: env.error };  // env.error already masked
+}
+return { success: true, user: env.user };  // intersection-type contract: env.user is typed
+```
+
+The `import { supabase } from '@/lib/supabase'` import in each service can stay if the file still uses it for non-RPC calls; otherwise drop it.
+
+## Mechanical pattern (per read-shape call site)
+
+**Before**:
+```typescript
+const { data, error } = await supabase.schema('api').rpc('list_users', {
+  p_org_id: claims.org_id,
+});
+if (error) { /* handle */ }
+return data ?? [];
+```
+
+**After**:
+```typescript
+const { data, error } = await supabaseService.apiRpc<UserListItem[]>('list_users', {
+  p_org_id: claims.org_id,
+});
+if (error) {
+  // error.message / details / hint already masked
+  /* handle */
+}
+return data ?? [];
+```
+
+Caller-side handling is unchanged; the wrapper masks `PostgrestError` fields.
+
+## ESLint rule (Phase 4)
+
+Replace the placeholder in `frontend/eslint.config.js`:
+
+```javascript
+// In the main `rules` block:
+'no-restricted-syntax': [
+  'error',
+  {
+    selector:
+      "CallExpression[callee.type='MemberExpression'][callee.property.name='rpc']" +
+      "[callee.object.type='CallExpression'][callee.object.callee.type='MemberExpression']" +
+      "[callee.object.callee.property.name='schema']",
+    message:
+      'Direct .schema("api").rpc(...) calls bypass PII masking. Use ' +
+      'supabaseService.apiRpcEnvelope<T>(...) for envelope-shaped writes or ' +
+      'supabaseService.apiRpc<T>(...) for read-shaped RPCs.',
+  },
+],
+```
+
+Add a file-level override:
+```javascript
+{
+  files: [
+    'src/services/auth/supabase.service.ts',
+    'src/services/api/envelope.ts',
+  ],
+  rules: { 'no-restricted-syntax': 'off' },
+},
+```
+
+## Open questions
+
+- **Q1**: Some services (`SupabaseOrganizationEntityService`) construct dynamic RPC names (`rpcName` variable). The ESLint rule's AST selector matches the static `.schema('api').rpc(...)` call shape; dynamic-name calls still trip the rule. Decide: refactor to static names, or whitelist via per-line `eslint-disable-next-line` with justification.
+- **Q2**: Do any service test files (`*.mapping.test.ts`) mock `supabase.schema('api').rpc(...)` directly? If yes, they'll trip the rule. Decide: add the test files to the allow-list, or migrate the mocks to mock `supabaseService.apiRpcEnvelope<T>`.
+- **Q3**: After migration, are there any services that no longer import from `@/lib/supabase`? If yes, remove the unused import to keep files clean.
+
+## Critical files (read-only until Phase 1)
+
+- `frontend/src/services/auth/supabase.service.ts` — helper definitions; SHOULD NOT be modified during this migration.
+- `frontend/src/services/api/envelope.ts` — boundary helper; SHOULD NOT be modified during this migration.
+- `frontend/src/services/CLAUDE.md` § 3 — usage convention; reference for explaining the migration in code review.
+- `frontend/eslint.config.js` — placeholder comment block to replace.
+- All 8 services listed in `context.md` § Scope.
+
+## Verification
+
+- `npm run typecheck` passes after each service migration (Phase 1, 2, 3).
+- `npm run lint` passes with `--max-warnings 0` after Phase 4. Confirms the ESLint rule fires only on intentional violations (which shouldn't exist).
+- `npm run build` passes — no missed type narrowing introduced by the helper's discriminated union.
+- Vitest suites for any migrated services pass (existing tests cover envelope handling via mocks).
+- Manual smoke check on one envelope-shaped UI flow (e.g., role assignment, user update) — confirm error toasts still display correctly post-migration.

--- a/dev/active/migrate-services-to-api-rpc-envelope/tasks.md
+++ b/dev/active/migrate-services-to-api-rpc-envelope/tasks.md
@@ -1,0 +1,50 @@
+# Tasks — Migrate Services to apiRpcEnvelope + Ship ESLint Rule
+
+## Current Status
+
+**Phase**: ACTIVE (2026-04-30)
+**Status**: 🟢 READY — awaiting bandwidth
+**Priority**: Medium
+
+## Tasks
+
+- [x] Card filed (2026-04-30) — spun out of PR #43 when v3 plan's B2 scope ballooned
+
+### Phase 0 — Inventory
+
+- [ ] Grep `frontend/src/services/` for `.schema('api').rpc(` and produce a complete call-site list grouped by service.
+- [ ] Per service method, classify each call as envelope-shaped vs read-shape and record the current return-shape contract for verification.
+
+### Phase 1 — Pilot service
+
+- [ ] Migrate `SupabaseRoleService` envelope-shaped writes to `apiRpcEnvelope<T>`. Run typecheck + Vitest. PR-local commit message: `refactor(services): migrate role service to apiRpcEnvelope (1/N)`.
+
+### Phase 2 — Bulk service migration
+
+- [ ] `SupabaseUserCommandService` (envelope writes) — highest PHI surface.
+- [ ] `SupabaseClientService` (envelope writes) — PHI: addresses, names, DOB.
+- [ ] `SupabaseClientFieldService` (envelope writes).
+- [ ] `SupabaseScheduleService` (envelope writes).
+- [ ] `SupabaseOrganizationCommandService` (envelope writes).
+- [ ] `SupabaseOrganizationEntityService` (envelope writes; resolve dynamic-name Q1).
+- [ ] `SupabaseOrganizationUnitService` (envelope writes).
+- [ ] `OrphanedDeletionService` (envelope writes).
+
+### Phase 3 — Read-shape migration
+
+- [ ] `SupabaseUserQueryService` reads → `supabaseService.apiRpc<T>(...)`.
+- [ ] `SupabaseOrganizationQueryService` reads → `supabaseService.apiRpc<T>(...)`.
+
+### Phase 4 — ESLint rule
+
+- [ ] Replace placeholder comment in `frontend/eslint.config.js` with the actual `no-restricted-syntax` rule + file-level override allow-listing the 2 SDK files.
+- [ ] Audit any test files that mock direct `.rpc()` calls (Q2) and either migrate the mocks or add to allow-list.
+
+### Phase 5 — Verification
+
+- [ ] `npm run typecheck` green for `frontend/`.
+- [ ] `npm run lint` green with `--max-warnings 0`.
+- [ ] `npm run build` green.
+- [ ] All Vitest suites green.
+- [ ] Manual smoke test on at least one envelope-shaped UI flow (role assignment / user update).
+- [ ] PR opened referencing this card.

--- a/documentation/architecture/decisions/adr-rpc-readback-pattern.md
+++ b/documentation/architecture/decisions/adr-rpc-readback-pattern.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last_updated: 2026-04-29
+last_updated: 2026-04-30
 ---
 
 
@@ -150,7 +150,9 @@ HTTP status: always 200 OK. The PostgREST response shape is `{success, ...}`; co
 
 **Software-architect-dbc** drafted the recommended ViewModel convention: `if (response.error?.startsWith('Event processing failed: ')) { /* surface as processingError, offer audit-log link */ } else { /* generic error */ }`.
 
-**Post-mask amend (2026-04-29)**: After PII masking lands (migration `20260430002824` and frontend SDK boundary), `result.error` text is **structurally redacted**. The literal prefix `"Event processing failed: "` is preserved (the masker never touches it), so the prefix-parse pattern continues to work. However, the suffix is degraded: `Key (col)=(value)` becomes `Key (col)=(<redacted>)`, UUIDs become `<uuid>`, emails become `<email>`. ViewModels MUST NOT extract identifiers from the masked suffix; use the captured `event_id` returned in the success envelope (or refetch by stream_id) for any audit-log linking affordance. Confirmed prefix-only consumer today: `frontend/src/pages/users/UsersManagePage.tsx:601-607`.
+**Post-mask amend (2026-04-29)**: After PII masking lands (migration `20260430002824` and frontend SDK boundary), `result.error` text is **structurally redacted**. The literal prefix `"Event processing failed: "` is preserved (the masker never touches it), so the prefix-parse pattern continues to work. However, the suffix is degraded: `Key (col)=(value)` becomes `Key (col)=(<redacted>)`, UUIDs become `<uuid>`, emails become `<email>`. ViewModels MUST NOT extract identifiers from the masked suffix; use the captured `event_id` returned in the success envelope (or refetch by stream_id) for any audit-log linking affordance.
+
+**Verified 2026-04-30** (PR #43 architect review LOW-2 follow-up): repo-wide grep confirms only **one** consumer parses `.error` by prefix — `frontend/src/pages/users/UsersManagePage.tsx:605` calls `.startsWith('Event processing failed:')` to swap a friendly fallback message for the raw RPC text. **Zero** consumers extract identifiers from the error suffix (no `.match` / `.split` / `.indexOf` patterns on `.error` strings). One ViewModel — `frontend/src/viewModels/settings/ClientFieldSettingsViewModel.ts:460` — uses `.error?.includes('Field key already exists')` for a substring-detect on a stable phrase emitted by a Rule-16-compliant handler `RAISE EXCEPTION`; the masker leaves that phrase untouched (no `Key (...)=(...)` pattern, no UUID, no email) so the consumer remains safe. Future ViewModels that want to branch on a specific failure mode SHOULD prefer the captured `event_id` + an audit-log lookup over text parsing.
 
 ## PII handling (2026-04-29)
 

--- a/documentation/architecture/decisions/adr-rpc-readback-pattern.md
+++ b/documentation/architecture/decisions/adr-rpc-readback-pattern.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last_updated: 2026-04-24
+last_updated: 2026-04-29
 ---
 
 
@@ -149,6 +149,33 @@ HTTP status: always 200 OK. The PostgREST response shape is `{success, ...}`; co
 **Why not the PostgREST `code` field**: The original n2 telemetry note from PR #29 review proposed using PostgreSQL `ERRCODE` (e.g. P9003 / P9004) surfaced via PostgREST's response `code` field. That would only work under Pattern B (`RAISE EXCEPTION ... USING ERRCODE = ...`), which Decision 2 forbids for handler-driven failures. Under Pattern A, PostgREST always returns 200 OK with `{success, error}`, so there is no `code` field to read.
 
 **Software-architect-dbc** drafted the recommended ViewModel convention: `if (response.error?.startsWith('Event processing failed: ')) { /* surface as processingError, offer audit-log link */ } else { /* generic error */ }`.
+
+**Post-mask amend (2026-04-29)**: After PII masking lands (migration `20260430002824` and frontend SDK boundary), `result.error` text is **structurally redacted**. The literal prefix `"Event processing failed: "` is preserved (the masker never touches it), so the prefix-parse pattern continues to work. However, the suffix is degraded: `Key (col)=(value)` becomes `Key (col)=(<redacted>)`, UUIDs become `<uuid>`, emails become `<email>`. ViewModels MUST NOT extract identifiers from the masked suffix; use the captured `event_id` returned in the success envelope (or refetch by stream_id) for any audit-log linking affordance. Confirmed prefix-only consumer today: `frontend/src/pages/users/UsersManagePage.tsx:601-607`.
+
+## PII handling (2026-04-29)
+
+`processing_error` carries operator-debug detail that historically included `PG_EXCEPTION_DETAIL` row data. In a multi-tenant medication-management platform this is HIPAA exposure: `Key (email)=(other-user@acme.com)`, `Key (phone)=(+15551234567)`, `Key (last_name, first_name)=(Smith, John)`, and `Failing row contains (uuid, email, John, Smith, 1985-06-12, ...)` are all canonical PG output shapes that leak cross-tenant PHI to any authenticated caller.
+
+**Three-layer model**:
+
+1. **Persistence layer** — `process_domain_event()` trigger now writes `processing_error = MESSAGE_TEXT` only; raw `PG_EXCEPTION_DETAIL` is preserved in NEW column `processing_error_detail` accessible only via a permission-gated RPC (`api.get_failed_events_with_detail()` gated on `platform.view_event_details`). Forensic parity with pre-migration behavior preserved; no operator-debug regression. `RAISE WARNING` in PG logs unchanged.
+
+2. **SDK boundary (frontend)** — `frontend/src/services/api/envelope.ts` provides `unwrapApiEnvelope<T>(rpcResult): ApiEnvelope<T>` as the only sanctioned way to read `error` off an `api.*` envelope. Helper applies `frontend/src/utils/maskPii.ts` exactly once. `supabaseService.apiRpcEnvelope<T>()` is the typed entry point. `apiRpc<T>` is also augmented to mask `PostgrestError.{message, details, hint}` for read-shape RPCs.
+
+3. **Source-side prevention** — handler/RPC `RAISE EXCEPTION` strings MUST NOT interpolate user/client identifiers. Use `USING ERRCODE = '<opaque>'` + a generic message instead. Codified as Rule 16 in `.claude/skills/infrastructure-guidelines/SKILL.md`. Five baseline_v4 violations were remediated in migration `20260430002824` (functions: `api.bulk_assign_role`, `api.sync_role_assignments`, `public.retry_failed_bootstrap`, `public.switch_organization`, `public.validate_role_scope_path_active`).
+
+**Workflow consumers**: `workflows/src/shared/utils/event-queries.ts:204,292-293` reads `processing_error` for failed-workflow rollups. Audit verdict: server-internal aggregation; never echoed to a frontend client. **No remediation needed**. Workflows that need forensic detail SELECT directly from `domain_events.processing_error_detail` — service role bypasses RLS and bypasses the RPC permission gate.
+
+**Edge Function audit (8 functions)**: All Edge Functions that surface PG/RPC error text route through one of three chokepoints:
+- `_shared/error-response.ts` `handleRpcError()` — masked at L185 (`details: maskPii(rpcError.message)`).
+- `_shared/error-response.ts` `createInternalError()` — masked at L286 (`details: details ? maskPii(details) : undefined`).
+- `invite-user/index.ts:382` (`sendInvitationEmail` catch path) — local helper, masked inline.
+- `invite-user/index.ts:369` (Resend non-OK response path) — masked inline.
+Affected functions: `accept-invitation`, `invite-user`, `manage-user`, `organization-bootstrap`, `organization-delete`, `validate-invitation`, `workflow-status`. Per-function Deno tests verify masking; CI runs them via `.github/workflows/supabase-edge-functions-test.yml`.
+
+**Client-side telemetry audit (frontend)**: `frontend/src/utils/logger.ts` `remote` output target is dead/stub code (TODO comment, no fetch implementation). No Sentry/Datadog/external SaaS shipper is currently configured. `LogOverlay.tsx` intercepts `console.error` for in-development overlay only — receives masked text under the new SDK boundary. Mask in **all environments** (no dev-only escape hatch). Re-audit when a SaaS shipper is introduced.
+
+**ESLint rule (deferred)**: a `no-restricted-syntax` rule forbidding direct `.schema('api').rpc(` outside `supabase.service.ts` and `envelope.ts` is **planned** but not yet shipped — the repo's `--max-warnings 0` lint policy means the rule cannot ship until existing call sites (~70 across 8 services) are migrated to `apiRpcEnvelope<T>`. Rule + bulk migration land together in a follow-up card.
 
 ## Contract
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -121,12 +121,14 @@ export default [
       'no-var': 'error',
       'no-undef': 'error', // This should be handled by globals now
 
-      // FUTURE (deferred to bulk-service-migration follow-up): a no-restricted-syntax rule
-      // forbidding direct .schema('api').rpc(...) outside src/services/auth/supabase.service.ts
-      // and src/services/api/envelope.ts. Lands together with the codemod that migrates the
-      // 8 legacy services to apiRpcEnvelope<T>. Repo-wide --max-warnings 0 means the rule
-      // can't ship until existing call sites are migrated. See ADR PII handling section and
-      // the dev/active follow-up card.
+      // FUTURE — deferred to follow-up card:
+      //   dev/active/migrate-services-to-api-rpc-envelope/
+      // A no-restricted-syntax rule will forbid direct .schema('api').rpc(...) outside
+      // src/services/auth/supabase.service.ts and src/services/api/envelope.ts. Lands
+      // together with the codemod that migrates the 8 legacy services to
+      // apiRpcEnvelope<T>. Repo-wide --max-warnings 0 means the rule can't ship until
+      // existing call sites are migrated. See also the PII handling section in
+      // documentation/architecture/decisions/adr-rpc-readback-pattern.md.
     },
   },
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -120,9 +120,16 @@ export default [
       'prefer-const': 'warn',
       'no-var': 'error',
       'no-undef': 'error', // This should be handled by globals now
+
+      // FUTURE (deferred to bulk-service-migration follow-up): a no-restricted-syntax rule
+      // forbidding direct .schema('api').rpc(...) outside src/services/auth/supabase.service.ts
+      // and src/services/api/envelope.ts. Lands together with the codemod that migrates the
+      // 8 legacy services to apiRpcEnvelope<T>. Repo-wide --max-warnings 0 means the rule
+      // can't ship until existing call sites are migrated. See ADR PII handling section and
+      // the dev/active follow-up card.
     },
   },
-  
+
   // Apply to Node.js files (scripts, config, tests)
   {
     files: ['scripts/**/*.{js,ts,cjs}', '*.config.{js,ts}', 'vitest.config.*', 'playwright.config.*'],

--- a/frontend/src/services/CLAUDE.md
+++ b/frontend/src/services/CLAUDE.md
@@ -23,7 +23,7 @@ last_updated: 2026-04-22
 
 # Frontend Services Guidelines
 
-This file governs code under `frontend/src/services/`. Three rules — all backed by past production incidents.
+This file governs code under `frontend/src/services/`. Four rules — all backed by past production incidents.
 
 ## 1. Service Session Management
 
@@ -145,7 +145,59 @@ const { data } = await client
 - `SupabaseOrganizationUnitService` → `api.get_organization_units()`
 - `SupabaseScheduleService` → `api.list_schedule_templates()`
 
-## 3. Correlation ID Pattern (Business-Scoped)
+## 3. RPC Helpers — `apiRpc` vs `apiRpcEnvelope`
+
+> **⚠️ HIPAA-relevant: PII masking happens at the SDK boundary.**
+> All `api.*` RPCs SHOULD route through `supabaseService.apiRpc(...)` or `supabaseService.apiRpcEnvelope<T>(...)` so error fields are masked exactly once before any consumer reads them.
+
+Two helpers, picked by **return shape**:
+
+### `apiRpcEnvelope<T>` — write/envelope-shaped RPCs (Pattern A v2)
+
+Use for any RPC that returns the `{success, error?, ...flat fields}` envelope (every `api.update_*`, `api.create_*`, `api.delete_*`, `api.change_*`, etc. — see [`adr-rpc-readback-pattern.md`](../../../documentation/architecture/decisions/adr-rpc-readback-pattern.md)).
+
+```typescript
+import { supabaseService } from '@/services/auth/supabase.service';
+
+const env = await supabaseService.apiRpcEnvelope<{ user: User; event_id: string }>(
+  'update_user',
+  { p_user_id: id, p_email: email },
+);
+if (!env.success) {
+  return { success: false, error: env.error };  // env.error is already masked
+}
+return { success: true, user: env.user };  // intersection-type contract: env.user is typed
+```
+
+The helper's return type is `ApiEnvelope<T> = ApiEnvelopeSuccess<T> | ApiEnvelopeFailure`, an intersection-type discriminated union (`{success: true} & T`). Existing flat-shape callers (`{success: true, role?: Role}`, etc.) work unchanged because the success-path spreads `data` fields onto the envelope.
+
+### `apiRpc<T>` — read-shape RPCs (arrays, scalars, custom objects)
+
+Use for RPCs whose `data` is NOT a `{success, error, ...}` envelope — typically `get_*`, `list_*`, `find_*`. The helper masks the wrapper-level `PostgrestError` (`.message`, `.details`, `.hint`) so PostgREST 4xx responses don't leak PHI either.
+
+```typescript
+const { data, error } = await supabaseService.apiRpc<UserOrgAccess[]>(
+  'list_user_org_access',
+  { p_user_id: userId },
+);
+if (error) {
+  // error.message / error.details / error.hint are already masked
+  return [];
+}
+return data ?? [];
+```
+
+### Why both helpers (don't mutate envelope `data` from `apiRpc`)
+
+`apiRpc<T>` only masks the wrapper error (`PostgrestError`), NOT the `data` payload. Mutating `data.error` inside a generic `apiRpc<T>` would silently change the caller's typed `T` — a contract break. `apiRpcEnvelope<T>` exists specifically to mask the envelope's `data.error` field via `unwrapApiEnvelope<T>` and return a typed `ApiEnvelope<T>`.
+
+### Direct `.schema('api').rpc(...)` (legacy)
+
+Some services still call `supabase.schema('api').rpc(...)` directly. These bypass masking and are slated for migration to `apiRpcEnvelope<T>` in a follow-up card. New code MUST use one of the two helpers above; an ESLint rule will land alongside the bulk migration to enforce this.
+
+**See**: `documentation/architecture/decisions/adr-rpc-readback-pattern.md` (PII handling section); `frontend/src/services/api/envelope.ts` (helper implementation); `frontend/src/utils/maskPii.ts` (masker).
+
+## 4. Correlation ID Pattern (Business-Scoped)
 
 `correlation_id` ties together the ENTIRE business transaction lifecycle, not just a single request.
 

--- a/frontend/src/services/admin/EventMonitoringService.ts
+++ b/frontend/src/services/admin/EventMonitoringService.ts
@@ -29,6 +29,7 @@ import type {
 } from '@/types/event-monitoring.types';
 import { supabaseService } from '@/services/auth/supabase.service';
 import { Logger } from '@/utils/logger';
+import { maskPii } from '@/utils/maskPii';
 
 const log = Logger.getLogger('api');
 
@@ -191,7 +192,12 @@ export class EventMonitoringService {
         event_type: row.event_type,
         event_data: row.event_data,
         event_metadata: row.event_metadata as FailedEvent['event_metadata'],
-        processing_error: row.processing_error,
+        // PII mask: row.processing_error is MESSAGE_TEXT only post-migration, but the field
+        // historically carried PG_EXCEPTION_DETAIL row data. Mask defensively for the admin
+        // dashboard so /admin/events sees the same sanitized text every other consumer sees.
+        // Forensic detail (raw PG_EXCEPTION_DETAIL) is available only via
+        // api.get_failed_events_with_detail() gated on platform.view_event_details.
+        processing_error: maskPii(row.processing_error),
         created_at: row.created_at,
         processed_at: row.processed_at,
         dismissed_at: row.dismissed_at,
@@ -288,10 +294,14 @@ export class EventMonitoringService {
         };
       }
 
+      // PII mask: data.new_error comes from api.retry_failed_event which returns the raw
+      // domain_events.processing_error column. Mask before logging or surfacing to UI.
+      const maskedNewError = maskPii(data.new_error);
+
       log.info('Event retry completed', {
         eventId,
         success: data.success,
-        newError: data.new_error,
+        newError: maskedNewError,
       });
 
       return {
@@ -299,7 +309,7 @@ export class EventMonitoringService {
         data: {
           success: data.success,
           event_id: data.event_id,
-          new_error: data.new_error,
+          new_error: maskedNewError || null,
           retried_at: data.retried_at,
         },
       };

--- a/frontend/src/services/api/envelope.test.ts
+++ b/frontend/src/services/api/envelope.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest';
+import type { PostgrestError, PostgrestSingleResponse } from '@supabase/supabase-js';
+import { unwrapApiEnvelope, maskPostgrestError } from './envelope';
+
+function pgError(overrides: Partial<PostgrestError> = {}): PostgrestError {
+  return {
+    name: 'PostgrestError',
+    code: '42501',
+    message: 'permission denied',
+    details: '',
+    hint: '',
+    ...overrides,
+  } as PostgrestError;
+}
+
+function rpcResult<T>(
+  data: T | null,
+  error: PostgrestError | null = null
+): PostgrestSingleResponse<T> {
+  return {
+    data,
+    error,
+    count: null,
+    status: error ? 401 : 200,
+    statusText: error ? 'Unauthorized' : 'OK',
+  } as PostgrestSingleResponse<T>;
+}
+
+describe('maskPostgrestError', () => {
+  it('masks message + details + hint', () => {
+    const err = pgError({
+      message: 'duplicate key - Key (email)=(a@b.com) already exists',
+      details: 'conflict on row 550e8400-e29b-41d4-a716-446655440000',
+      hint: 'try x@y.com instead',
+    });
+    const out = maskPostgrestError(err);
+    expect(out.message).toContain('Key (email)=(<redacted>)');
+    expect(out.message).not.toContain('a@b.com');
+    expect(out.details).toContain('<uuid>');
+    expect(out.details).not.toContain('550e8400');
+    expect(out.hint).toContain('<email>');
+    expect(out.hint).not.toContain('x@y.com');
+    expect(out.code).toBe('42501');
+  });
+
+  it('preserves undefined for empty details/hint', () => {
+    const err = pgError({ message: 'plain', details: '', hint: '' });
+    const out = maskPostgrestError(err);
+    expect(out.details).toBeUndefined();
+    expect(out.hint).toBeUndefined();
+  });
+});
+
+describe('unwrapApiEnvelope', () => {
+  describe('PostgREST error path', () => {
+    it('returns ApiEnvelopeFailure with masked postgrestError', () => {
+      const env = unwrapApiEnvelope(
+        rpcResult(
+          null,
+          pgError({ message: 'denied for user 550e8400-e29b-41d4-a716-446655440000' })
+        )
+      );
+      expect(env.success).toBe(false);
+      if (!env.success) {
+        expect(env.error).toContain('<uuid>');
+        expect(env.error).not.toContain('550e8400');
+        expect(env.postgrestError?.code).toBe('42501');
+        expect(env.postgrestError?.message).toContain('<uuid>');
+      }
+    });
+
+    it('masks all three string fields on PostgrestError', () => {
+      const env = unwrapApiEnvelope(
+        rpcResult(
+          null,
+          pgError({
+            message: 'Key (email)=(a@b.com) already exists',
+            details: 'row 550e8400-e29b-41d4-a716-446655440000',
+            hint: 'see x@y.com',
+          })
+        )
+      );
+      expect(env.success).toBe(false);
+      if (!env.success) {
+        expect(env.error).toContain('Key (email)=(<redacted>)');
+        expect(env.postgrestError?.details).toContain('<uuid>');
+        expect(env.postgrestError?.hint).toContain('<email>');
+      }
+    });
+  });
+
+  describe('Pattern A v2 envelope failure path', () => {
+    it('masks data.error string', () => {
+      const env = unwrapApiEnvelope(
+        rpcResult({
+          success: false,
+          error: 'Event processing failed: Key (email)=(other-user@acme.com) already exists',
+        })
+      );
+      expect(env.success).toBe(false);
+      if (!env.success) {
+        expect(env.error).toContain('Event processing failed: ');
+        expect(env.error).toContain('Key (email)=(<redacted>)');
+        expect(env.error).not.toContain('other-user@acme.com');
+        expect(env.postgrestError).toBeUndefined();
+      }
+    });
+
+    it('handles missing error string with fallback', () => {
+      const env = unwrapApiEnvelope(rpcResult({ success: false }));
+      expect(env.success).toBe(false);
+      if (!env.success) {
+        expect(env.error).toBe('Unknown error');
+      }
+    });
+  });
+
+  describe('success path (intersection-type spread)', () => {
+    it('spreads flat fields onto envelope', () => {
+      type Result = { user: { id: string; name: string }; event_id: string };
+      const env = unwrapApiEnvelope<Result>(
+        rpcResult({
+          success: true,
+          user: { id: 'u1', name: 'Alice' },
+          event_id: 'e1',
+        })
+      );
+      expect(env.success).toBe(true);
+      if (env.success) {
+        // Intersection-type contract: fields are flat on the envelope, not nested under .data
+        expect(env.user).toEqual({ id: 'u1', name: 'Alice' });
+        expect(env.event_id).toBe('e1');
+      }
+    });
+
+    it('handles success with no extra fields', () => {
+      const env = unwrapApiEnvelope(rpcResult({ success: true }));
+      expect(env.success).toBe(true);
+    });
+
+    it('handles null data as success (defensive default)', () => {
+      const env = unwrapApiEnvelope(rpcResult(null));
+      expect(env.success).toBe(true);
+    });
+  });
+
+  describe('masking-applied-once invariant', () => {
+    it('does not double-mask already-masked text', () => {
+      const env = unwrapApiEnvelope(
+        rpcResult({
+          success: false,
+          error: 'Key (email)=(<redacted>) already exists',
+        })
+      );
+      expect(env.success).toBe(false);
+      if (!env.success) {
+        expect(env.error).toBe('Key (email)=(<redacted>) already exists');
+      }
+    });
+  });
+});

--- a/frontend/src/services/api/envelope.ts
+++ b/frontend/src/services/api/envelope.ts
@@ -1,0 +1,90 @@
+import type { PostgrestError, PostgrestSingleResponse } from '@supabase/supabase-js';
+import { maskPii } from '@/utils/maskPii';
+
+/**
+ * Typed boundary for `api.*` RPC envelopes (Pattern A v2).
+ *
+ * `unwrapApiEnvelope<T>` is the only sanctioned way to read `error` off an
+ * `api.*` RPC envelope. It applies `maskPii` exactly once at the SDK boundary
+ * so consumers (services, ViewModels, log emissions) cannot accidentally
+ * surface raw PHI.
+ *
+ * Success-path shape is an INTERSECTION TYPE (`{success: true} & T`) — not a
+ * nested wrapper — because services in this repo already return flat shapes
+ * like `{success: true, role?: Role}`, `{success: true, invitation?: Invitation}`.
+ * See `documentation/architecture/decisions/adr-rpc-readback-pattern.md` and
+ * `frontend/src/services/CLAUDE.md` for the contract.
+ */
+
+export type ApiEnvelopeSuccess<T extends Record<string, unknown> = Record<string, never>> = {
+  success: true;
+} & T;
+
+export interface ApiEnvelopeFailure {
+  success: false;
+  error: string;
+  errorCode?: string;
+  postgrestError?: { code: string; message: string; details?: string; hint?: string };
+}
+
+export type ApiEnvelope<T extends Record<string, unknown> = Record<string, never>> =
+  | ApiEnvelopeSuccess<T>
+  | ApiEnvelopeFailure;
+
+/**
+ * Mask all PII-bearing string fields on a PostgrestError.
+ * Returns a NEW object (does not mutate the input).
+ */
+export function maskPostgrestError(err: PostgrestError): {
+  code: string;
+  message: string;
+  details?: string;
+  hint?: string;
+} {
+  return {
+    code: err.code,
+    message: maskPii(err.message),
+    details: err.details ? maskPii(err.details) : undefined,
+    hint: err.hint ? maskPii(err.hint) : undefined,
+  };
+}
+
+/**
+ * Unwrap an `api.*` RPC result into a typed `ApiEnvelope<T>`.
+ *
+ * Precondition: `rpcResult` is a PostgrestSingleResponse from a Supabase RPC call.
+ * Postcondition: returns a discriminated `ApiEnvelope<T>`; `.error` and any
+ *   `postgrestError.{message,details,hint}` strings have been masked exactly once.
+ * Invariant: callers MUST consume the returned envelope; raw `rpcResult.error.*`
+ *   strings MUST NOT be read after this call.
+ *
+ * Three paths:
+ *   1. PostgREST-level error (e.g. 42501, 401) → mask `error.message`/`details`/`hint`
+ *      and surface as ApiEnvelopeFailure with `postgrestError`.
+ *   2. Envelope success=false (Pattern A v2 handler-driven failure) → mask
+ *      `data.error` and surface as ApiEnvelopeFailure.
+ *   3. Otherwise → spread `data` fields onto `{success: true}` (intersection-type
+ *      contract). For RPCs whose `data` is an array or scalar, the caller should
+ *      use `apiRpc<T>` instead of this helper.
+ */
+export function unwrapApiEnvelope<T extends Record<string, unknown> = Record<string, never>>(
+  rpcResult: PostgrestSingleResponse<unknown>
+): ApiEnvelope<T> {
+  if (rpcResult.error) {
+    const masked = maskPostgrestError(rpcResult.error);
+    return { success: false, error: masked.message, postgrestError: masked };
+  }
+
+  const data = rpcResult.data as { success?: boolean; error?: string } | null;
+
+  if (data && typeof data === 'object' && data.success === false) {
+    return { success: false, error: maskPii(data.error ?? 'Unknown error') };
+  }
+
+  // Success path: spread data fields onto envelope (intersection-type contract).
+  // Callers whose RPC returns arrays/scalars should use apiRpc<T> instead.
+  if (data && typeof data === 'object') {
+    return { success: true, ...(data as Record<string, unknown>) } as ApiEnvelopeSuccess<T>;
+  }
+  return { success: true } as ApiEnvelopeSuccess<T>;
+}

--- a/frontend/src/services/auth/supabase.service.ts
+++ b/frontend/src/services/auth/supabase.service.ts
@@ -91,19 +91,19 @@ class SupabaseService {
   /**
    * Execute an RPC call on the 'api' schema (read-shape: arrays, scalars, custom objects).
    *
-   * Centralizes schema selection and provides typed return values. Use this for
-   * `api.*` RPCs whose return shape is NOT the Pattern A v2 envelope. For
-   * envelope-shaped writes (`{success, error?, ...}`), use `apiRpcEnvelope<T>`
-   * instead — it returns a typed `ApiEnvelope<T>` with `error` already masked.
+   * ⚠️ **MUST NOT** be used for RPCs that return the Pattern A v2 envelope
+   *    (`{success: true, ...}` | `{success: false, error: string, ...}`).
+   *    Call `apiRpcEnvelope<T>` for those. `apiRpc` does NOT mask `data.error` —
+   *    masking caller-owned `T` would silently break the typed contract.
    *
-   * Failure-path masking: PostgrestError fields (`message`, `details`, `hint`) are
+   * Failure-path masking: PostgrestError fields (`message`, `details`, `hint`) ARE
    * masked at the SDK boundary so callers cannot accidentally surface raw PHI in
    * log lines or UI. The returned object preserves the PostgrestError shape; only
    * its string fields are replaced.
    *
    * @param functionName - Name of the RPC function (e.g., 'get_user_org_access')
    * @param params - Parameters to pass to the function
-   * @returns Promise with typed data or masked error
+   * @returns Promise with typed data or masked PostgrestError
    *
    * @example
    * ```typescript
@@ -112,6 +112,10 @@ class SupabaseService {
    *   { p_user_id: userId }
    * );
    * ```
+   *
+   * @see apiRpcEnvelope — for envelope-shaped writes (Pattern A v2)
+   * @see frontend/src/services/api/envelope.ts — unwrapApiEnvelope helper
+   * @see dev/active/migrate-services-to-api-rpc-envelope/ — bulk-migration follow-up
    */
   async apiRpc<T>(
     functionName: string,

--- a/frontend/src/services/auth/supabase.service.ts
+++ b/frontend/src/services/auth/supabase.service.ts
@@ -1,6 +1,7 @@
 import { SupabaseClient, PostgrestError } from '@supabase/supabase-js';
 import { supabase } from '@/lib/supabase';
 import { Logger } from '@/utils/logger';
+import { unwrapApiEnvelope, maskPostgrestError, type ApiEnvelope } from '@/services/api/envelope';
 
 const log = Logger.getLogger('api');
 
@@ -88,14 +89,21 @@ class SupabaseService {
   }
 
   /**
-   * Execute an RPC call on the 'api' schema.
+   * Execute an RPC call on the 'api' schema (read-shape: arrays, scalars, custom objects).
    *
-   * Centralizes schema selection and provides typed return values.
-   * Use this for all RPC functions defined in the 'api' schema.
+   * Centralizes schema selection and provides typed return values. Use this for
+   * `api.*` RPCs whose return shape is NOT the Pattern A v2 envelope. For
+   * envelope-shaped writes (`{success, error?, ...}`), use `apiRpcEnvelope<T>`
+   * instead — it returns a typed `ApiEnvelope<T>` with `error` already masked.
+   *
+   * Failure-path masking: PostgrestError fields (`message`, `details`, `hint`) are
+   * masked at the SDK boundary so callers cannot accidentally surface raw PHI in
+   * log lines or UI. The returned object preserves the PostgrestError shape; only
+   * its string fields are replaced.
    *
    * @param functionName - Name of the RPC function (e.g., 'get_user_org_access')
    * @param params - Parameters to pass to the function
-   * @returns Promise with typed data or error
+   * @returns Promise with typed data or masked error
    *
    * @example
    * ```typescript
@@ -110,7 +118,49 @@ class SupabaseService {
     params: Record<string, unknown>
   ): Promise<{ data: T | null; error: PostgrestError | null }> {
     const apiClient = this.client as AnySchemaSupabaseClient;
-    return apiClient.schema('api').rpc(functionName, params);
+    const result = await apiClient.schema('api').rpc(functionName, params);
+    if (result.error) {
+      const masked = maskPostgrestError(result.error);
+      return {
+        data: result.data as T | null,
+        error: { ...result.error, ...masked } as PostgrestError,
+      };
+    }
+    return result as { data: T | null; error: PostgrestError | null };
+  }
+
+  /**
+   * Execute a Pattern A v2 RPC and unwrap the envelope into a typed `ApiEnvelope<T>`.
+   *
+   * This is the ONLY sanctioned way to read `error` off an `api.*` RPC envelope.
+   * `unwrapApiEnvelope` applies `maskPii` exactly once at the SDK boundary so any
+   * downstream consumer (services, ViewModels, log emissions) can never accidentally
+   * surface raw PHI from `processing_error` or `PG_EXCEPTION_DETAIL`.
+   *
+   * Success-path shape is `{success: true} & T` — flat intersection — preserving the
+   * existing return-shape convention used by services in this repo.
+   *
+   * @param functionName - Name of the envelope-shaped RPC (e.g., 'update_user', 'create_role')
+   * @param params - Parameters to pass to the function
+   * @returns Promise with discriminated `ApiEnvelope<T>`
+   *
+   * @example
+   * ```typescript
+   * const env = await supabaseService.apiRpcEnvelope<{ user: User; event_id: string }>(
+   *   'update_user',
+   *   { p_user_id: id, p_email: email }
+   * );
+   * if (!env.success) return { success: false, error: env.error };
+   * return { success: true, user: env.user };  // flat intersection: env.user is typed
+   * ```
+   */
+  async apiRpcEnvelope<T extends Record<string, unknown> = Record<string, never>>(
+    functionName: string,
+    params: Record<string, unknown>
+  ): Promise<ApiEnvelope<T>> {
+    const apiClient = this.client as AnySchemaSupabaseClient;
+    const result = await apiClient.schema('api').rpc(functionName, params);
+    return unwrapApiEnvelope<T>(result);
   }
 }
 

--- a/frontend/src/types/database.types.ts
+++ b/frontend/src/types/database.types.ts
@@ -578,6 +578,10 @@ export type Database = {
               stream_version: number
             }[]
           }
+      get_failed_events_with_detail: {
+        Args: { p_limit?: number; p_offset?: number }
+        Returns: Json
+      }
       get_field_usage_count: { Args: { p_field_key: string }; Returns: Json }
       get_invitation_by_id: {
         Args: { p_invitation_id: string }
@@ -2947,6 +2951,7 @@ export type Database = {
           parent_span_id: string | null
           processed_at: string | null
           processing_error: string | null
+          processing_error_detail: string | null
           retry_count: number | null
           sequence_number: number
           session_id: string | null
@@ -2969,6 +2974,7 @@ export type Database = {
           parent_span_id?: string | null
           processed_at?: string | null
           processing_error?: string | null
+          processing_error_detail?: string | null
           retry_count?: number | null
           sequence_number?: number
           session_id?: string | null
@@ -2991,6 +2997,7 @@ export type Database = {
           parent_span_id?: string | null
           processed_at?: string | null
           processing_error?: string | null
+          processing_error_detail?: string | null
           retry_count?: number | null
           sequence_number?: number
           session_id?: string | null

--- a/frontend/src/utils/maskPii.test.ts
+++ b/frontend/src/utils/maskPii.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { maskPii } from './maskPii';
+
+describe('maskPii', () => {
+  describe('canonical PG_EXCEPTION_DETAIL shapes', () => {
+    it('masks Key (email)=(value) preserving column name', () => {
+      const input =
+        'Event processing failed: duplicate key value - Key (email)=(other-user@acme.com) already exists.';
+      const out = maskPii(input);
+      expect(out).toContain('Event processing failed: '); // prefix preserved
+      expect(out).toContain('Key (email)=(<redacted>)');
+      expect(out).not.toContain('other-user@acme.com');
+      expect(out).not.toContain('acme.com');
+    });
+
+    it('masks phone number in Key (phone)=(value)', () => {
+      const out = maskPii('Key (phone)=(+15551234567) already exists.');
+      expect(out).toBe('Key (phone)=(<redacted>) already exists.');
+      expect(out).not.toContain('5551234567');
+    });
+
+    it('masks multi-column key including names', () => {
+      const out = maskPii('Key (last_name, first_name)=(Smith, John) already exists.');
+      expect(out).toBe('Key (last_name, first_name)=(<redacted>) already exists.');
+      expect(out).not.toContain('Smith');
+      expect(out).not.toContain('John');
+    });
+
+    it('masks DOB+name composite key (HIPAA identifier collision)', () => {
+      const out = maskPii('Key (date_of_birth, last_name)=(1985-06-12, Smith) already exists.');
+      expect(out).toBe('Key (date_of_birth, last_name)=(<redacted>) already exists.');
+      expect(out).not.toContain('1985-06-12');
+      expect(out).not.toContain('Smith');
+    });
+
+    it('masks Failing row contains (...) shape', () => {
+      const input =
+        'DETAIL: Failing row contains (550e8400-e29b-41d4-a716-446655440000, john@x.com, John, Smith, 1985-06-12, null).';
+      const out = maskPii(input);
+      expect(out).toContain('Failing row contains (<redacted>)');
+      expect(out).not.toContain('john@x.com');
+      expect(out).not.toContain('Smith');
+      expect(out).not.toContain('1985-06-12');
+    });
+
+    it('masks UUID + email inside structural shape (single replacement wins)', () => {
+      const out = maskPii(
+        'Key (organization_id, email)=(550e8400-e29b-41d4-a716-446655440000, other@acme.com) already exists.'
+      );
+      // Structural strip subsumes inner UUID/email match.
+      expect(out).toBe('Key (organization_id, email)=(<redacted>) already exists.');
+      expect(out).not.toContain('550e8400');
+      expect(out).not.toContain('other@acme.com');
+    });
+  });
+
+  describe('free-form belt-and-braces', () => {
+    it('masks free-form UUID outside structural shape', () => {
+      const out = maskPii('User 550e8400-e29b-41d4-a716-446655440000 not found');
+      expect(out).toBe('User <uuid> not found');
+    });
+
+    it('masks free-form email outside structural shape', () => {
+      const out = maskPii('No invitation found for x@y.com');
+      expect(out).toBe('No invitation found for <email>');
+    });
+
+    it('masks UPPER-CASE UUID (case-insensitive)', () => {
+      const out = maskPii('User A1B2C3D4-E5F6-7890-ABCD-EF1234567890 not found');
+      expect(out).toBe('User <uuid> not found');
+    });
+
+    it('masks multiple UUIDs and emails in one string', () => {
+      const out = maskPii(
+        'Conflict between 550e8400-e29b-41d4-a716-446655440000 and a@b.com vs 660e8400-e29b-41d4-a716-446655440000 and c@d.com'
+      );
+      expect(out).toBe('Conflict between <uuid> and <email> vs <uuid> and <email>');
+    });
+  });
+
+  describe('non-PII passthrough', () => {
+    it('preserves non-PII text verbatim', () => {
+      const out = maskPii('duplicate key value violates unique constraint "users_email_key"');
+      expect(out).toBe('duplicate key value violates unique constraint "users_email_key"');
+    });
+
+    it('preserves the "Event processing failed: " prefix (ADR Decision 5 contract)', () => {
+      const out = maskPii('Event processing failed: handler raised exception');
+      expect(out).toContain('Event processing failed: ');
+      expect(out).toBe('Event processing failed: handler raised exception');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns empty string for null', () => {
+      expect(maskPii(null)).toBe('');
+    });
+
+    it('returns empty string for undefined', () => {
+      expect(maskPii(undefined)).toBe('');
+    });
+
+    it('returns empty string for empty string', () => {
+      expect(maskPii('')).toBe('');
+    });
+
+    it('is idempotent (already-masked input returns unchanged)', () => {
+      const masked = 'Key (email)=(<redacted>) and id=<uuid>';
+      expect(maskPii(masked)).toBe(masked);
+    });
+
+    it('idempotent on doubly-masked structural shape', () => {
+      const once = maskPii('Key (email)=(other-user@acme.com) already exists.');
+      const twice = maskPii(once);
+      expect(twice).toBe(once);
+    });
+  });
+});

--- a/frontend/src/utils/maskPii.ts
+++ b/frontend/src/utils/maskPii.ts
@@ -1,0 +1,30 @@
+/**
+ * PII masking for error strings surfaced to UI consumers.
+ *
+ * Defense-in-depth layer for HIPAA-relevant text returned by Pattern A v2 RPCs and
+ * PostgREST errors. The trigger persistence layer (process_domain_event) drops
+ * PG_EXCEPTION_DETAIL into a separate gated column; this utility is the SDK-boundary
+ * mask applied via unwrapApiEnvelope so any consumer that reads result.error sees
+ * structurally-redacted text.
+ *
+ * Strategy: structural strip on the canonical PG shapes (Key (col)=(value),
+ * Failing row contains (...)) preserves diagnostic value (column names) while
+ * erasing all values. UUID/email regex is a belt for free-form RAISE EXCEPTION
+ * text and PostgREST messages.
+ *
+ * Idempotent: passing already-masked text returns it unchanged.
+ */
+
+const PG_DETAIL_RE = /Key \(([^)]+)\)=\(([^)]+)\)/g;
+const FAILING_ROW_RE = /Failing row contains \(([^)]+)\)/g;
+const UUID_RE = /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
+const EMAIL_RE = /\b[\w.+-]+@[\w-]+\.[\w.-]+\b/g;
+
+export function maskPii(text: string | null | undefined): string {
+  if (!text) return '';
+  return text
+    .replace(PG_DETAIL_RE, 'Key ($1)=(<redacted>)')
+    .replace(FAILING_ROW_RE, 'Failing row contains (<redacted>)')
+    .replace(UUID_RE, '<uuid>')
+    .replace(EMAIL_RE, '<email>');
+}

--- a/infrastructure/supabase/handlers/trigger/process_domain_event.sql
+++ b/infrastructure/supabase/handlers/trigger/process_domain_event.sql
@@ -46,12 +46,17 @@ BEGIN
 
         NEW.processed_at = clock_timestamp();
         NEW.processing_error = NULL;
+        NEW.processing_error_detail = NULL;
 
     EXCEPTION
         WHEN OTHERS THEN
             GET STACKED DIAGNOSTICS v_error_msg = MESSAGE_TEXT, v_error_detail = PG_EXCEPTION_DETAIL;
+            -- RAISE WARNING preserves operator-debug visibility in PG logs.
             RAISE WARNING 'Event processing error for event %: % - %', NEW.id, v_error_msg, COALESCE(v_error_detail, '');
-            NEW.processing_error = v_error_msg || ' - ' || COALESCE(v_error_detail, '');
+            -- Persisted columns: MESSAGE_TEXT visible to platform.admin via api.get_failed_events;
+            -- PG_EXCEPTION_DETAIL gated behind platform.view_event_details via api.get_failed_events_with_detail.
+            NEW.processing_error = v_error_msg;
+            NEW.processing_error_detail = v_error_detail;
     END;
 
     RETURN NEW;

--- a/infrastructure/supabase/supabase/functions/_shared/__tests__/error-response.test.ts
+++ b/infrastructure/supabase/supabase/functions/_shared/__tests__/error-response.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for the masked HTTP response helpers (_shared/error-response.ts).
+ *
+ * Run with: deno test --allow-net _shared/__tests__/error-response.test.ts
+ *
+ * Covers the PII-masking patches at handleRpcError() and createInternalError() —
+ * both of which surface error.message into HTTP response body.details and were
+ * pre-mask the primary leak vector for Edge Functions.
+ */
+
+import { assertEquals, assertStringIncludes, assert } from 'https://deno.land/std@0.220.1/assert/mod.ts';
+
+import { handleRpcError, createInternalError } from '../error-response.ts';
+
+const corsHeaders = { 'Access-Control-Allow-Origin': '*' };
+
+async function readBody(res: Response): Promise<{ details?: string; error?: string }> {
+  return await res.json();
+}
+
+Deno.test('handleRpcError masks PG_EXCEPTION_DETAIL in details field', async () => {
+  const res = handleRpcError(
+    {
+      message: 'duplicate key value - Key (email)=(other@acme.com) already exists',
+    },
+    'corr-1',
+    corsHeaders,
+    'invite',
+  );
+  const body = await readBody(res);
+  assertStringIncludes(body.details ?? '', 'Key (email)=(<redacted>)');
+  assert(!(body.details ?? '').includes('other@acme.com'));
+});
+
+Deno.test('handleRpcError masks UUID in error string surfaced to UI', async () => {
+  const res = handleRpcError(
+    {
+      message: 'User 550e8400-e29b-41d4-a716-446655440000 not found',
+    },
+    'corr-2',
+    corsHeaders,
+    'lookup',
+  );
+  const body = await readBody(res);
+  // The 'Event processing failed:' prefix-detection short-circuits to a generic UI message;
+  // the un-prefixed input should preserve the operation prefix and mask the UUID in details.
+  assertStringIncludes(body.details ?? '', '<uuid>');
+  assert(!(body.details ?? '').includes('550e8400'));
+});
+
+Deno.test('handleRpcError preserves Event processing failed prefix', async () => {
+  const res = handleRpcError(
+    {
+      message: 'Event processing failed: handler raised',
+    },
+    'corr-3',
+    corsHeaders,
+  );
+  const body = await readBody(res);
+  // userMessage is replaced with friendly text when prefix matches; details still has masked input.
+  assertStringIncludes(body.details ?? '', 'Event processing failed: handler raised');
+});
+
+Deno.test('createInternalError masks UUID/email in details', async () => {
+  const res = createInternalError(
+    'corr-4',
+    corsHeaders,
+    'rpc failed for 550e8400-e29b-41d4-a716-446655440000 with email a@b.com',
+  );
+  const body = await readBody(res);
+  assertStringIncludes(body.details ?? '', '<uuid>');
+  assertStringIncludes(body.details ?? '', '<email>');
+  assert(!(body.details ?? '').includes('550e8400'));
+  assert(!(body.details ?? '').includes('a@b.com'));
+});
+
+Deno.test('createInternalError omits details when not provided', async () => {
+  const res = createInternalError('corr-5', corsHeaders);
+  const body = await readBody(res);
+  assertEquals(body.details, undefined);
+});

--- a/infrastructure/supabase/supabase/functions/_shared/__tests__/maskPii.test.ts
+++ b/infrastructure/supabase/supabase/functions/_shared/__tests__/maskPii.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Unit tests for the Edge Function PII masking utility (_shared/maskPii.ts).
+ *
+ * Run with: deno test --allow-net _shared/__tests__/maskPii.test.ts
+ *
+ * Mirrors frontend/src/utils/maskPii.test.ts coverage. Both consumer copies must
+ * stay byte-equivalent in the underlying utility — these tests guard regression
+ * in the Deno port specifically.
+ */
+
+import { assertEquals, assertStringIncludes, assert } from 'https://deno.land/std@0.220.1/assert/mod.ts';
+
+import { maskPii } from '../maskPii.ts';
+
+Deno.test('maskPii: canonical PG_EXCEPTION_DETAIL — Key (email)=(value)', () => {
+  const out = maskPii(
+    'Event processing failed: duplicate key value - Key (email)=(other-user@acme.com) already exists.',
+  );
+  assertStringIncludes(out, 'Event processing failed: ');
+  assertStringIncludes(out, 'Key (email)=(<redacted>)');
+  assert(!out.includes('other-user@acme.com'));
+  assert(!out.includes('acme.com'));
+});
+
+Deno.test('maskPii: phone PHI in Key (phone)=(value)', () => {
+  assertEquals(
+    maskPii('Key (phone)=(+15551234567) already exists.'),
+    'Key (phone)=(<redacted>) already exists.',
+  );
+});
+
+Deno.test('maskPii: multi-column key (last_name, first_name)', () => {
+  assertEquals(
+    maskPii('Key (last_name, first_name)=(Smith, John) already exists.'),
+    'Key (last_name, first_name)=(<redacted>) already exists.',
+  );
+});
+
+Deno.test('maskPii: DOB+name composite key (HIPAA identifier collision)', () => {
+  const out = maskPii('Key (date_of_birth, last_name)=(1985-06-12, Smith) already exists.');
+  assertEquals(out, 'Key (date_of_birth, last_name)=(<redacted>) already exists.');
+});
+
+Deno.test('maskPii: Failing row contains (...) shape', () => {
+  const out = maskPii(
+    'DETAIL: Failing row contains (550e8400-e29b-41d4-a716-446655440000, john@x.com, John, Smith, 1985-06-12, null).',
+  );
+  assertStringIncludes(out, 'Failing row contains (<redacted>)');
+  assert(!out.includes('john@x.com'));
+  assert(!out.includes('Smith'));
+});
+
+Deno.test('maskPii: structural strip subsumes inner UUID/email match', () => {
+  const out = maskPii(
+    'Key (organization_id, email)=(550e8400-e29b-41d4-a716-446655440000, other@acme.com) already exists.',
+  );
+  assertEquals(out, 'Key (organization_id, email)=(<redacted>) already exists.');
+});
+
+Deno.test('maskPii: free-form UUID outside structural shape', () => {
+  assertEquals(
+    maskPii('User 550e8400-e29b-41d4-a716-446655440000 not found'),
+    'User <uuid> not found',
+  );
+});
+
+Deno.test('maskPii: free-form email outside structural shape', () => {
+  assertEquals(maskPii('No invitation found for x@y.com'), 'No invitation found for <email>');
+});
+
+Deno.test('maskPii: case-insensitive UUID', () => {
+  assertEquals(
+    maskPii('User A1B2C3D4-E5F6-7890-ABCD-EF1234567890 not found'),
+    'User <uuid> not found',
+  );
+});
+
+Deno.test('maskPii: non-PII passthrough preserves verbatim', () => {
+  const text = 'duplicate key value violates unique constraint "users_email_key"';
+  assertEquals(maskPii(text), text);
+});
+
+Deno.test('maskPii: null / undefined / empty → empty string', () => {
+  assertEquals(maskPii(null), '');
+  assertEquals(maskPii(undefined), '');
+  assertEquals(maskPii(''), '');
+});
+
+Deno.test('maskPii: idempotent on already-masked text', () => {
+  const masked = 'Key (email)=(<redacted>) and id=<uuid>';
+  assertEquals(maskPii(masked), masked);
+});
+
+Deno.test('maskPii: idempotent on doubly-masked structural shape', () => {
+  const once = maskPii('Key (email)=(other-user@acme.com) already exists.');
+  assertEquals(maskPii(once), once);
+});

--- a/infrastructure/supabase/supabase/functions/_shared/error-response.ts
+++ b/infrastructure/supabase/supabase/functions/_shared/error-response.ts
@@ -27,6 +27,8 @@
  * @see documentation/infrastructure/guides/event-observability.md
  */
 
+import { maskPii } from './maskPii.ts';
+
 /**
  * Standard error response structure for all Edge Functions.
  * Compatible with frontend's extractEdgeFunctionError() pattern.
@@ -179,10 +181,11 @@ export function handleRpcError(
 
   return createErrorResponse(
     {
-      error: userMessage,
+      error: maskPii(userMessage),
       code,
       status,
-      details: rpcError.message,
+      // PII mask: rpcError.message can carry PG_EXCEPTION_DETAIL row data.
+      details: maskPii(rpcError.message),
       correlationId,
     },
     corsHeaders
@@ -283,7 +286,9 @@ export function createInternalError(
       code: ErrorCodes.INTERNAL_ERROR,
       status: 500,
       correlationId,
-      details,
+      // PII mask: details often originates from caught error.message which can carry
+      // PG_EXCEPTION_DETAIL or other identifiers.
+      details: details ? maskPii(details) : undefined,
     },
     corsHeaders
   );

--- a/infrastructure/supabase/supabase/functions/_shared/maskPii.ts
+++ b/infrastructure/supabase/supabase/functions/_shared/maskPii.ts
@@ -1,0 +1,27 @@
+/**
+ * PII masking for error strings echoed to HTTP response bodies from Edge Functions.
+ *
+ * Byte-equivalent Deno port of frontend/src/utils/maskPii.ts. Two consumer copies must
+ * stay in lockstep: any change to the regexes here must be mirrored in the frontend file
+ * and vice versa.
+ *
+ * Strategy: structural strip on canonical PG shapes (Key (col)=(value), Failing row
+ * contains (...)) preserves diagnostic value (column names) while erasing values.
+ * UUID/email regex is a belt for free-form RAISE EXCEPTION text and PostgREST messages.
+ *
+ * Idempotent: passing already-masked text returns it unchanged.
+ */
+
+const PG_DETAIL_RE = /Key \(([^)]+)\)=\(([^)]+)\)/g;
+const FAILING_ROW_RE = /Failing row contains \(([^)]+)\)/g;
+const UUID_RE = /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
+const EMAIL_RE = /\b[\w.+-]+@[\w-]+\.[\w.-]+\b/g;
+
+export function maskPii(text: string | null | undefined): string {
+  if (!text) return '';
+  return text
+    .replace(PG_DETAIL_RE, 'Key ($1)=(<redacted>)')
+    .replace(FAILING_ROW_RE, 'Failing row contains (<redacted>)')
+    .replace(UUID_RE, '<uuid>')
+    .replace(EMAIL_RE, '<email>');
+}

--- a/infrastructure/supabase/supabase/functions/invite-user/__tests__/email-error-mask.test.ts
+++ b/infrastructure/supabase/supabase/functions/invite-user/__tests__/email-error-mask.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for invite-user email error masking.
+ *
+ * Run with: deno test --allow-net invite-user/__tests__/email-error-mask.test.ts
+ *
+ * sendInvitationEmail bypasses the shared error-response chokepoint and constructs
+ * its own error string from the catch path. This test verifies the maskPii application
+ * at index.ts:382 (catch path) and the Resend errorData.message path at index.ts:369.
+ *
+ * Per-Edge-Function test pattern from PR #42.
+ */
+
+import { assert, assertEquals, assertStringIncludes } from 'https://deno.land/std@0.220.1/assert/mod.ts';
+
+import { sendInvitationEmail } from '../index.ts';
+
+const baseParams = {
+  email: 'recipient@example.com',
+  firstName: 'Alice',
+  lastName: 'Smith',
+  orgName: 'Acme Org',
+  token: 'tok-abc',
+  expiresAt: new Date('2026-12-31T23:59:59Z'),
+  frontendUrl: 'https://app.example.com',
+  baseDomain: 'example.com',
+};
+
+Deno.test('sendInvitationEmail: catch path masks UUID/email in error.message', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = () => {
+    throw new Error(
+      'connect ECONNREFUSED for user 550e8400-e29b-41d4-a716-446655440000 with email leaked@x.com',
+    );
+  };
+
+  try {
+    const result = await sendInvitationEmail('rsk_test_123', baseParams);
+    assertEquals(result.success, false);
+    assertStringIncludes(result.error ?? '', 'Failed to send email: ');
+    assertStringIncludes(result.error ?? '', '<uuid>');
+    assertStringIncludes(result.error ?? '', '<email>');
+    assert(!(result.error ?? '').includes('550e8400'));
+    assert(!(result.error ?? '').includes('leaked@x.com'));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test('sendInvitationEmail: Resend non-OK response masks errorData.message', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = () =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({
+          message: 'Validation error: invalid recipient leaked@x.com',
+        }),
+        { status: 422, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+  try {
+    const result = await sendInvitationEmail('rsk_test_123', baseParams);
+    assertEquals(result.success, false);
+    assertStringIncludes(result.error ?? '', 'Resend API error: 422');
+    assertStringIncludes(result.error ?? '', '<email>');
+    assert(!(result.error ?? '').includes('leaked@x.com'));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/infrastructure/supabase/supabase/functions/invite-user/index.ts
+++ b/infrastructure/supabase/supabase/functions/invite-user/index.ts
@@ -31,6 +31,7 @@ import {
   type TracingContext,
 } from '../_shared/tracing-context.ts';
 import { buildEventMetadata } from '../_shared/emit-event.ts';
+import { maskPii } from '../_shared/maskPii.ts';
 
 // Deployment version tracking
 const DEPLOY_VERSION = 'v17-revoke-extracted';
@@ -262,7 +263,7 @@ async function emitExpirationEvent(
 /**
  * Send invitation email via Resend API
  */
-async function sendInvitationEmail(
+export async function sendInvitationEmail(
   resendApiKey: string,
   params: {
     email: string;
@@ -366,7 +367,8 @@ If you didn't expect this invitation, you can safely ignore this email.
       const errorData = await response.json();
       return {
         success: false,
-        error: `Resend API error: ${response.status} - ${errorData.message || 'Unknown error'}`,
+        // PII mask: Resend errorData.message can echo recipient email back.
+        error: `Resend API error: ${response.status} - ${maskPii(errorData.message) || 'Unknown error'}`,
       };
     }
 
@@ -378,7 +380,8 @@ If you didn't expect this invitation, you can safely ignore this email.
   } catch (error) {
     return {
       success: false,
-      error: `Failed to send email: ${error.message}`,
+      // PII mask: error.message may carry email server response detail with email addresses.
+      error: `Failed to send email: ${maskPii(error.message)}`,
     };
   }
 }

--- a/infrastructure/supabase/supabase/migrations/20260430002824_strip_processing_error_detail_with_admin_rpc.sql
+++ b/infrastructure/supabase/supabase/migrations/20260430002824_strip_processing_error_detail_with_admin_rpc.sql
@@ -1,0 +1,769 @@
+-- Migration: PII sanitization for domain_events.processing_error
+--
+-- HIPAA-relevant fix. Pattern A v2 RPCs return processing_error to authenticated callers,
+-- and the dispatcher trigger today concatenates MESSAGE_TEXT || ' - ' || PG_EXCEPTION_DETAIL.
+-- PG_EXCEPTION_DETAIL carries row data (Key (col)=(value), Failing row contains (...)) which
+-- in this multi-tenant medication-management platform leaks cross-tenant PHI.
+--
+-- This migration:
+--   A. Adds processing_error_detail column for forensic recovery (PHI-bearing).
+--   B. Seeds permission platform.view_event_details to gate access.
+--   C. Creates api.get_failed_events_with_detail() RPC with permission gate (matches
+--      api.get_failed_events convention — RPC-level authorization).
+--   D. Updates process_domain_event() trigger to split MESSAGE_TEXT and PG_EXCEPTION_DETAIL
+--      into separate columns. processing_error gets MESSAGE_TEXT only (visible via existing
+--      api.get_failed_events to platform.admin holders); processing_error_detail gets the
+--      raw PG_EXCEPTION_DETAIL (gated by the new permission).
+--   E. Chunked historical backfill — moves concatenated detail from existing rows into the
+--      new gated column. LIMIT 1000 + FOR UPDATE SKIP LOCKED + 50ms sleep between batches
+--      keeps locks short on potentially large tables. RAISE WARNING in PG logs unchanged.
+--   F. Fixes 6 identifier-leaking RAISE EXCEPTION statements in handlers/RPCs:
+--        - api.bulk_assign_role (line 373 of baseline_v4)
+--        - api.sync_role_assignments (line 5582)
+--        - public.retry_failed_bootstrap (line 11579)
+--        - public.switch_organization (line 11737)
+--        - public.validate_role_scope_path_active (lines 12240 + 12254)
+--
+-- See documentation/architecture/decisions/adr-rpc-readback-pattern.md (PII handling section)
+-- and dev/active/rpc-error-pii-sanitization/ for the full design.
+
+-- =====================================================================================
+-- A. Add forensic detail column on domain_events
+-- =====================================================================================
+
+ALTER TABLE public.domain_events
+    ADD COLUMN IF NOT EXISTS processing_error_detail text;
+
+COMMENT ON COLUMN public.domain_events.processing_error_detail IS
+  'Raw PG_EXCEPTION_DETAIL captured at handler-failure time. PHI-bearing. Access only via api.get_failed_events_with_detail() gated on platform.view_event_details. Service role (workflows) bypasses RLS — direct table reads acceptable for server-side forensic queries.';
+
+-- =====================================================================================
+-- B. Permission seed via CQRS — emit permission.defined event.
+--    Pattern matches 20260406221739_client_permissions_seed.sql + 20260422052825 §1h.1.
+--    handle_permission_defined() populates permissions_projection.
+-- =====================================================================================
+
+DO $$ BEGIN
+    INSERT INTO public.domain_events (stream_id, stream_type, stream_version, event_type, event_data, event_metadata)
+    VALUES (
+        gen_random_uuid(), 'permission', 1, 'permission.defined',
+        '{"applet": "platform", "action": "view_event_details", "description": "View raw PG_EXCEPTION_DETAIL on failed events for forensic recovery (PHI-bearing)", "scope_type": "global", "requires_mfa": false}'::jsonb,
+        '{"user_id": "00000000-0000-0000-0000-000000000000", "reason": "Seed: gate forensic detail visibility on processing_error_detail column"}'::jsonb
+    );
+EXCEPTION WHEN unique_violation THEN NULL;
+END $$;
+
+-- =====================================================================================
+-- C. Permission-gated RPC for admin UI to fetch detail.
+--    Matches api.get_failed_events convention (RPC-level authorization, not column RLS).
+-- =====================================================================================
+
+CREATE OR REPLACE FUNCTION api.get_failed_events_with_detail(
+    p_limit integer DEFAULT 50,
+    p_offset integer DEFAULT 0
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY INVOKER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $$
+DECLARE
+    v_events jsonb;
+BEGIN
+    -- Permission gate. RAISE EXCEPTION here is permitted (RPC entry guard, not handler-driven).
+    IF NOT public.has_permission('platform.view_event_details') THEN
+        RAISE EXCEPTION 'Access denied'
+            USING ERRCODE = '42501';
+    END IF;
+
+    SELECT jsonb_agg(sub.e ORDER BY (sub.e->>'created_at') DESC)
+    INTO v_events
+    FROM (
+        SELECT jsonb_build_object(
+            'id', id,
+            'stream_id', stream_id,
+            'stream_type', stream_type,
+            'event_type', event_type,
+            'processing_error', processing_error,
+            'processing_error_detail', processing_error_detail,
+            'created_at', created_at
+        ) AS e
+        FROM public.domain_events
+        WHERE processing_error IS NOT NULL
+        ORDER BY created_at DESC
+        LIMIT p_limit OFFSET p_offset
+    ) sub;
+
+    RETURN jsonb_build_object(
+        'success', true,
+        'events', COALESCE(v_events, '[]'::jsonb)
+    );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION api.get_failed_events_with_detail(integer, integer) TO authenticated;
+
+COMMENT ON FUNCTION api.get_failed_events_with_detail(integer, integer) IS
+    'Admin RPC for failed-event forensic detail. Gated by platform.view_event_details. Returns processing_error AND raw PG_EXCEPTION_DETAIL captured at handler-failure time.';
+
+-- =====================================================================================
+-- D. Update process_domain_event() trigger: split MESSAGE_TEXT vs PG_EXCEPTION_DETAIL.
+--    Body identical to handlers/trigger/process_domain_event.sql except for the EXCEPTION
+--    block that now writes to two columns.
+-- =====================================================================================
+
+CREATE OR REPLACE FUNCTION public.process_domain_event()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $function$
+DECLARE
+    v_error_msg TEXT;
+    v_error_detail TEXT;
+BEGIN
+    -- Skip already-processed events (idempotency)
+    IF NEW.processed_at IS NOT NULL THEN
+        RETURN NEW;
+    END IF;
+
+    BEGIN
+        IF (NEW.event_type LIKE '%.linked' OR NEW.event_type LIKE '%.unlinked')
+           AND NEW.event_type NOT IN ('contact.user.linked', 'contact.user.unlinked') THEN
+            PERFORM process_junction_event(NEW);
+        ELSE
+            CASE NEW.stream_type
+                WHEN 'role'              THEN PERFORM process_rbac_event(NEW);
+                WHEN 'permission'        THEN PERFORM process_rbac_event(NEW);
+                WHEN 'user'              THEN PERFORM process_user_event(NEW);
+                WHEN 'organization'      THEN PERFORM process_organization_event(NEW);
+                WHEN 'organization_unit' THEN PERFORM process_organization_unit_event(NEW);
+                WHEN 'schedule'          THEN PERFORM process_schedule_event(NEW);
+                WHEN 'contact'           THEN PERFORM process_contact_event(NEW);
+                WHEN 'address'           THEN PERFORM process_address_event(NEW);
+                WHEN 'phone'             THEN PERFORM process_phone_event(NEW);
+                WHEN 'email'             THEN PERFORM process_email_event(NEW);
+                WHEN 'invitation'        THEN PERFORM process_invitation_event(NEW);
+                WHEN 'access_grant'      THEN PERFORM process_access_grant_event(NEW);
+                WHEN 'impersonation'            THEN PERFORM process_impersonation_event(NEW);
+                WHEN 'client_field_definition'  THEN PERFORM process_client_field_definition_event(NEW);
+                WHEN 'client_field_category'    THEN PERFORM process_client_field_category_event(NEW);
+                WHEN 'client'                   THEN PERFORM process_client_event(NEW);
+                -- Administrative stream_types — No projection needed
+                WHEN 'platform_admin'    THEN NULL;
+                WHEN 'workflow_queue'    THEN NULL;
+                WHEN 'test'              THEN NULL;
+                ELSE
+                    RAISE EXCEPTION 'Unknown stream_type "%" for event %', NEW.stream_type, NEW.id
+                        USING ERRCODE = 'P9002';
+            END CASE;
+        END IF;
+
+        NEW.processed_at = clock_timestamp();
+        NEW.processing_error = NULL;
+        NEW.processing_error_detail = NULL;
+
+    EXCEPTION
+        WHEN OTHERS THEN
+            GET STACKED DIAGNOSTICS v_error_msg = MESSAGE_TEXT, v_error_detail = PG_EXCEPTION_DETAIL;
+            -- RAISE WARNING preserves operator-debug visibility in PG logs.
+            RAISE WARNING 'Event processing error for event %: % - %', NEW.id, v_error_msg, COALESCE(v_error_detail, '');
+            -- Persisted columns: MESSAGE_TEXT visible to platform.admin via api.get_failed_events;
+            -- PG_EXCEPTION_DETAIL gated behind platform.view_event_details via api.get_failed_events_with_detail.
+            NEW.processing_error = v_error_msg;
+            NEW.processing_error_detail = v_error_detail;
+    END;
+
+    RETURN NEW;
+END;
+$function$;
+
+-- =====================================================================================
+-- E. Chunked historical backfill — moves leak-window detail into the gated column.
+--    Production-safe: LIMIT 1000 + FOR UPDATE SKIP LOCKED + 50ms inter-batch sleep.
+-- =====================================================================================
+
+DO $$
+DECLARE
+    v_total_rows bigint;
+    v_updated_rows bigint;
+    v_grand_total bigint := 0;
+    v_batch_size integer := 1000;
+BEGIN
+    SELECT count(*) INTO v_total_rows
+    FROM public.domain_events
+    WHERE processing_error LIKE '% - %' AND processing_error_detail IS NULL;
+
+    RAISE NOTICE 'Backfill: % candidate rows', v_total_rows;
+
+    IF v_total_rows = 0 THEN
+        RAISE NOTICE 'Backfill: no rows to process; skipping loop';
+        RETURN;
+    END IF;
+
+    LOOP
+        WITH batch AS (
+            SELECT id FROM public.domain_events
+            WHERE processing_error LIKE '% - %'
+              AND processing_error_detail IS NULL
+            LIMIT v_batch_size FOR UPDATE SKIP LOCKED
+        )
+        UPDATE public.domain_events de
+        SET processing_error_detail = substring(de.processing_error from ' - (.*)$'),
+            processing_error        = split_part(de.processing_error, ' - ', 1)
+        FROM batch
+        WHERE de.id = batch.id;
+
+        GET DIAGNOSTICS v_updated_rows = ROW_COUNT;
+        v_grand_total := v_grand_total + v_updated_rows;
+        EXIT WHEN v_updated_rows = 0;
+        PERFORM pg_sleep(0.05);  -- Yield between batches.
+    END LOOP;
+
+    RAISE NOTICE 'Backfill complete: % rows updated', v_grand_total;
+END;
+$$;
+
+-- =====================================================================================
+-- F.1. Fix api.bulk_assign_role — replace 'Role not found: %' with opaque code.
+-- =====================================================================================
+
+CREATE OR REPLACE FUNCTION "api"."bulk_assign_role"("p_role_id" "uuid", "p_user_ids" "uuid"[], "p_scope_path" "extensions"."ltree", "p_correlation_id" "uuid" DEFAULT "gen_random_uuid"(), "p_reason" "text" DEFAULT 'Bulk role assignment'::"text") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  v_user_scope extensions.ltree;
+  v_org_id UUID;
+  v_role_name TEXT;
+  v_user_id UUID;
+  v_user_index INT := 0;
+  v_total_users INT;
+  v_successful UUID[] := ARRAY[]::UUID[];
+  v_failed JSONB := '[]'::JSONB;
+  v_event_data JSONB;
+  v_event_metadata JSONB;
+  v_assigned_by UUID;
+BEGIN
+  v_assigned_by := auth.uid();
+
+  IF v_assigned_by IS NULL THEN
+    RAISE EXCEPTION 'Authentication required'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  v_user_scope := public.get_permission_scope('user.role_assign');
+
+  IF v_user_scope IS NULL THEN
+    RAISE EXCEPTION 'Missing permission: user.role_assign'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF NOT (v_user_scope @> p_scope_path) THEN
+    RAISE EXCEPTION 'Requested scope is outside your permission scope'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  SELECT r.name INTO v_role_name
+  FROM roles_projection r
+  WHERE r.id = p_role_id
+    AND r.deleted_at IS NULL;
+
+  IF v_role_name IS NULL THEN
+    -- PII-safe: identifier removed; opaque code preserves callsite behavior.
+    RAISE EXCEPTION 'Role not found'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  SELECT o.id INTO v_org_id
+  FROM organizations_projection o
+  WHERE o.path = subpath(p_scope_path, 0, 1)
+    AND o.deleted_at IS NULL;
+
+  IF v_org_id IS NULL THEN
+    RAISE EXCEPTION 'Organization not found for scope path'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  v_total_users := array_length(p_user_ids, 1);
+
+  IF v_total_users IS NULL OR v_total_users = 0 THEN
+    RETURN jsonb_build_object(
+      'successful', '[]'::JSONB,
+      'failed', '[]'::JSONB,
+      'totalRequested', 0,
+      'totalSucceeded', 0,
+      'totalFailed', 0,
+      'correlationId', p_correlation_id
+    );
+  END IF;
+
+  FOREACH v_user_id IN ARRAY p_user_ids LOOP
+    v_user_index := v_user_index + 1;
+
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1 FROM users u
+        WHERE u.id = v_user_id
+          AND u.current_organization_id = v_org_id
+          AND u.deleted_at IS NULL
+      ) THEN
+        RAISE EXCEPTION 'User not found or not in organization';
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT 1 FROM users u
+        WHERE u.id = v_user_id
+          AND u.is_active = true
+      ) THEN
+        RAISE EXCEPTION 'User is not active';
+      END IF;
+
+      IF EXISTS (
+        SELECT 1 FROM user_roles_projection ur
+        WHERE ur.user_id = v_user_id
+          AND ur.role_id = p_role_id
+          AND ur.scope_path = p_scope_path
+      ) THEN
+        RAISE EXCEPTION 'User already has this role at this scope';
+      END IF;
+
+      v_event_data := jsonb_build_object(
+        'role_id', p_role_id,
+        'role_name', v_role_name,
+        'org_id', v_org_id,
+        'scope_path', p_scope_path::TEXT,
+        'assigned_by', v_assigned_by
+      );
+
+      v_event_metadata := jsonb_build_object(
+        'timestamp', NOW()::TEXT,
+        'correlation_id', p_correlation_id,
+        'user_id', v_assigned_by::TEXT,
+        'reason', p_reason,
+        'source', 'api',
+        'tags', to_jsonb(ARRAY['bulk-assignment']::TEXT[]),
+        'bulk_operation', true,
+        'bulk_operation_id', p_correlation_id::TEXT,
+        'user_index', v_user_index,
+        'total_users', v_total_users
+      );
+
+      PERFORM api.emit_domain_event(
+        v_user_id,
+        'user',
+        'user.role.assigned',
+        v_event_data,
+        v_event_metadata
+      );
+
+      v_successful := array_append(v_successful, v_user_id);
+
+    EXCEPTION WHEN OTHERS THEN
+      v_failed := v_failed || jsonb_build_object(
+        'userId', v_user_id,
+        'reason', SQLERRM,
+        'sqlstate', SQLSTATE
+      );
+    END;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'successful', to_jsonb(v_successful),
+    'failed', v_failed,
+    'totalRequested', v_total_users,
+    'totalSucceeded', array_length(v_successful, 1),
+    'totalFailed', jsonb_array_length(v_failed),
+    'correlationId', p_correlation_id
+  );
+END;
+$$;
+
+-- =====================================================================================
+-- F.2. Fix api.sync_role_assignments — same RAISE EXCEPTION pattern as F.1.
+-- =====================================================================================
+
+CREATE OR REPLACE FUNCTION "api"."sync_role_assignments"("p_role_id" "uuid", "p_user_ids_to_add" "uuid"[], "p_user_ids_to_remove" "uuid"[], "p_scope_path" "extensions"."ltree", "p_correlation_id" "uuid" DEFAULT "gen_random_uuid"(), "p_reason" "text" DEFAULT 'Role assignment update'::"text") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  v_user_scope extensions.ltree;
+  v_org_id UUID;
+  v_role_name TEXT;
+  v_user_id UUID;
+  v_acting_user UUID;
+  v_event_data JSONB;
+  v_event_metadata JSONB;
+  v_added_successful UUID[] := ARRAY[]::UUID[];
+  v_added_failed JSONB := '[]'::JSONB;
+  v_removed_successful UUID[] := ARRAY[]::UUID[];
+  v_removed_failed JSONB := '[]'::JSONB;
+  v_total_operations INT;
+  v_current_index INT := 0;
+BEGIN
+  v_acting_user := auth.uid();
+
+  IF v_acting_user IS NULL THEN
+    RAISE EXCEPTION 'Authentication required'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  v_user_scope := public.get_permission_scope('user.role_assign');
+
+  IF v_user_scope IS NULL THEN
+    RAISE EXCEPTION 'Missing permission: user.role_assign'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF NOT (v_user_scope @> p_scope_path) THEN
+    RAISE EXCEPTION 'Requested scope is outside your permission scope'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  SELECT r.name INTO v_role_name
+  FROM roles_projection r
+  WHERE r.id = p_role_id
+    AND r.deleted_at IS NULL;
+
+  IF v_role_name IS NULL THEN
+    -- PII-safe: identifier removed; opaque code preserves callsite behavior.
+    RAISE EXCEPTION 'Role not found'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  SELECT o.id INTO v_org_id
+  FROM organizations_projection o
+  WHERE o.path = subpath(p_scope_path, 0, 1)
+    AND o.deleted_at IS NULL;
+
+  IF v_org_id IS NULL THEN
+    RAISE EXCEPTION 'Organization not found for scope path'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  v_total_operations := COALESCE(array_length(p_user_ids_to_add, 1), 0)
+                      + COALESCE(array_length(p_user_ids_to_remove, 1), 0);
+
+  IF v_total_operations = 0 THEN
+    RETURN jsonb_build_object(
+      'added', jsonb_build_object('successful', '[]'::JSONB, 'failed', '[]'::JSONB),
+      'removed', jsonb_build_object('successful', '[]'::JSONB, 'failed', '[]'::JSONB),
+      'correlationId', p_correlation_id
+    );
+  END IF;
+
+  IF p_user_ids_to_add IS NOT NULL THEN
+    FOREACH v_user_id IN ARRAY p_user_ids_to_add LOOP
+      v_current_index := v_current_index + 1;
+
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM users u
+          WHERE u.id = v_user_id
+            AND u.current_organization_id = v_org_id
+            AND u.deleted_at IS NULL
+        ) THEN
+          RAISE EXCEPTION 'User not found or not in organization';
+        END IF;
+
+        IF NOT EXISTS (
+          SELECT 1 FROM users u
+          WHERE u.id = v_user_id
+            AND u.is_active = true
+        ) THEN
+          RAISE EXCEPTION 'User is not active';
+        END IF;
+
+        IF EXISTS (
+          SELECT 1 FROM user_roles_projection ur
+          WHERE ur.user_id = v_user_id
+            AND ur.role_id = p_role_id
+            AND ur.scope_path = p_scope_path
+        ) THEN
+          RAISE EXCEPTION 'User already has this role at this scope';
+        END IF;
+
+        v_event_data := jsonb_build_object(
+          'role_id', p_role_id,
+          'role_name', v_role_name,
+          'org_id', v_org_id,
+          'scope_path', p_scope_path::TEXT,
+          'assigned_by', v_acting_user
+        );
+
+        v_event_metadata := jsonb_build_object(
+          'timestamp', NOW()::TEXT,
+          'correlation_id', p_correlation_id,
+          'user_id', v_acting_user::TEXT,
+          'reason', p_reason,
+          'source', 'api',
+          'tags', to_jsonb(ARRAY['role-management', 'assignment']::TEXT[]),
+          'bulk_operation', true,
+          'bulk_operation_id', p_correlation_id::TEXT,
+          'operation_index', v_current_index,
+          'total_operations', v_total_operations
+        );
+
+        PERFORM api.emit_domain_event(
+          v_user_id,
+          'user',
+          'user.role.assigned',
+          v_event_data,
+          v_event_metadata
+        );
+
+        v_added_successful := array_append(v_added_successful, v_user_id);
+
+      EXCEPTION WHEN OTHERS THEN
+        v_added_failed := v_added_failed || jsonb_build_object(
+          'userId', v_user_id,
+          'reason', SQLERRM,
+          'sqlstate', SQLSTATE
+        );
+      END;
+    END LOOP;
+  END IF;
+
+  IF p_user_ids_to_remove IS NOT NULL THEN
+    FOREACH v_user_id IN ARRAY p_user_ids_to_remove LOOP
+      v_current_index := v_current_index + 1;
+
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM users u
+          WHERE u.id = v_user_id
+            AND u.current_organization_id = v_org_id
+            AND u.deleted_at IS NULL
+        ) THEN
+          RAISE EXCEPTION 'User not found or not in organization';
+        END IF;
+
+        IF NOT EXISTS (
+          SELECT 1 FROM user_roles_projection ur
+          WHERE ur.user_id = v_user_id
+            AND ur.role_id = p_role_id
+            AND ur.scope_path = p_scope_path
+        ) THEN
+          RAISE EXCEPTION 'User does not have this role at this scope';
+        END IF;
+
+        v_event_data := jsonb_build_object(
+          'role_id', p_role_id,
+          'role_name', v_role_name,
+          'org_id', v_org_id,
+          'scope_path', p_scope_path::TEXT,
+          'removed_by', v_acting_user
+        );
+
+        v_event_metadata := jsonb_build_object(
+          'timestamp', NOW()::TEXT,
+          'correlation_id', p_correlation_id,
+          'user_id', v_acting_user::TEXT,
+          'reason', p_reason,
+          'source', 'api',
+          'tags', to_jsonb(ARRAY['role-management', 'removal']::TEXT[]),
+          'bulk_operation', true,
+          'bulk_operation_id', p_correlation_id::TEXT,
+          'operation_index', v_current_index,
+          'total_operations', v_total_operations
+        );
+
+        PERFORM api.emit_domain_event(
+          v_user_id,
+          'user',
+          'user.role.revoked',
+          v_event_data,
+          v_event_metadata
+        );
+
+        v_removed_successful := array_append(v_removed_successful, v_user_id);
+
+      EXCEPTION WHEN OTHERS THEN
+        v_removed_failed := v_removed_failed || jsonb_build_object(
+          'userId', v_user_id,
+          'reason', SQLERRM,
+          'sqlstate', SQLSTATE
+        );
+      END;
+    END LOOP;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'added', jsonb_build_object(
+      'successful', to_jsonb(v_added_successful),
+      'failed', v_added_failed
+    ),
+    'removed', jsonb_build_object(
+      'successful', to_jsonb(v_removed_successful),
+      'failed', v_removed_failed
+    ),
+    'correlationId', p_correlation_id
+  );
+END;
+$$;
+
+-- =====================================================================================
+-- F.3. Fix public.retry_failed_bootstrap — drop bootstrap_id from message.
+-- =====================================================================================
+
+CREATE OR REPLACE FUNCTION "public"."retry_failed_bootstrap"("p_bootstrap_id" "uuid", "p_user_id" "uuid") RETURNS "uuid"
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  v_failed_event RECORD;
+  v_new_bootstrap_id UUID;
+  v_organization_id UUID;
+BEGIN
+  SELECT * INTO v_failed_event
+  FROM domain_events
+  WHERE event_type = 'organization.bootstrap.failed'
+    AND event_data->>'bootstrap_id' = p_bootstrap_id::TEXT
+  ORDER BY created_at DESC
+  LIMIT 1;
+
+  IF NOT FOUND THEN
+    -- PII-safe: drop bootstrap_id from message (caller has it; opaque code suffices).
+    RAISE EXCEPTION 'Bootstrap failure event not found'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  v_new_bootstrap_id := gen_random_uuid();
+  v_organization_id := gen_random_uuid();
+
+  INSERT INTO domain_events (
+    stream_id, stream_type, stream_version, event_type, event_data, event_metadata, created_at
+  ) VALUES (
+    v_organization_id,
+    'organization',
+    1,
+    'organization.bootstrap.retry_requested',
+    jsonb_build_object(
+      'bootstrap_id', v_new_bootstrap_id,
+      'retry_of', p_bootstrap_id,
+      'organization_name', v_failed_event.event_data->>'organization_name',
+      'organization_type', v_failed_event.event_data->>'organization_type',
+      'admin_email', v_failed_event.event_data->>'admin_email'
+    ),
+    jsonb_build_object(
+      'user_id', p_user_id,
+      'organization_id', v_organization_id::TEXT,
+      'reason', format('Manual retry of failed bootstrap %s', p_bootstrap_id),
+      'original_bootstrap_id', p_bootstrap_id
+    ),
+    NOW()
+  );
+
+  RETURN v_new_bootstrap_id;
+END;
+$$;
+
+-- =====================================================================================
+-- F.4. Fix public.switch_organization — drop org_id from message + remove SQLERRM rewrap.
+-- =====================================================================================
+
+CREATE OR REPLACE FUNCTION "public"."switch_organization"("p_new_org_id" "uuid") RETURNS "jsonb"
+    LANGUAGE "plpgsql" SECURITY DEFINER
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  v_user_id uuid;
+  v_has_access boolean;
+BEGIN
+  v_user_id := auth.uid();
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated'
+      USING ERRCODE = '42501';
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.user_roles_projection ur
+    WHERE ur.user_id = v_user_id
+      AND (ur.organization_id = p_new_org_id OR ur.organization_id IS NULL)
+  ) INTO v_has_access;
+
+  IF NOT v_has_access THEN
+    -- PII-safe: drop org_id from message (caller knows what they asked for).
+    RAISE EXCEPTION 'Access denied'
+      USING ERRCODE = '42501';
+  END IF;
+
+  UPDATE public.users
+  SET current_organization_id = p_new_org_id,
+      updated_at = NOW()
+  WHERE id = v_user_id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'org_id', p_new_org_id,
+    'message', 'Organization context updated. Please refresh your session to get updated JWT claims.'
+  );
+
+-- Removed the catch-all "EXCEPTION WHEN OTHERS THEN RAISE EXCEPTION 'Failed ... %', SQLERRM"
+-- block. SQLERRM can carry handler-driven detail and rewrapping it loses the original ERRCODE.
+END;
+$$;
+
+-- =====================================================================================
+-- F.5. Fix public.validate_role_scope_path_active — both RAISE EXCEPTIONs (lines 12240 + 12254).
+-- =====================================================================================
+
+CREATE OR REPLACE FUNCTION "public"."validate_role_scope_path_active"() RETURNS "trigger"
+    LANGUAGE "plpgsql"
+    SET "search_path" TO 'public', 'extensions', 'pg_temp'
+    AS $$
+DECLARE
+  v_scope_path LTREE;
+  v_scope_depth INTEGER;
+  v_inactive_ancestor_path LTREE;
+  v_inactive_ancestor_name TEXT;
+BEGIN
+  v_scope_path := NEW.scope_path;
+
+  IF v_scope_path IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  v_scope_depth := nlevel(v_scope_path);
+
+  IF v_scope_depth <= 2 THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT ou.path, ou.name
+  INTO v_inactive_ancestor_path, v_inactive_ancestor_name
+  FROM organization_units_projection ou
+  WHERE v_scope_path <@ ou.path
+    AND ou.is_active = false
+    AND ou.deleted_at IS NULL
+  ORDER BY ou.depth DESC
+  LIMIT 1;
+
+  IF FOUND THEN
+    -- PII-safe: drop ancestor name and path from message (both can be facility identifiers).
+    RAISE EXCEPTION 'Cannot assign role to inactive organization unit scope (deactivated ancestor)'
+      USING ERRCODE = 'check_violation',
+            HINT = 'Reactivate the organization unit before assigning roles to it or its descendants.';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM organization_units_projection
+    WHERE path = v_scope_path
+      AND deleted_at IS NOT NULL
+  ) THEN
+    -- PII-safe: drop scope path from message.
+    RAISE EXCEPTION 'Cannot assign role to deleted organization unit scope'
+      USING ERRCODE = 'check_violation',
+            HINT = 'The organization unit has been deleted and cannot receive role assignments.';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- =====================================================================================
+-- End of migration. Verification queries (run separately):
+--   SELECT count(*) FROM domain_events WHERE processing_error_detail IS NOT NULL;
+--   SELECT api.get_failed_events_with_detail();  -- as authenticated user without permission → 42501
+-- =====================================================================================

--- a/workflows/src/types/database.types.ts
+++ b/workflows/src/types/database.types.ts
@@ -578,6 +578,10 @@ export type Database = {
               stream_version: number
             }[]
           }
+      get_failed_events_with_detail: {
+        Args: { p_limit?: number; p_offset?: number }
+        Returns: Json
+      }
       get_field_usage_count: { Args: { p_field_key: string }; Returns: Json }
       get_invitation_by_id: {
         Args: { p_invitation_id: string }
@@ -2947,6 +2951,7 @@ export type Database = {
           parent_span_id: string | null
           processed_at: string | null
           processing_error: string | null
+          processing_error_detail: string | null
           retry_count: number | null
           sequence_number: number
           session_id: string | null
@@ -2969,6 +2974,7 @@ export type Database = {
           parent_span_id?: string | null
           processed_at?: string | null
           processing_error?: string | null
+          processing_error_detail?: string | null
           retry_count?: number | null
           sequence_number?: number
           session_id?: string | null
@@ -2991,6 +2997,7 @@ export type Database = {
           parent_span_id?: string | null
           processed_at?: string | null
           processing_error?: string | null
+          processing_error_detail?: string | null
           retry_count?: number | null
           sequence_number?: number
           session_id?: string | null


### PR DESCRIPTION
## Summary

HIPAA-relevant fix. Pattern A v2 RPCs returned raw `processing_error` text concatenating `MESSAGE_TEXT || ' - ' || PG_EXCEPTION_DETAIL` to authenticated callers. `PG_EXCEPTION_DETAIL` carries row data (`Key (col)=(value)`, `Failing row contains (...)`) which leaked cross-tenant PHI — emails, phone numbers, names, DOBs, UUIDs — to any authenticated caller, even when RLS would otherwise block direct row reads.

Three-layer defense (architect-reviewed, Hybrid Option 6):

- **Persistence**: trigger writes `processing_error = MESSAGE_TEXT` only; raw `PG_EXCEPTION_DETAIL` preserved in NEW column `processing_error_detail` accessible only via permission-gated RPC `api.get_failed_events_with_detail()` (gated on new permission `platform.view_event_details`). Chunked backfill (LIMIT 1000 + FOR UPDATE SKIP LOCKED + 50ms sleep) moves leak-window detail from existing rows. RAISE WARNING in PG logs unchanged.
- **SDK boundary (frontend)**: typed `unwrapApiEnvelope<T>` helper at `frontend/src/services/api/envelope.ts` — only sanctioned way to read `error` from `api.*` envelope. Structural-strip masker (`Key (...)`, `Failing row contains (...)` + UUID/email belt). New `apiRpcEnvelope<T>` and augmented `apiRpc<T>` PostgrestError masking. EventMonitoringService row mapping + retry path masked.
- **Source-side prevention**: Rule 16 in `infrastructure-guidelines` SKILL.md — handler `RAISE EXCEPTION` strings MUST NOT interpolate identifiers. 6 baseline_v4 violations remediated across 5 functions (`api.bulk_assign_role`, `api.sync_role_assignments`, `public.retry_failed_bootstrap`, `public.switch_organization`, `public.validate_role_scope_path_active`).

Edge Functions: 7 functions routing through one shared chokepoint at `_shared/error-response.ts`. Three patches close the leak (handleRpcError L185, createInternalError L286, invite-user index L382+L369). New Deno `_shared/maskPii.ts` byte-equivalent to frontend utility. New CI workflow runs `deno test` on every PR touching `functions/`.

ADR Decision 5 amended: ViewModels MUST NOT extract identifiers from masked error suffix; use captured `event_id` for audit-log linking. Confirmed prefix-only consumer today: `UsersManagePage.tsx:601-607` (safe).

## Architect-reviewed via two passes

- Initial 6-option enumeration: agent `ad2e78383cd378c9f` (2026-04-23). Recommended Option 6.
- Plan-review pass: agent `a4d2a101a4e75858c` (2026-04-29). 13 findings; v3 plan amended to close all critical/high. v3 plan at `dev/active/rpc-error-pii-sanitization/` will be archived post-merge.

## Out of scope (filed as follow-up)

- Migrate ~70 direct `.schema('api').rpc(...)` callers across 8 services to `apiRpcEnvelope<T>`. Repo `--max-warnings 0` means the ESLint rule (`no-restricted-syntax`) lands together with the codemod.
- Admin UI consumer for `processing_error_detail` (column + RPC + permission ready; no UI yet).
- Permission implication `platform.admin → platform.view_event_details`.

## Production deploy state

- Migration `20260430002824` applied to linked project; backfill moved 2 historical rows.
- Both `frontend/` and `workflows/` `database.types.ts` regenerated (byte-identical, 5,926 lines each).
- 7 Edge Functions redeployed: accept-invitation v134, manage-user v75, organization-bootstrap v118, organization-delete v15, validate-invitation v109, workflow-status v112, invite-user v84.

## Test plan

- [x] Frontend Vitest: 17 maskPii cases + 10 envelope cases pass
- [x] Edge Function Deno tests: 13 maskPii + 5 error-response + 2 email-error-mask cases pass
- [x] Frontend `npm run typecheck` / `lint` / `build` green
- [x] Workflows `npm run typecheck` green
- [x] Migration applies with chunked backfill (2 rows moved)
- [x] All 7 affected Edge Functions ACTIVE post-deploy
- [ ] Manual: trigger duplicate-email assignment in UI → toast shows `Key (email)=(<redacted>)`
- [ ] Manual: `/admin/events` displays masked `processing_error` column
- [ ] Manual: forced retry-and-fail-again from FailedEventsPage shows masked `new_error`
- [ ] Manual: `SELECT api.get_failed_events_with_detail()` as user without `platform.view_event_details` → 42501

🤖 Generated with [Claude Code](https://claude.com/claude-code)