### PR TITLE
fix(rpc): api.get_failed_events_with_detail must be SECURITY DEFINER

### DIFF
--- a/dev/active/add-failed-event-detail-viewed-audit-emission-seed.md
+++ b/dev/active/add-failed-event-detail-viewed-audit-emission-seed.md
@@ -1,0 +1,46 @@
+# Add `platform.admin.failed_event_detail_viewed` audit emission to `api.get_failed_events_with_detail`
+
+**Status**: seed (not yet planned)
+**Priority**: Medium (PHI-bearing data, audit asymmetry vs. sibling RPC)
+**Origin**: PR #48 architect-review Note #2 (software-architect-dbc, 2026-05-06)
+
+## Problem
+
+`api.get_failed_events_with_detail` returns `processing_error_detail` rows that may contain raw `PG_EXCEPTION_DETAIL` strings — the column is documented PHI-bearing per migration `20260430002824`'s `COMMENT ON COLUMN`. Despite returning more sensitive data than its sibling, the RPC does NOT emit an audit event when invoked.
+
+The sibling RPC `api.get_failed_events` (`baseline_v4.sql:2479-2422`, currently in production) DOES emit a `platform.admin.failed_events_viewed` event before returning. The asymmetry is a pre-existing gap from `20260430002824` (where the detail RPC was originally created) and was outside PR #48's scope.
+
+## Why this matters
+
+- HIPAA audit trail: every read of PHI-bearing data should be auditable. The sibling RPC sets this expectation; the detail RPC violates it.
+- Forensic completeness: if the detail dashboard ever surfaces a leak (e.g., a developer pastes a `processing_error_detail` row into a non-confidential channel), the `domain_events` audit trail must record who read what and when.
+- Pattern consistency: the platform-admin operations stream has `platform.admin.*_viewed` precedent; closing this gap keeps the registry uniform.
+
+## Proposed shape
+
+Emit a `platform.admin.failed_event_detail_viewed` event before the SELECT in `api.get_failed_events_with_detail`. Event metadata includes `user_id`, `reason: 'Failed event detail dashboard view'`, and optionally `p_limit` / `p_offset` for query scoping. Event_data is empty or echoes the pagination parameters.
+
+Reference the existing `api.get_failed_events` emit pattern verbatim — same stream_type (`platform_admin` or whatever it currently uses), same event-naming style.
+
+## Steps
+
+1. Read `baseline_v4.sql:2479-2422` for the `api.get_failed_events` emit pattern.
+2. Verify the `platform.admin.failed_events_viewed` event_type is registered in AsyncAPI (`infrastructure/supabase/contracts/asyncapi.yaml`); add the `_detail_viewed` variant if it's not already there.
+3. Confirm a router/handler exists that no-ops or projects this event type (likely `process_platform_admin_event` or similar). If no router exists, audit how the sibling event is currently handled — it may be `WHEN ... THEN NULL` (audit-only).
+4. Create migration: `supabase migration new add_failed_event_detail_viewed_audit_emission`. CREATE OR REPLACE the RPC with the new emit statement. Function signature unchanged → OID stable → `@a4c-rpc-shape: envelope` COMMENT preserved.
+5. Generate types if any new fields exposed (likely not).
+6. UAT: as platform admin with `platform.view_event_details`, call the RPC; query `domain_events WHERE event_type = 'platform.admin.failed_event_detail_viewed' AND event_metadata->>'user_id' = '<your_user_id>'` to confirm.
+
+## Out of scope
+
+- Adding `platform.view_event_details` to a role template (separate seed: `seed-platform-view-event-details-permission-seed.md`). Until that seed lands, this card's UAT requires a manually-granted permission via direct event emission.
+
+## Files involved
+
+- `infrastructure/supabase/supabase/migrations/20260430002824_strip_processing_error_detail_with_admin_rpc.sql:61-100` (current RPC body)
+- `infrastructure/supabase/supabase/migrations/20260212010625_baseline_v4.sql:2479-2422` (sibling RPC pattern reference)
+- `infrastructure/supabase/contracts/asyncapi.yaml` (event registration check)
+
+## Trigger to start
+
+Follow-up to PR #48 (sibling fix). No external trigger; can be picked up any time bandwidth allows.

