### PR TITLE
fix(rpc): api.update_role must be SECURITY DEFINER

### DIFF
--- a/infrastructure/supabase/supabase/migrations/20260506010451_fix_update_role_security_definer.sql
+++ b/infrastructure/supabase/supabase/migrations/20260506010451_fix_update_role_security_definer.sql
@@ -1,0 +1,230 @@
+-- =====================================================================
+-- Fix: api.update_role must run as SECURITY DEFINER
+-- =====================================================================
+--
+-- Bug: as of baseline_v4 (and through 2026-05-06), `api.update_role` is
+-- the ONLY api.* function that reads from `public.domain_events` while
+-- running as `SECURITY INVOKER`. The Pattern A v2 read-back at the end
+-- of the function body executes:
+--
+--   SELECT processing_error FROM domain_events
+--   WHERE id = ANY(v_event_ids) AND processing_error IS NOT NULL
+--   ORDER BY created_at DESC LIMIT 1;
+--
+-- The `authenticated` Postgres role has zero table-level grants on
+-- `public.domain_events` (only `postgres` does). Because `api.update_role`
+-- runs as the caller, the SELECT raises SQLSTATE 42501 ("permission
+-- denied for table domain_events"), which PostgREST surfaces as HTTP 403
+-- to the frontend. The user sees "Failed to update role / permission
+-- denied for table domain_events" and the entire edit-role flow is
+-- broken — no `role.updated`, `role.permission.granted`, or
+-- `role.permission.revoked` events fire.
+--
+-- This has been broken since at least 2026-04-08 (last successful
+-- `role.updated` event before the user's 2026-05-05/06 reproduction),
+-- but went unnoticed because role-edit is a low-frequency flow.
+--
+-- Discovery: surfaced 2026-05-06 by `johnltice@yahoo.com` (provider_admin
+-- at testorg-20260329) attempting to add permissions to the existing
+-- "South Valley Admin" role as setup for UAT scenario 4 of the
+-- modify_user_roles plan.
+--
+-- Convention check (run 2026-05-06):
+--   60 of 61 api.* functions that read from domain_events are
+--   SECURITY DEFINER. api.update_role is the lone INVOKER outlier.
+--
+-- Fix: change `api.update_role` to `SECURITY DEFINER`. Function body
+-- unchanged. The DEFINER (postgres role) has all table-level grants on
+-- domain_events and `rolbypassrls=true`, so the read-back's SELECT
+-- succeeds. The function still calls `auth.uid()` and reads
+-- `request.jwt.claims` for caller identity — those use session settings
+-- not the function's executing role, so SECURITY DEFINER does NOT defeat
+-- the per-caller permission/scope checks.
+--
+-- Idempotency: `CREATE OR REPLACE FUNCTION` preserves the function's
+-- OID. The existing `COMMENT ON FUNCTION` (carrying the
+-- `@a4c-rpc-shape: envelope` tag from PR #44's M3 backfill) is keyed to
+-- OID and therefore preserved automatically. Per Rule 17 of
+-- `.claude/skills/infrastructure-guidelines/SKILL.md`, the DROP+CREATE
+-- re-tag rule does NOT apply here because we are NOT changing the
+-- function signature — only the SECURITY mode. No COMMENT re-issue
+-- required.
+--
+-- See:
+--   - documentation/architecture/decisions/adr-rpc-readback-pattern.md
+--     §"Pattern A v2 — capture event_id + race-safe post-emit check"
+--   - infrastructure/supabase/CLAUDE.md § Critical Rules (Pattern A v2)
+-- =====================================================================
+
+CREATE OR REPLACE FUNCTION api.update_role(
+    p_role_id        uuid,
+    p_name           text DEFAULT NULL::text,
+    p_description    text DEFAULT NULL::text,
+    p_permission_ids uuid[] DEFAULT NULL::uuid[]
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $function$
+DECLARE
+    v_user_id uuid;
+    v_org_id uuid;
+    v_existing record;
+    v_current_perms uuid[];
+    v_new_perms uuid[];
+    v_to_grant uuid[];
+    v_to_revoke uuid[];
+    v_perm_id uuid;
+    v_user_perms uuid[];
+    v_perm_name text;
+    v_row record;
+    v_perm_ids_after uuid[];
+    v_processing_error text;
+    v_event_ids uuid[] := '{}';  -- M2: capture every emit's id for race-safe PK check
+BEGIN
+    v_user_id := public.get_current_user_id();
+    v_org_id := public.get_current_org_id();
+
+    -- Caller-driven validation (pre-emit) — unchanged
+    SELECT * INTO v_existing FROM roles_projection
+    WHERE id = p_role_id AND deleted_at IS NULL;
+
+    IF NOT FOUND THEN
+        RETURN jsonb_build_object(
+            'success', false,
+            'error', 'Role not found',
+            'errorDetails', jsonb_build_object('code', 'NOT_FOUND', 'message', 'Role not found or access denied')
+        );
+    END IF;
+
+    IF NOT v_existing.is_active THEN
+        RETURN jsonb_build_object(
+            'success', false,
+            'error', 'Cannot update inactive role',
+            'errorDetails', jsonb_build_object('code', 'INACTIVE_ROLE', 'message', 'Reactivate the role before making changes')
+        );
+    END IF;
+
+    -- Emit role.updated event if name or description changed
+    IF p_name IS NOT NULL OR p_description IS NOT NULL THEN
+        v_event_ids := array_append(v_event_ids, api.emit_domain_event(
+            p_stream_id := p_role_id,
+            p_stream_type := 'role',
+            p_event_type := 'role.updated',
+            p_event_data := jsonb_build_object(
+                'name', COALESCE(p_name, v_existing.name),
+                'description', COALESCE(p_description, v_existing.description)
+            ),
+            p_event_metadata := jsonb_build_object(
+                'user_id', v_user_id,
+                'organization_id', v_org_id,
+                'reason', 'Role metadata update via Role Management UI'
+            )
+        ));
+    END IF;
+
+    -- Handle permission changes
+    IF p_permission_ids IS NOT NULL THEN
+        SELECT array_agg(permission_id) INTO v_current_perms
+        FROM role_permissions_projection WHERE role_id = p_role_id;
+        v_current_perms := COALESCE(v_current_perms, '{}');
+        v_new_perms := p_permission_ids;
+
+        v_user_perms := public.get_user_aggregated_permissions(v_user_id);
+
+        v_to_grant := ARRAY(SELECT unnest(v_new_perms) EXCEPT SELECT unnest(v_current_perms));
+
+        IF NOT public.check_permissions_subset(v_to_grant, v_user_perms) THEN
+            FOREACH v_perm_id IN ARRAY v_to_grant
+            LOOP
+                IF NOT (v_perm_id = ANY(v_user_perms)) THEN
+                    SELECT name INTO v_perm_name FROM permissions_projection WHERE id = v_perm_id;
+                    RETURN jsonb_build_object(
+                        'success', false,
+                        'error', 'Cannot grant permission you do not possess',
+                        'errorDetails', jsonb_build_object(
+                            'code', 'SUBSET_ONLY_VIOLATION',
+                            'message', format('Permission %s is not in your granted set', COALESCE(v_perm_name, v_perm_id::text))
+                        )
+                    );
+                END IF;
+            END LOOP;
+        END IF;
+
+        v_to_revoke := ARRAY(SELECT unnest(v_current_perms) EXCEPT SELECT unnest(v_new_perms));
+
+        FOREACH v_perm_id IN ARRAY v_to_grant
+        LOOP
+            SELECT name INTO v_perm_name FROM permissions_projection WHERE id = v_perm_id;
+            v_event_ids := array_append(v_event_ids, api.emit_domain_event(
+                p_stream_id := p_role_id,
+                p_stream_type := 'role',
+                p_event_type := 'role.permission.granted',
+                p_event_data := jsonb_build_object(
+                    'permission_id', v_perm_id,
+                    'permission_name', v_perm_name
+                ),
+                p_event_metadata := jsonb_build_object(
+                    'user_id', v_user_id,
+                    'organization_id', v_org_id,
+                    'reason', 'Permission added via Role Management UI'
+                )
+            ));
+        END LOOP;
+
+        FOREACH v_perm_id IN ARRAY v_to_revoke
+        LOOP
+            SELECT name INTO v_perm_name FROM permissions_projection WHERE id = v_perm_id;
+            v_event_ids := array_append(v_event_ids, api.emit_domain_event(
+                p_stream_id := p_role_id,
+                p_stream_type := 'role',
+                p_event_type := 'role.permission.revoked',
+                p_event_data := jsonb_build_object(
+                    'permission_id', v_perm_id,
+                    'permission_name', v_perm_name,
+                    'revocation_reason', 'Permission removed via Role Management UI'
+                ),
+                p_event_metadata := jsonb_build_object(
+                    'user_id', v_user_id,
+                    'organization_id', v_org_id,
+                    'reason', 'Permission removed via Role Management UI'
+                )
+            ));
+        END LOOP;
+    END IF;
+
+    -- Pattern A COMPLEX-CASE read-back: compose role row + permission_ids array
+    SELECT * INTO v_row FROM roles_projection WHERE id = p_role_id AND deleted_at IS NULL;
+
+    IF NOT FOUND THEN
+        -- M2 fix: race-safe — lookup failure among THIS RPC's emitted events only
+        SELECT processing_error INTO v_processing_error
+        FROM domain_events
+        WHERE id = ANY(v_event_ids) AND processing_error IS NOT NULL
+        ORDER BY created_at DESC LIMIT 1;
+        RETURN jsonb_build_object('success', false,
+            'error', 'Event processing failed: ' || COALESCE(v_processing_error, 'unknown'));
+    END IF;
+
+    SELECT array_agg(permission_id ORDER BY permission_id) INTO v_perm_ids_after
+    FROM role_permissions_projection WHERE role_id = p_role_id;
+    v_perm_ids_after := COALESCE(v_perm_ids_after, '{}');
+
+    -- M2 fix: replaces 5-second-window with captured-ID PK scan.
+    -- Empty v_event_ids (no-op update) → no rows → v_processing_error IS NULL → success.
+    SELECT processing_error INTO v_processing_error
+    FROM domain_events
+    WHERE id = ANY(v_event_ids) AND processing_error IS NOT NULL
+    ORDER BY created_at DESC LIMIT 1;
+
+    RETURN jsonb_build_object(
+        'success', v_processing_error IS NULL,
+        'role', row_to_json(v_row)::jsonb,
+        'permission_ids', to_jsonb(v_perm_ids_after),
+        'error', CASE WHEN v_processing_error IS NOT NULL
+                      THEN 'Event processing failed: ' || v_processing_error
+                      ELSE NULL END
+    );
+END;
+$function$;

--- a/infrastructure/supabase/supabase/migrations/20260506011954_add_update_role_tenancy_guard.sql
+++ b/infrastructure/supabase/supabase/migrations/20260506011954_add_update_role_tenancy_guard.sql
@@ -1,0 +1,247 @@
+-- =====================================================================
+-- Add in-body tenancy guard to api.update_role
+-- =====================================================================
+--
+-- Follow-up to migration 20260506010451 (SECURITY INVOKER → DEFINER).
+-- Architectural review (software-architect-dbc, 2026-05-06) identified
+-- a residual cross-tenant exposure that the DEFINER flip introduced:
+--
+--   Pre-fix (INVOKER), the initial `SELECT * FROM roles_projection WHERE
+--   id = p_role_id` was constrained by RLS:
+--     - roles_global_select: organization_id IS NULL AND auth user
+--     - roles_org_admin_select: organization_id IS NOT NULL AND
+--         has_org_admin_permission() AND organization_id = current_org
+--   A caller passing a foreign-tenant role id received zero rows and
+--   the function returned 'Role not found'.
+--
+--   Post-fix (DEFINER, BYPASSRLS=true on postgres owner), that SELECT
+--   returns rows from any tenant. The subset-only delegation guard
+--   (`check_permissions_subset`) prevents a malicious caller from
+--   GRANTING permissions cross-tenant, but does NOT prevent revoking
+--   permissions from a foreign-tenant role (revocation isn't
+--   subset-checked). It also lets cross-tenant updates emit events
+--   carrying the caller's `organization_id` in metadata while the
+--   stream_id belongs to a different tenant — provenance/audit
+--   poisoning.
+--
+-- This migration restores the prior security envelope by adding an
+-- in-body tenancy guard that mirrors the RLS policies it replaced.
+-- The guard returns the same `'Role not found'` envelope as the
+-- existing not-found branch, so the not-found-vs-cross-tenant
+-- distinction remains opaque to callers (matches the canonical pattern
+-- used by other tenancy-guarded RPCs — see PR #40 precedent and
+-- `infrastructure/supabase/CLAUDE.md` § Critical Rules).
+--
+-- Function body is otherwise UNCHANGED from migration 20260506010451.
+-- The CREATE OR REPLACE preserves the OID and therefore preserves
+-- the `@a4c-rpc-shape: envelope` COMMENT (Rule 17 of SKILL.md).
+--
+-- Tenancy semantics:
+--   - Platform admin (`has_platform_privilege()`): unrestricted (matches
+--     `roles_projection.platform_admin_all` policy).
+--   - Org-scoped role (organization_id IS NOT NULL): caller must be
+--     same-tenant AND have org-admin permission.
+--   - Global role (organization_id IS NULL): not gated here. Pre-fix
+--     RLS allowed any authenticated user to SELECT global role
+--     templates; the subset-only delegation guard further constrains
+--     what permissions can be granted on them.
+--
+-- See:
+--   - Architect review: PR #47 software-architect-dbc, 2026-05-06
+--   - documentation/architecture/decisions/adr-rpc-readback-pattern.md
+--     §"Pattern A v2 — capture event_id + race-safe post-emit check"
+--   - infrastructure/supabase/CLAUDE.md § Critical Rules (tenancy guard)
+-- =====================================================================
+
+CREATE OR REPLACE FUNCTION api.update_role(
+    p_role_id        uuid,
+    p_name           text DEFAULT NULL::text,
+    p_description    text DEFAULT NULL::text,
+    p_permission_ids uuid[] DEFAULT NULL::uuid[]
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $function$
+DECLARE
+    v_user_id uuid;
+    v_org_id uuid;
+    v_existing record;
+    v_current_perms uuid[];
+    v_new_perms uuid[];
+    v_to_grant uuid[];
+    v_to_revoke uuid[];
+    v_perm_id uuid;
+    v_user_perms uuid[];
+    v_perm_name text;
+    v_row record;
+    v_perm_ids_after uuid[];
+    v_processing_error text;
+    v_event_ids uuid[] := '{}';  -- M2: capture every emit's id for race-safe PK check
+BEGIN
+    v_user_id := public.get_current_user_id();
+    v_org_id := public.get_current_org_id();
+
+    -- Caller-driven validation (pre-emit) — unchanged
+    SELECT * INTO v_existing FROM roles_projection
+    WHERE id = p_role_id AND deleted_at IS NULL;
+
+    IF NOT FOUND THEN
+        RETURN jsonb_build_object(
+            'success', false,
+            'error', 'Role not found',
+            'errorDetails', jsonb_build_object('code', 'NOT_FOUND', 'message', 'Role not found or access denied')
+        );
+    END IF;
+
+    -- Tenancy guard (compensates for RLS bypass under SECURITY DEFINER).
+    -- Mirrors roles_projection RLS: platform_admin_all OR
+    --   (organization_id IS NULL AND auth) OR
+    --   (organization_id IS NOT NULL AND has_org_admin_permission() AND
+    --    organization_id = get_current_org_id()).
+    -- Returns the same 'Role not found' envelope to keep
+    -- not-found-vs-cross-tenant indistinguishable.
+    IF NOT public.has_platform_privilege() THEN
+        IF v_existing.organization_id IS NOT NULL THEN
+            IF v_existing.organization_id IS DISTINCT FROM v_org_id
+               OR NOT public.has_org_admin_permission() THEN
+                RETURN jsonb_build_object(
+                    'success', false,
+                    'error', 'Role not found',
+                    'errorDetails', jsonb_build_object('code', 'NOT_FOUND', 'message', 'Role not found or access denied')
+                );
+            END IF;
+        END IF;
+    END IF;
+
+    IF NOT v_existing.is_active THEN
+        RETURN jsonb_build_object(
+            'success', false,
+            'error', 'Cannot update inactive role',
+            'errorDetails', jsonb_build_object('code', 'INACTIVE_ROLE', 'message', 'Reactivate the role before making changes')
+        );
+    END IF;
+
+    -- Emit role.updated event if name or description changed
+    IF p_name IS NOT NULL OR p_description IS NOT NULL THEN
+        v_event_ids := array_append(v_event_ids, api.emit_domain_event(
+            p_stream_id := p_role_id,
+            p_stream_type := 'role',
+            p_event_type := 'role.updated',
+            p_event_data := jsonb_build_object(
+                'name', COALESCE(p_name, v_existing.name),
+                'description', COALESCE(p_description, v_existing.description)
+            ),
+            p_event_metadata := jsonb_build_object(
+                'user_id', v_user_id,
+                'organization_id', v_org_id,
+                'reason', 'Role metadata update via Role Management UI'
+            )
+        ));
+    END IF;
+
+    -- Handle permission changes
+    IF p_permission_ids IS NOT NULL THEN
+        SELECT array_agg(permission_id) INTO v_current_perms
+        FROM role_permissions_projection WHERE role_id = p_role_id;
+        v_current_perms := COALESCE(v_current_perms, '{}');
+        v_new_perms := p_permission_ids;
+
+        v_user_perms := public.get_user_aggregated_permissions(v_user_id);
+
+        v_to_grant := ARRAY(SELECT unnest(v_new_perms) EXCEPT SELECT unnest(v_current_perms));
+
+        IF NOT public.check_permissions_subset(v_to_grant, v_user_perms) THEN
+            FOREACH v_perm_id IN ARRAY v_to_grant
+            LOOP
+                IF NOT (v_perm_id = ANY(v_user_perms)) THEN
+                    SELECT name INTO v_perm_name FROM permissions_projection WHERE id = v_perm_id;
+                    RETURN jsonb_build_object(
+                        'success', false,
+                        'error', 'Cannot grant permission you do not possess',
+                        'errorDetails', jsonb_build_object(
+                            'code', 'SUBSET_ONLY_VIOLATION',
+                            'message', format('Permission %s is not in your granted set', COALESCE(v_perm_name, v_perm_id::text))
+                        )
+                    );
+                END IF;
+            END LOOP;
+        END IF;
+
+        v_to_revoke := ARRAY(SELECT unnest(v_current_perms) EXCEPT SELECT unnest(v_new_perms));
+
+        FOREACH v_perm_id IN ARRAY v_to_grant
+        LOOP
+            SELECT name INTO v_perm_name FROM permissions_projection WHERE id = v_perm_id;
+            v_event_ids := array_append(v_event_ids, api.emit_domain_event(
+                p_stream_id := p_role_id,
+                p_stream_type := 'role',
+                p_event_type := 'role.permission.granted',
+                p_event_data := jsonb_build_object(
+                    'permission_id', v_perm_id,
+                    'permission_name', v_perm_name
+                ),
+                p_event_metadata := jsonb_build_object(
+                    'user_id', v_user_id,
+                    'organization_id', v_org_id,
+                    'reason', 'Permission added via Role Management UI'
+                )
+            ));
+        END LOOP;
+
+        FOREACH v_perm_id IN ARRAY v_to_revoke
+        LOOP
+            SELECT name INTO v_perm_name FROM permissions_projection WHERE id = v_perm_id;
+            v_event_ids := array_append(v_event_ids, api.emit_domain_event(
+                p_stream_id := p_role_id,
+                p_stream_type := 'role',
+                p_event_type := 'role.permission.revoked',
+                p_event_data := jsonb_build_object(
+                    'permission_id', v_perm_id,
+                    'permission_name', v_perm_name,
+                    'revocation_reason', 'Permission removed via Role Management UI'
+                ),
+                p_event_metadata := jsonb_build_object(
+                    'user_id', v_user_id,
+                    'organization_id', v_org_id,
+                    'reason', 'Permission removed via Role Management UI'
+                )
+            ));
+        END LOOP;
+    END IF;
+
+    -- Pattern A COMPLEX-CASE read-back: compose role row + permission_ids array
+    SELECT * INTO v_row FROM roles_projection WHERE id = p_role_id AND deleted_at IS NULL;
+
+    IF NOT FOUND THEN
+        -- M2 fix: race-safe — lookup failure among THIS RPC's emitted events only
+        SELECT processing_error INTO v_processing_error
+        FROM domain_events
+        WHERE id = ANY(v_event_ids) AND processing_error IS NOT NULL
+        ORDER BY created_at DESC LIMIT 1;
+        RETURN jsonb_build_object('success', false,
+            'error', 'Event processing failed: ' || COALESCE(v_processing_error, 'unknown'));
+    END IF;
+
+    SELECT array_agg(permission_id ORDER BY permission_id) INTO v_perm_ids_after
+    FROM role_permissions_projection WHERE role_id = p_role_id;
+    v_perm_ids_after := COALESCE(v_perm_ids_after, '{}');
+
+    -- M2 fix: replaces 5-second-window with captured-ID PK scan.
+    -- Empty v_event_ids (no-op update) → no rows → v_processing_error IS NULL → success.
+    SELECT processing_error INTO v_processing_error
+    FROM domain_events
+    WHERE id = ANY(v_event_ids) AND processing_error IS NOT NULL
+    ORDER BY created_at DESC LIMIT 1;
+
+    RETURN jsonb_build_object(
+        'success', v_processing_error IS NULL,
+        'role', row_to_json(v_row)::jsonb,
+        'permission_ids', to_jsonb(v_perm_ids_after),
+        'error', CASE WHEN v_processing_error IS NOT NULL
+                      THEN 'Event processing failed: ' || v_processing_error
+                      ELSE NULL END
+    );
+END;
+$function$;


### PR DESCRIPTION
## TL;DR

`api.update_role` was the **lone `SECURITY INVOKER` outlier** among 61 `api.*` functions that read from `domain_events`. The `authenticated` role has zero table-level grants on `domain_events` (only `postgres` does), so the function's Pattern A v2 read-back SELECT failed with `42501: permission denied for table domain_events` → PostgREST 403. **Every role-edit save has been broken since at least 2026-04-08.**

This PR has **two commits**:

| Commit | What |
|---|---|
| `3334c2d3` | `SECURITY INVOKER` → `SECURITY DEFINER` (closes the 403) |
| `57d598b4` | In-body tenancy guard (closes the cross-tenant revoke vector that DEFINER opened) |

The second commit was added in response to the [architect review](https://github.com/Analytics4Change/A4C-AppSuite/pull/47#issuecomment-4384420229) (software-architect-dbc, 2026-05-06).

## Discovery

Surfaced 2026-05-06 by reporter `johnltice@yahoo.com` (`provider_admin` at `testorg-20260329`) attempting to add permissions to the existing "South Valley Admin" role as setup for UAT scenario 4 of the modify_user_roles plan. Frontend showed _"Failed to update role / permission denied for table domain_events"_ with HTTP 403 in DevTools Network tab.

DB confirmed: zero `role.updated`, `role.permission.granted`, or `role.permission.revoked` events for the role since its creation on 2026-04-29 16:53:17Z. Last successful `role.updated` event tenant-wide was **2026-04-08** (28+ days ago).

## Root cause trace

1. `api.update_role` is `SECURITY INVOKER` → runs as the caller (`authenticated`).
2. End of function body has the Pattern A v2 read-back guard:
   ```sql
   SELECT processing_error FROM domain_events
   WHERE id = ANY(v_event_ids) AND processing_error IS NOT NULL
   ORDER BY created_at DESC LIMIT 1;
   ```
3. `authenticated` has no table-level GRANT on `domain_events`. Table-level GRANT is checked **before** RLS, so any RLS policy on `domain_events` is unreachable — the GRANT denial fires first.
4. SQLSTATE `42501` ("permission denied for table domain_events") propagates up. PostgREST maps it to HTTP 403.

## Convention check

```sql
SELECT n.nspname || '.' || p.proname AS fn,
       CASE WHEN p.prosecdef THEN 'DEFINER' ELSE 'INVOKER' END AS sec
FROM pg_proc p
JOIN pg_namespace n ON n.oid = p.pronamespace
WHERE n.nspname = 'api'
  AND p.prokind = 'f'
  AND p.prosrc ~ 'FROM\s+domain_events';
```

→ 60 of 61 results were `DEFINER`. Only `api.update_role` was `INVOKER`. (PR #48 covers `api.get_failed_events_with_detail`, the second offender, surfaced by an extended audit that searched on the substring `domain_events` rather than the regex above — that RPC SELECTs `FROM public.domain_events` with explicit schema qualifier, which the regex above missed.)

## Commit 1 — `SECURITY INVOKER` → `SECURITY DEFINER`

`CREATE OR REPLACE FUNCTION api.update_role(...) RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER ...`. Function body unchanged in this commit. The `@a4c-rpc-shape: envelope` COMMENT (from PR #44's M3 registry backfill) is preserved automatically because `CREATE OR REPLACE FUNCTION` keeps the OID stable; the COMMENT is keyed to OID. Verified post-apply.

Per-caller permission checks (`check_permissions_subset`, `get_user_aggregated_permissions`, the subset-only delegation rule) still operate against the actual caller's permissions — `auth.uid()` and `request.jwt.claims` read session settings, which `SECURITY DEFINER` does not change.

## Commit 2 — In-body tenancy guard (architect follow-up)

The architect review identified that flipping to DEFINER silently broadens cross-tenant access on `roles_projection`:

- Pre-fix (INVOKER), the initial `SELECT * FROM roles_projection WHERE id = p_role_id` was constrained by RLS (`roles_global_select` for global roles + `roles_org_admin_select` for org-scoped). Cross-tenant role IDs returned zero rows → `'Role not found'`.
- Post-fix (DEFINER, BYPASSRLS=true on postgres owner), that SELECT returns rows from any tenant. Subset-only delegation prevents privilege escalation via grants, but does NOT prevent revoking permissions from a foreign-tenant role; cross-tenant updates also poison the audit trail (event metadata's `organization_id` ≠ stream's tenant).

Mitigation in commit 2 mirrors the RLS policies in PL/pgSQL:
- `has_platform_privilege()` bypass (matches `platform_admin_all` policy).
- Org-scoped role: caller must be same-tenant AND have `has_org_admin_permission()`.
- Global role (`organization_id IS NULL`): not gated here. Pre-fix RLS allowed any authenticated user to SELECT global role templates; the subset-only delegation guard further constrains what permissions can be granted on them.

Returns the same `'Role not found / Role not found or access denied'` envelope to keep not-found-vs-cross-tenant indistinguishable (canonical pattern from PR #40 `api.delete_user`).

## Verification

| Check | Result |
|---|---|
| Both migrations apply cleanly to dev | ✓ (applied via `supabase db push --linked` on 2026-05-06) |
| `api.update_role` post-apply: `SECURITY DEFINER` | ✓ (verified `prosecdef = true`) |
| Tenancy guard markers present in `prosrc` (`has_platform_privilege`, `has_org_admin_permission`, `Tenancy guard` comment) | ✓ |
| `@a4c-rpc-shape: envelope` COMMENT preserved across both `CREATE OR REPLACE` calls | ✓ |
| Frontend signature unchanged | ✓ (no `database.types.ts` regen needed) |

Note: `plpgsql_check_function` was NOT run as part of this PR — CI runs `supabase db lint --level error` automatically and will block on validation failures.

## Test plan (UAT)

- [ ] Reporter retries: log in as `johnltice@yahoo.com`, navigate to `/roles/manage`, open "South Valley Admin", toggle a permission you possess (e.g., `role.view`), Save Changes.
- [ ] Expected: success state, no 403, role's permissions persist across logout/login.
- [ ] Verification SQL: `SELECT id, event_type, processing_error FROM domain_events WHERE stream_id = 'e6409dc1-821d-4f6f-9f28-737d975341c4' AND created_at > NOW() - INTERVAL '5 minutes'` — confirms a fresh `role.permission.granted` (or `.revoked`) event with `processing_error IS NULL`.
- [ ] Tenancy guard smoke: as a `provider_admin` at tenant A, attempt to call `api.update_role` with a `p_role_id` belonging to tenant B (e.g., via SQL Editor). Expected: `{success: false, error: 'Role not found', errorDetails: {code: 'NOT_FOUND', ...}}` — the same envelope the function returns for a non-existent role.
- [ ] UAT scenario 4 of `manual-ui-test-plan.md` unblocks.

## Out of scope

- Migrating `SupabaseRoleService.updateRole` to `apiRpcEnvelope<T>` (covered by `migrate-services-to-api-rpc-envelope/` card).
- A type-level enforcement preventing future INVOKER-reads-`domain_events` regressions. The M3 RPC-shape registry only narrows envelope vs read shape, not SECURITY mode. **Safety net for future**: the cross-product `pg_proc` audit query is canonicalized in `memory/audit-rpc-security-mode-vs-domain-events.md`; run it on every new `api.*` migration that touches `domain_events`.

## Merge order

This PR should merge **before** PR #48 to keep prod migration timestamps in order:

```
20260506010451  ← this PR (commit 1)
20260506011954  ← this PR (commit 2)
20260506012315  ← PR #48
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)