### PR TITLE
feat(rbac): role-management → organization.view_ou implications (closes structural cross-aggregate gap)

### DIFF
--- a/dev/active/sub-tenant-admin-design/plan.md
+++ b/dev/active/sub-tenant-admin-design/plan.md
@@ -20,6 +20,42 @@ Verified empirical state (2026-04-27, against `tmrjlswbsxmbglmaclxu`):
 - All role assignments at depth 1 (no sub-tenant OU assignments exist).
 - 0 of 6 users have `current_org_unit_id` populated.
 
+## Phase 0 Discovery — narrower alternative vs. full sub-tenant admin
+
+> **Decide before §1.** Sub-tenant admin (this card's full scope) is potentially over-scoped for the immediate need. There is a narrower alternative that solves role-management gating without any user-model evolution.
+
+### Two architectural alternatives
+
+1. **Sub-tenant admin (this card's full scope)** — assign roles like "South Valley Admin" at scope `testorg-20260329.south_valley`, not at tenant root. Reuses `effective_permissions[].s` ltree containment via `has_effective_permission(perm, target_path)`. **Requires user-identity to acquire OU-bounded location** (per "Trigger" above). Heavy: user-model evolution, multi-role aggregation, identity-vs-shift-OU distinction, helper redesign, RPC retrofit across `delete_user` / `deactivate_user` / `update_user_profile` etc.
+
+2. **Role-scope containment check** — distinct from actor's `effective_permissions[].s` paths: `actor's role's org_hierarchy_scope @> target role's org_hierarchy_scope`. Reads as "South Valley Admin can only manage role assignments whose scope is at-or-below `south_valley`." **No user-model change required.** The check sits at the role-management RPC layer (`modify_user_roles`, `assign_role`, `revoke_role`). Targets a `user_roles_projection` row — which already has `scope_path` — not a user identity.
+
+### Which alternative is actually needed?
+
+Matrix the two against the operation taxonomy in §3 below:
+
+| Operation class | Examples | Option 2 sufficient? | Why |
+|---|---|---|---|
+| **Role-scoped** | `modify_user_roles`, `assign_role`, `revoke_role`, `bulk_assign_role` | ✅ Yes | Target has scope (`user_roles_projection.scope_path`); the canonical pattern is already implemented in `baseline_v4 bulk_assign_role`. Actor's role scope @> target row's scope is the natural check. |
+| **Identity-scoped** | `delete_user`, `deactivate_user`, `update_user_profile`, `update_notification_preferences` | ❌ No | Target has no scope today; needs user-identity OU evolution (Option 1). Option 2 cannot answer "is this user under my administrative authority?" because user identity has no path. |
+
+### Phase 0 finding
+
+**Option 2 is the smaller hammer for role-management gating; Option 1 (this card's full scope) is the broader capability for identity-scoped delegation.** They are not substitutes — they apply to different operation classes.
+
+- If the immediate business driver is **role-management only** (e.g., "South Valley Admin shouldn't be able to assign roles outside south_valley"): ship Option 2 as a focused implementation card and defer this one.
+- If the driver **also includes identity-scoped delegation** (e.g., "South Valley Admin should be able to delete users at south_valley"): this card's full design space applies, and Option 2 is one tactical sub-component of it.
+
+### Discovery action
+
+Phase 0 must:
+1. Enumerate the operations that today need a scope-gating boundary the platform doesn't enforce.
+2. Classify each as **role-scoped** or **identity-scoped** per the table above.
+3. **If only role-scoped operations surface**: write a separate small implementation card for Option 2 (target the role-management RPCs only) and keep this card SEEDED.
+4. **If identity-scoped operations also surface**: this card's full design space applies; proceed to §1.
+
+The 2026-05-06 surfacing case (PR #49 — South Valley Admin clicking into 42501 on `api.list_users_for_role_management`) is purely role-management-adjacent (a list-users-for-role-assignment query). It does NOT, by itself, require sub-tenant admin. It requires either (a) the existing tenancy guard already in place, or (b) Option 2 if we want to constrain South Valley Admin's role-management reach further.
+
 ## Design space
 
 ### 1. Data-model changes

--- a/dev/active/sub-tenant-admin-design/tasks.md
+++ b/dev/active/sub-tenant-admin-design/tasks.md
@@ -9,6 +9,11 @@
 ## Tasks
 
 - [x] Card seeded with context, design-space plan, references — 2026-04-27
+- [ ] **Phase 0 Discovery — narrower alternative vs. full sub-tenant admin** (added 2026-05-06; gates all subsequent work)
+  - Enumerate operations needing a scope-gating boundary the platform doesn't enforce today.
+  - Classify each as role-scoped (target has `scope_path`) vs identity-scoped (target is user identity).
+  - If only role-scoped: spin off a focused implementation card for Option 2 (`actor's role scope @> target role scope`) and keep this card SEEDED.
+  - If identity-scoped operations also surface: this card's full design space applies. See `plan.md` § Phase 0 Discovery.
 - [ ] **Business-need trigger** — surface sub-tenant admin requirement from a customer / partner / compliance driver
 - [ ] **Design exploration** — answer Open Questions in `plan.md` (multi-OU membership semantics, identity-vs-shift-OU distinction, role-aggregation rule, placement-eligibility filter relationship)
 - [ ] **Architectural review** — `software-architect-dbc` once design is settled; pre-empt the same misreading that triggered the 2026-04-27 course correction

--- a/infrastructure/supabase/sql/99-seeds/003-permission-implications-seed.sql
+++ b/infrastructure/supabase/sql/99-seeds/003-permission-implications-seed.sql
@@ -8,10 +8,17 @@
 -- IMPORTANT: This is configuration data, NOT event-sourced.
 -- Must run AFTER 001-permissions-seed.sql (depends on permissions_projection).
 --
--- Total: 22 implication rules
+-- Total: 28 implication rules
 --
--- Last Updated: 2026-02-12
+-- Last Updated: 2026-05-06
 -- Changes:
+--   - 2026-05-06: Added 6 cross-aggregate role-management → OU read implications
+--                 (role.{create,update,delete} → organization.view_ou;
+--                  user.role_{assign,revoke} → organization.view_ou;
+--                  user.role_revoke → user.view).
+--                 Mirror of migration 20260506190626. Closes structural gap
+--                 surfaced by lars.tice+test UAT 2026-05-06; architect-reviewed
+--                 (software-architect-dbc) F3 + P2-B.
 --   - 2026-02-12: Extracted from archived migration 20260122204647 during Day 0 v4 baseline
 --   - 2026-02-02: Added user.schedule_manage → user.view, user.client_assign → user.view
 --   - 2026-01-22: Initial creation (Multi-Role Authorization Phase 2A)
@@ -81,4 +88,65 @@ INSERT INTO permission_implications (permission_id, implies_permission_id)
 SELECT p1.id, p2.id
 FROM permissions_projection p1, permissions_projection p2
 WHERE p1.name = 'user.client_assign' AND p2.name = 'user.view'
+ON CONFLICT DO NOTHING;
+
+-- =============================================================================
+-- Cross-Aggregate Role-Management → OU Read Implications
+-- (Added 2026-05-06 — mirror of migration 20260506190626)
+-- Role-management UI structurally depends on OU visibility
+-- (RolesManagePage.tsx derives rootScopePath from the OU tree). These
+-- edges close the cross-aggregate gap so any custom role granting
+-- role-management permissions automatically inherits OU read at the
+-- same scope. Deliberately excludes `role.view → organization.view_ou`
+-- to avoid widening read implications across the codebase.
+-- =============================================================================
+
+-- role.create → organization.view_ou
+-- (Create-role form requires OU selector for org_hierarchy_scope)
+INSERT INTO permission_implications (permission_id, implies_permission_id)
+SELECT p1.id, p2.id
+FROM permissions_projection p1, permissions_projection p2
+WHERE p1.name = 'role.create' AND p2.name = 'organization.view_ou'
+ON CONFLICT DO NOTHING;
+
+-- role.update → organization.view_ou
+-- (Edit-role form may show or change OU scope)
+INSERT INTO permission_implications (permission_id, implies_permission_id)
+SELECT p1.id, p2.id
+FROM permissions_projection p1, permissions_projection p2
+WHERE p1.name = 'role.update' AND p2.name = 'organization.view_ou'
+ON CONFLICT DO NOTHING;
+
+-- role.delete → organization.view_ou
+-- (Delete-confirmation surfaces role's org_hierarchy_scope; symmetric
+--  with the existing _ou-mutator-implies-view_ou pattern)
+INSERT INTO permission_implications (permission_id, implies_permission_id)
+SELECT p1.id, p2.id
+FROM permissions_projection p1, permissions_projection p2
+WHERE p1.name = 'role.delete' AND p2.name = 'organization.view_ou'
+ON CONFLICT DO NOTHING;
+
+-- user.role_assign → organization.view_ou
+-- (Role-assignment dialog derives rootScopePath from OU tree)
+INSERT INTO permission_implications (permission_id, implies_permission_id)
+SELECT p1.id, p2.id
+FROM permissions_projection p1, permissions_projection p2
+WHERE p1.name = 'user.role_assign' AND p2.name = 'organization.view_ou'
+ON CONFLICT DO NOTHING;
+
+-- user.role_revoke → organization.view_ou
+-- (Symmetric with user.role_assign — same UI surface, same dependency)
+INSERT INTO permission_implications (permission_id, implies_permission_id)
+SELECT p1.id, p2.id
+FROM permissions_projection p1, permissions_projection p2
+WHERE p1.name = 'user.role_revoke' AND p2.name = 'organization.view_ou'
+ON CONFLICT DO NOTHING;
+
+-- user.role_revoke → user.view
+-- (Closes pre-existing symmetry gap with user.role_assign → user.view;
+--  must be able to see users to revoke roles from them)
+INSERT INTO permission_implications (permission_id, implies_permission_id)
+SELECT p1.id, p2.id
+FROM permissions_projection p1, permissions_projection p2
+WHERE p1.name = 'user.role_revoke' AND p2.name = 'user.view'
 ON CONFLICT DO NOTHING;

--- a/infrastructure/supabase/supabase/migrations/20260506190626_add_role_management_view_ou_implications.sql
+++ b/infrastructure/supabase/supabase/migrations/20260506190626_add_role_management_view_ou_implications.sql
@@ -70,6 +70,19 @@
 --      UI degrades gracefully on raw ltree paths. View permissions
 --      should be granted explicitly.
 --
+--   7. Forward-looking note for sub-tenant-admin work
+--      (`dev/active/sub-tenant-admin-design/`): when role assignments
+--      eventually live at narrower scopes (e.g., a "South Valley
+--      Admin" assigned at `testorg.south_valley` instead of tenant
+--      root), `compute_effective_permissions`'s `we.scope_path`
+--      inheritance (baseline_v4:6970) propagates the narrower scope to
+--      the derived permissions added here. So a holder of
+--      `role.create` at `testorg.south_valley` will get
+--      `organization.view_ou` at `testorg.south_valley` (NOT tenant
+--      root). The new edges automatically benefit from this property —
+--      no change required to this migration when sub-tenant admin
+--      semantics arrive.
+--
 -- See:
 --   - documentation/architecture/decisions/adr-rpc-readback-pattern.md (no new RPC; not applicable)
 --   - infrastructure/supabase/CLAUDE.md § Critical Rules (CQRS distinction:
@@ -128,3 +141,35 @@ SELECT p1.id, p2.id
 FROM permissions_projection p1, permissions_projection p2
 WHERE p1.name = 'user.role_revoke' AND p2.name = 'user.view'
 ON CONFLICT DO NOTHING;
+
+-- =====================================================================
+-- Postcondition assertion (per architect review P2-A, 2026-05-06)
+-- =====================================================================
+-- The per-edge `INSERT ... SELECT FROM permissions_projection WHERE
+-- name = '<literal>'` pattern silently produces zero rows if a
+-- permission is ever renamed without updating this migration. The
+-- pattern is also used 4× in `sql/99-seeds/003-permission-implications-seed.sql`
+-- with the same latent risk. Make the postcondition explicit:
+DO $$
+DECLARE
+  v_actual integer;
+BEGIN
+  SELECT COUNT(*) INTO v_actual
+  FROM permission_implications pi
+  JOIN permissions_projection p1 ON p1.id = pi.permission_id
+  JOIN permissions_projection p2 ON p2.id = pi.implies_permission_id
+  WHERE (p1.name, p2.name) IN (
+    ('role.create',      'organization.view_ou'),
+    ('role.update',      'organization.view_ou'),
+    ('role.delete',      'organization.view_ou'),
+    ('user.role_assign', 'organization.view_ou'),
+    ('user.role_revoke', 'organization.view_ou'),
+    ('user.role_revoke', 'user.view')
+  );
+  IF v_actual <> 6 THEN
+    RAISE EXCEPTION
+      'Postcondition violated: expected 6 implication rows, found %. '
+      'Likely cause: a source or target permission name was renamed '
+      'without updating this migration.', v_actual;
+  END IF;
+END $$;

--- a/infrastructure/supabase/supabase/migrations/20260506190626_add_role_management_view_ou_implications.sql
+++ b/infrastructure/supabase/supabase/migrations/20260506190626_add_role_management_view_ou_implications.sql
@@ -1,0 +1,130 @@
+-- =====================================================================
+-- Add cross-aggregate permission implications for role management
+-- =====================================================================
+--
+-- Closes a structural gap in the permission-implication graph: roles
+-- granting role-management permissions did not automatically inherit
+-- `organization.view_ou` (or `user.view` for revoke), even though the
+-- frontend role-management UI structurally depends on OU visibility
+-- (`RolesManagePage.tsx:125` derives `rootScopePath = ouNodes[0].path`
+-- and passes it as `p_scope_path` to `api.list_users_for_role_management`).
+--
+-- Surfaced 2026-05-06 by `lars.tice+test@gmail.com` (custom role
+-- "South Valley Admin", granted full `role.*` + `user.*` perm set
+-- but no `organization.view_ou`). Symptom cascade:
+--   1. `api.get_organization_units` raised 42501 → empty `ouNodes`
+--   2. `rootScopePath = ''` (empty ltree) → assignment dialog passed
+--      empty scope to `api.list_users_for_role_management`
+--   3. Backend `v_user_scope @> ''::ltree` = FALSE → 42501 again
+--
+-- Existing implications already encode the same pattern at half-strength:
+--   organization.{create,update,delete,deactivate,reactivate}_ou → organization.view_ou
+--   role.{create,update,delete}                                  → role.view
+--   user.role_assign                                             → user.view
+--
+-- This migration adds the missing cross-aggregate cluster:
+--   role.create        → organization.view_ou
+--   role.update        → organization.view_ou
+--   role.delete        → organization.view_ou
+--   user.role_assign   → organization.view_ou
+--   user.role_revoke   → organization.view_ou
+--   user.role_revoke   → user.view  (closes pre-existing symmetry gap with user.role_assign)
+--
+-- Architectural notes (per software-architect-dbc review, 2026-05-06):
+--
+--   1. `permission_implications` is CONFIGURATION DATA, NOT event-sourced
+--      (per seed file header line 8). No `permission.implication_added`
+--      event type exists. Plain INSERT ... ON CONFLICT DO NOTHING is the
+--      correct pattern, mirroring `sql/99-seeds/003-permission-implications-seed.sql`.
+--
+--   2. RLS policy `permission_implications_modify` (baseline_v4:15532)
+--      restricts runtime mutations to `user_role = 'super_admin'`.
+--      This migration runs as `postgres` (RLS bypass at deploy time).
+--      Future runtime mutations would require super_admin context.
+--
+--   3. JWT-refresh required for live sessions to pick up new implications.
+--      The `effective_permissions` claim is computed in
+--      `auth.custom_access_token_hook` and baked into the JWT at
+--      login/refresh. Affected users will not see the new derivations
+--      until they logout/login or their token expires (~1 hour).
+--      Implication grants are additive and not security-critical —
+--      NO force-logout broadcast is needed.
+--
+--   4. Scope propagation: `compute_effective_permissions` (baseline_v4:6970)
+--      inherits `we.scope_path` verbatim from the source permission to
+--      the derived permission, and picks the widest scope (shortest
+--      ltree, baseline_v4:6981) per perm name. So a holder of
+--      `role.create` at scope `testorg-20260329` automatically gets
+--      `organization.view_ou` at scope `testorg-20260329` (matches the
+--      caller's mental model — same scope as the source grant).
+--
+--   5. `provider_admin` already holds `organization.view_ou` directly
+--      (per `sql/99-seeds/002-role-permission-templates-seed.sql:137`).
+--      After this migration: `compute_effective_permissions` widest-scope
+--      rule means the explicit grant continues to win → NO functional
+--      change for provider_admin or super_admin.
+--
+--   6. Deliberately NOT added: `role.view → organization.view_ou`.
+--      Argument against: widens read implications across the codebase;
+--      every role-viewer would automatically see every OU in tenant.
+--      UI degrades gracefully on raw ltree paths. View permissions
+--      should be granted explicitly.
+--
+-- See:
+--   - documentation/architecture/decisions/adr-rpc-readback-pattern.md (no new RPC; not applicable)
+--   - infrastructure/supabase/CLAUDE.md § Critical Rules (CQRS distinction:
+--     config tables vs projection tables)
+--   - dev/active/sub-tenant-admin-design/ (separate, deferred concern;
+--     this migration does NOT change scope semantics for role assignment,
+--     only completes the implication graph for view permissions)
+-- =====================================================================
+
+-- role.create → organization.view_ou
+-- (Create-role form requires OU selector for org_hierarchy_scope)
+INSERT INTO permission_implications (permission_id, implies_permission_id)
+SELECT p1.id, p2.id
+FROM permissions_projection p1, permissions_projection p2
+WHERE p1.name = 'role.create' AND p2.name = 'organization.view_ou'
+ON CONFLICT DO NOTHING;
+
+-- role.update → organization.view_ou
+-- (Edit-role form may show or change OU scope)
+INSERT INTO permission_implications (permission_id, implies_permission_id)
+SELECT p1.id, p2.id
+FROM permissions_projection p1, permissions_projection p2
+WHERE p1.name = 'role.update' AND p2.name = 'organization.view_ou'
+ON CONFLICT DO NOTHING;
+
+-- role.delete → organization.view_ou
+-- (Delete-confirmation surfaces role's org_hierarchy_scope; symmetric
+--  with the existing _ou-mutator-implies-view_ou pattern)
+INSERT INTO permission_implications (permission_id, implies_permission_id)
+SELECT p1.id, p2.id
+FROM permissions_projection p1, permissions_projection p2
+WHERE p1.name = 'role.delete' AND p2.name = 'organization.view_ou'
+ON CONFLICT DO NOTHING;
+
+-- user.role_assign → organization.view_ou
+-- (RolesManagePage assignment dialog derives rootScopePath from OU tree)
+INSERT INTO permission_implications (permission_id, implies_permission_id)
+SELECT p1.id, p2.id
+FROM permissions_projection p1, permissions_projection p2
+WHERE p1.name = 'user.role_assign' AND p2.name = 'organization.view_ou'
+ON CONFLICT DO NOTHING;
+
+-- user.role_revoke → organization.view_ou
+-- (Symmetric with user.role_assign — same UI surface, same rootScopePath dependency)
+INSERT INTO permission_implications (permission_id, implies_permission_id)
+SELECT p1.id, p2.id
+FROM permissions_projection p1, permissions_projection p2
+WHERE p1.name = 'user.role_revoke' AND p2.name = 'organization.view_ou'
+ON CONFLICT DO NOTHING;
+
+-- user.role_revoke → user.view
+-- (Closes pre-existing symmetry gap with user.role_assign → user.view.
+--  Must be able to see users to revoke roles from them.)
+INSERT INTO permission_implications (permission_id, implies_permission_id)
+SELECT p1.id, p2.id
+FROM permissions_projection p1, permissions_projection p2
+WHERE p1.name = 'user.role_revoke' AND p2.name = 'user.view'
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary

Closes a structural gap in the permission-implication graph. Roles granting role-management permissions (`role.*`, `user.role_*`) did not automatically inherit `organization.view_ou`, even though the role-management UI structurally depends on OU visibility. Six new cross-aggregate implications complete the existing pattern.

## Discovery

Surfaced 2026-05-06 by `lars.tice+test@gmail.com` (custom role "South Valley Admin" with full `role.*` + `user.*` perm set but no `organization.view_ou`) during modify_user_roles UAT scenario #4 setup. Symptom cascade:

1. `api.get_organization_units` raised 42501 → empty `ouNodes`
2. `rootScopePath = ''` (empty ltree) at `RolesManagePage.tsx:125`
3. Assignment dialog passed empty scope to `api.list_users_for_role_management`
4. Backend `v_user_scope @> ''::ltree` = FALSE → 42501 again

## What this changes

Adds 6 rows to `permission_implications` via `INSERT ... ON CONFLICT DO NOTHING`:

| Source permission | Implies | Justification |
|---|---|---|
| `role.create` | `organization.view_ou` | Create-role form requires OU selector for `org_hierarchy_scope` |
| `role.update` | `organization.view_ou` | Edit-role form may show/change OU scope |
| `role.delete` | `organization.view_ou` | Delete-confirmation surfaces role's OU path |
| `user.role_assign` | `organization.view_ou` | Assignment dialog derives `rootScopePath` from OU tree |
| `user.role_revoke` | `organization.view_ou` | Symmetric with `user.role_assign` |
| `user.role_revoke` | `user.view` | Closes pre-existing symmetry gap with `user.role_assign → user.view` |

**Deliberately NOT added**: `role.view → organization.view_ou` (would widen read implications across codebase; UI degrades gracefully on raw ltree paths).

## Existing pattern this completes

```
✅ organization.{create,update,delete,deactivate,reactivate}_ou → organization.view_ou   (mutate ⇒ read on OU)
✅ role.{create,update,delete}                                  → role.view              (mutate ⇒ read on role)
✅ user.role_assign                                              → user.view              (assigner gets user list)
✅ user.schedule_manage / user.client_assign                     → user.view              (managers get user list)
✅ medication.administer                                         → medication.view        (administer ⇒ read)
+ this PR's 6 cross-aggregate role-management → OU read implications
```

## Architectural review (software-architect-dbc, 2026-05-06)

**Verdict: APPROVE WITH FOLLOW-UPS** (all 7 follow-ups addressed inline, no further cards filed):

- F1 — `permission_implications` is config table, not event-sourced. Plain INSERT used (not event emission). ✓
- F2 — Correct seed file path: `infrastructure/supabase/sql/99-seeds/003-permission-implications-seed.sql`. ✓
- F3 — All 6 implications enumerated above. ✓
- F4 — RLS policy `permission_implications_modify` (super_admin only) documented in migration header. ✓
- F5 — Issue 4 (separate concern, /roles/manage role list visibility) handled out-of-band with concrete URL `?status=` hypothesis user can self-verify in 30 seconds. ✓
- F6 — UI affordance audit (route gates, sidebar nav, OU dropdown) documented inline. No surprise capability expansion (`organization.view_ou` is view-only across all 11 grep hits in `frontend/src`). ✓
- F7 — JWT-refresh expectation documented; no force-logout broadcast needed. ✓

## Verification (DB-confirmed on dev post-apply)

```sql
-- lars.tice+test@gmail.com derivation works
SELECT permission_name, effective_scope::text
FROM public.compute_effective_permissions(
    '61cbb03f-b54c-4aac-bbfc-460e98a70821'::uuid,
    '2d0829ae-224b-4a79-ac3a-726b00d6c172'::uuid
)
WHERE permission_name IN ('organization.view_ou', 'user.view');
-- Result:
--   organization.view_ou | testorg-20260329
--   user.view            | testorg-20260329
```

`provider_admin` regression check — explicit grant continues to win via `compute_effective_permissions` widest-scope rule:
```sql
-- johnltice@yahoo.com still has organization.view_ou at testorg-20260329 (no widening, no shift).
```

## Test plan

- [x] Migration applied cleanly to dev (`supabase db push --linked`)
- [x] All 6 implication rows present in `permission_implications` post-apply
- [x] `compute_effective_permissions` derives `organization.view_ou` and `user.view` for lars.tice+test at scope `testorg-20260329`
- [x] `provider_admin` (`johnltice@yahoo.com`) unchanged — explicit grant still active
- [ ] CI green on supabase-migrations workflow (push to main triggers it)
- [ ] Manual UAT — lars.tice+test logs out + back in, navigates to `/roles/manage`, opens create-role flow → OU dropdown populates
- [ ] Manual UAT — assignment dialog opens for South Valley Admin (Issue 2 cascade resolved)
- [ ] Manual UAT — modify_user_roles UAT scenario #4 reaches `validate_role_assignment` and produces `SUBSET_ONLY_VIOLATION` envelope for West Valley Admin

## What this does NOT change

- Frontend code: zero changes; this is purely permission-model.
- South Valley Admin role's explicit permission set: unchanged.
- Sub-tenant admin model (`dev/active/sub-tenant-admin-design/`): correctly deferred.
- New follow-up cards: none. Per project standing direction, items go in memory if needed for cross-session continuity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)