--- a/dev/active/seed-platform-view-event-details-permission-seed.md
+++ b/dev/active/seed-platform-view-event-details-permission-seed.md
@@ -1,0 +1,59 @@
+# Seed `platform.view_event_details` permission into `platform_admin` role
+
+**Status**: seed (not yet planned)
+**Priority**: Medium (test-plan blocker; gates the failed-event detail dashboard for platform admins)
+**Origin**: PR #48 architect-review Note #3 (software-architect-dbc, 2026-05-06)
+
+## Problem
+
+`platform.view_event_details` was created in migration `20260430002824` with `scope_type: 'global'`, zero implication chains in `seeds/003-permission-implications-seed.sql`, and is in NO role-permission template. Even after PR #48 lands and `api.get_failed_events_with_detail` works at the database layer, the in-body `IF NOT public.has_permission('platform.view_event_details') THEN RAISE EXCEPTION 'Access denied'` gate will reject every caller until someone manually grants the permission via direct event emission.
+
+The PR #48 UAT plan documents this as a setup step ("ensure your test user has been granted `platform.view_event_details`"), but that's a workaround. The right fix is to seed the permission into the `platform_admin` role template so anyone holding that role gets it transitively.
+
+## Why this matters
+
+- Defense-in-depth gate that nobody can pass = vestigial code.
+- Onboarding gap: a fresh platform admin holds `platform.admin` but cannot see failed-event detail without an extra manual step that is not documented anywhere outside the PR #48 UAT plan.
+- Pattern consistency: every other platform-admin permission is held by the `platform_admin` role template by default.
+
+## Two options
+
+### Option A — Add to `platform_admin` role-permission template
+
+Modify `infrastructure/supabase/supabase/seeds/002-role-templates-seed.sql` (or wherever `platform_admin` template permissions are seeded) to include `platform.view_event_details`. Re-emit the seed events for existing platform admins via a backfill migration.
+
+**Pro**: minimal surface, matches existing pattern.
+**Con**: requires backfill emission for already-bootstrapped platform admins.
+
+### Option B — Add as implication of `platform.admin`
+
+Add `platform.admin → platform.view_event_details` to `infrastructure/supabase/supabase/seeds/003-permission-implications-seed.sql`. `compute_effective_permissions` will then derive it on-the-fly during JWT custom-claim minting.
+
+**Pro**: no backfill needed; takes effect on next token refresh for all platform admins.
+**Con**: implications are typically used for permission hierarchies (e.g., `update_ou → view_ou`), not for "this admin role grants this leaf permission". May not be the intended use of implications.
+
+Recommend Option A. Option B is cleaner operationally but conflates implications-as-hierarchy with implications-as-bundle. Option A keeps the role template self-documenting.
+
+## Steps (Option A)
+
+1. Read `002-role-templates-seed.sql` for the `platform_admin` template definition.
+2. Add `platform.view_event_details` to the permission list.
+3. Create migration: `supabase migration new seed_platform_view_event_details_into_platform_admin`. Migration emits a backfill event for each existing user holding `platform_admin`: `role.permission.granted` with `permission_id = <view_event_details>`, `role_id = <platform_admin role id>`, metadata `reason = 'Backfill: seed platform.view_event_details into platform_admin role (PR #48 follow-up)'`. The handler will project to `role_permissions_projection` idempotently.
+4. UAT: log in as a platform admin, refresh the session (force JWT regen), navigate to the failed-event detail dashboard. Confirm the `42501` is gone.
+
+## Out of scope
+
+- Wiring the failed-event detail dashboard UI (separate concern; the RPC is currently anticipating a UI not yet built — see PR #48 framing).
+- Audit emission for the detail RPC (separate seed: `add-failed-event-detail-viewed-audit-emission-seed.md`).
+
+## Files involved
+
+- `infrastructure/supabase/supabase/seeds/002-role-templates-seed.sql`
+- `infrastructure/supabase/supabase/seeds/003-permission-implications-seed.sql` (Option B, not recommended)
+- `infrastructure/supabase/supabase/migrations/20260430002824_strip_processing_error_detail_with_admin_rpc.sql:50` (`scope_type: 'global'` declaration)
+
+## Trigger to start
+
+Either of:
+- A platform admin needs to use the failed-event detail dashboard (currently a test-plan blocker for PR #48 UAT).
+- The failed-event detail dashboard UI gets prioritized.

--- a/infrastructure/supabase/supabase/migrations/20260506012315_fix_get_failed_events_with_detail_security_definer.sql
+++ b/infrastructure/supabase/supabase/migrations/20260506012315_fix_get_failed_events_with_detail_security_definer.sql
@@ -1,0 +1,112 @@
+-- =====================================================================
+-- Fix: api.get_failed_events_with_detail must run as SECURITY DEFINER
+-- =====================================================================
+--
+-- Latent defect of the same class as PR #47 (api.update_role,
+-- migration 20260506010451). `api.get_failed_events_with_detail` was
+-- created in migration 20260430002824 as `SECURITY INVOKER` but reads
+-- from `public.domain_events`. The `authenticated` Postgres role has
+-- no table-level grants on `domain_events` (only `postgres` does), so
+-- the SELECT raises SQLSTATE 42501 ("permission denied for table
+-- domain_events") on the first invocation by any caller, surfacing as
+-- HTTP 403.
+--
+-- Status: latent, not yet observed in production. Repo grep
+-- (2026-05-06) shows zero call sites — `EventMonitoringService.ts`
+-- consumes only `api.get_failed_events`, not `_with_detail`. The RPC
+-- was added in 20260430002824 anticipating a future detail-view UI
+-- that has not yet been wired. Closing the defect now prevents the
+-- 403 from ever being observed by an end user.
+--
+-- Discovery: cross-product audit (2026-05-06) following the
+-- `api.update_role` defect (PR #47). Audit query identified all
+-- `api.*` SECURITY INVOKER functions whose `prosrc` references
+-- `domain_events`; this RPC was the lone remaining offender after
+-- `api.update_role` was fixed.
+--
+-- Why this is the safer of the two SECURITY mode flips
+-- (architect review, software-architect-dbc, 2026-05-06):
+--
+--   1. The function's first executable statement is an explicit
+--      permission gate:
+--          IF NOT public.has_permission('platform.view_event_details')
+--          THEN RAISE EXCEPTION ...
+--      That gate reads JWT claims (session-bound, not role-bound) so
+--      it survives the SECURITY mode flip unchanged.
+--
+--   2. The function has no tenancy dimension to lose. By design it
+--      scans `domain_events` cross-tenant — it is a platform-admin
+--      forensic tool. There is no RLS policy on `domain_events` that
+--      a permission-passing caller was relying on for tenancy
+--      isolation; `processing_error` rows already cross tenant
+--      boundaries by virtue of the admin's role.
+--
+--   3. Unlike `api.update_role`, this RPC is read-only. There is no
+--      subset-only delegation guard or projection write to reason
+--      about under DEFINER.
+--
+-- Therefore, no in-body tenancy guard is required (compare PR #47
+-- migration `20260506011954_add_update_role_tenancy_guard.sql`).
+--
+-- Fix: change `SECURITY INVOKER` to `SECURITY DEFINER`. Function body
+-- and signature unchanged. The DEFINER (postgres role) has all
+-- table-level grants on `domain_events` and `rolbypassrls=true`, so
+-- the SELECT succeeds. The permission gate at line 1 of the body
+-- continues to gate access via JWT claims.
+--
+-- Idempotency: `CREATE OR REPLACE FUNCTION` preserves the function's
+-- OID. The existing `COMMENT ON FUNCTION` (carrying the
+-- `@a4c-rpc-shape: envelope` tag from migration `20260430172625`'s
+-- M3 backfill) is keyed to OID and therefore preserved
+-- automatically. Per Rule 17 of `.claude/skills/infrastructure-
+-- guidelines/SKILL.md`, the DROP+CREATE re-tag rule does NOT apply
+-- here because we are NOT changing the function signature.
+--
+-- See:
+--   - PR #47 (sibling fix): infrastructure/supabase/supabase/
+--     migrations/20260506010451_fix_update_role_security_definer.sql
+--   - documentation/architecture/decisions/adr-rpc-readback-pattern.md
+--     §"PII handling"
+--   - infrastructure/supabase/CLAUDE.md § Critical Rules
+-- =====================================================================
+
+CREATE OR REPLACE FUNCTION api.get_failed_events_with_detail(
+    p_limit integer DEFAULT 50,
+    p_offset integer DEFAULT 0
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $$
+DECLARE
+    v_events jsonb;
+BEGIN
+    -- Permission gate. RAISE EXCEPTION here is permitted (RPC entry guard, not handler-driven).
+    IF NOT public.has_permission('platform.view_event_details') THEN
+        RAISE EXCEPTION 'Access denied'
+            USING ERRCODE = '42501';
+    END IF;
+
+    SELECT jsonb_agg(sub.e ORDER BY (sub.e->>'created_at') DESC)
+    INTO v_events
+    FROM (
+        SELECT jsonb_build_object(
+            'id', id,
+            'stream_id', stream_id,
+            'stream_type', stream_type,
+            'event_type', event_type,
+            'processing_error', processing_error,
+            'processing_error_detail', processing_error_detail,
+            'created_at', created_at
+        ) AS e
+        FROM public.domain_events
+        WHERE processing_error IS NOT NULL
+        ORDER BY created_at DESC
+        LIMIT p_limit OFFSET p_offset
+    ) sub;
+
+    RETURN jsonb_build_object(
+        'success', true,
+        'events', COALESCE(v_events, '[]'::jsonb)
+    );
+END;
+$$;


### PR DESCRIPTION
## Summary

Sibling defect to #47. `api.get_failed_events_with_detail` was the only other `api.*` `SECURITY INVOKER` function reading from `public.domain_events` — same root cause (authenticated role lacks table-level grants on `domain_events`; SELECT raises 42501 → HTTP 403 to caller).

**Status: latent defect.** Repo grep (2026-05-06) shows zero call sites — `EventMonitoringService.ts` consumes only `api.get_failed_events`, not `_with_detail`. The detail RPC was added in `20260430002824` (2026-04-30) anticipating a future detail-view UI that has not yet been wired. Closing the defect now prevents the 403 from ever being observed by an end user once the UI is built.

Surfaced via cross-product audit on 2026-05-06 following PR #47's diagnosis.

## Why a separate PR (not bundled into #47)

Architect review (software-architect-dbc, 2026-05-06) on #47 explicitly recommended splitting:

- Different risk profile. This RPC has an explicit `has_permission('platform.view_event_details')` gate as its first executable statement; the gate reads JWT claims (session-bound) and survives the SECURITY mode flip unchanged. No in-body tenancy guard is needed (compare #47's `20260506011954_add_update_role_tenancy_guard.sql`).
- No tenancy dimension. By design a cross-tenant forensic tool gated solely by platform-admin permission.
- Read-only. No projection writes or subset-only delegation logic to reason about under DEFINER.
- Cleaner rollback. Bundling forces reviewers to evaluate two unrelated security-mode flips through the lens of #47's tenancy concern.

## Files changed

- `infrastructure/supabase/supabase/migrations/20260506012315_fix_get_failed_events_with_detail_security_definer.sql` (NEW)
- `dev/active/add-failed-event-detail-viewed-audit-emission-seed.md` (NEW — architect Note #2 follow-up)
- `dev/active/seed-platform-view-event-details-permission-seed.md` (NEW — architect Note #3 follow-up)

## ⚠️ Merge order — MUST merge AFTER PR #47

This branch is currently rebased on top of #47, so the diff shown here includes #47's two commits. Migration timestamps must apply in order in prod:

```
20260506010451  ← #47 commit 1 (INVOKER → DEFINER)
20260506011954  ← #47 commit 2 (tenancy guard)
20260506012315  ← THIS PR
```

**Before merging this PR**:
1. PR #47 must be merged to `main` first.
2. Rebase this branch onto the new `main`: `git checkout fix/get-failed-events-with-detail-security-definer && git fetch origin && git rebase origin/main && git push --force-with-lease`.
3. After the rebase, this PR will show a single migration commit + the two seed cards.
4. Then merge.

Reviewing this PR is fine before #47 merges (the change here is self-contained and simpler than #47), but **do not click merge** until the rebase above is done.

## Architect review — three non-blocking notes addressed

The [architect review](https://github.com/Analytics4Change/A4C-AppSuite/pull/48#pullrequestreview-78SQks) flagged three non-blocking notes; all three are addressed in the current PR state.

### Note #1 — Latent vs. live framing → fixed in commit `2e882659`

Reviewer pointed out the original PR description and migration header described the bug as "breaks the dashboard end-to-end / broken since 2026-04-30 ~6 days", but repo grep shows zero call sites. Reality: latent defect, not a live breakage. Migration header (lines 5–19) and this PR description re-framed accordingly.

### Note #2 — Audit emission asymmetry → seeded as follow-up card

Sibling RPC `api.get_failed_events` emits a `platform.admin.failed_events_viewed` event before returning rows; `api.get_failed_events_with_detail` does NOT, despite returning more sensitive PHI-bearing data. Pre-existing gap from `20260430002824`, outside PR #48's scope. Tracked: [`dev/active/add-failed-event-detail-viewed-audit-emission-seed.md`](../tree/fix/get-failed-events-with-detail-security-definer/dev/active/add-failed-event-detail-viewed-audit-emission-seed.md).

### Note #3 — Pre-existing permission-grant gap → seeded as follow-up card + UAT setup step

`platform.view_event_details` is `scope_type: 'global'` with zero implication chains and is in no role-permission template. Even after PR #48 lands, a platform admin cannot call the RPC unless the permission is manually granted. Pre-existing gap from `20260430002824`. Tracked: [`dev/active/seed-platform-view-event-details-permission-seed.md`](../tree/fix/get-failed-events-with-detail-security-definer/dev/active/seed-platform-view-event-details-permission-seed.md). UAT plan below now includes a setup step.

## Test plan

### Setup (required for UAT)

- [ ] Confirm your test platform-admin user holds `platform.view_event_details`. Until the Note #3 follow-up card lands, this is NOT in the `platform_admin` role template; you must grant it manually:
  ```sql
  -- Replace <platform_admin_role_id> and <permission_id> as appropriate
  SELECT api.emit_domain_event(
    p_stream_id      := '<platform_admin_role_id>'::uuid,
    p_stream_type    := 'role',
    p_event_type     := 'role.permission.granted',
    p_event_data     := jsonb_build_object('permission_id', '<view_event_details_permission_id>'),
    p_event_metadata := jsonb_build_object(
      'user_id',         auth.uid(),
      'organization_id', NULL,
      'reason',          'Manual grant for PR #48 UAT pending Note #3 follow-up card'
    )
  );
  ```
  Then re-login to refresh JWT custom claims.

### Verifications

- [x] Migration applied cleanly to dev (manual `supabase db push --linked` on 2026-05-06)
- [x] Post-apply verification: `prosecdef = true` (confirmed via SQL)
- [x] Post-apply verification: `@a4c-rpc-shape: envelope` COMMENT preserved (confirmed via SQL — OID-stable across `CREATE OR REPLACE`)
- [ ] CI green on the rebased branch (post-#47-merge)
- [ ] Manual UAT (positive path) — log in as the test user from the Setup step; call `SELECT api.get_failed_events_with_detail()` directly via SQL Editor; verify it returns `{success: true, events: [...]}` (was 42501 pre-fix).
- [ ] Manual UAT (negative path) — log in as a non-platform-admin (no `platform.view_event_details`); call the RPC; verify it returns `Access denied` / SQLSTATE 42501 (the in-body permission gate still rejects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)