### PR TITLE
fix(invitation): drop deprecated role column; switch to roles[] contract

### DIFF
--- a/.github/workflows/rpc-registry-sync.yml
+++ b/.github/workflows/rpc-registry-sync.yml
@@ -42,12 +42,29 @@ jobs:
         with:
           version: latest
 
+      # `supabase start` auto-applies any migrations in supabase/migrations/
+      # on first init (confirmed by failing log on the prior CI run). Move the
+      # directory aside before start so the container boots with no migrations,
+      # then restore for the phased manual apply below. Without this, the May
+      # 6 postcondition migration runs before our seed step has a chance.
+      - name: Move migrations aside (prevent supabase start auto-apply)
+        working-directory: infrastructure/supabase
+        run: |
+          mv supabase/migrations supabase/migrations.staged
+          mkdir supabase/migrations  # supabase CLI requires the directory to exist
+
       - name: Start local Supabase container
         working-directory: infrastructure/supabase
         run: |
           supabase start
           # Wait for the container to be fully ready (status reports DB URL)
           supabase status
+
+      - name: Restore migrations directory
+        working-directory: infrastructure/supabase
+        run: |
+          rmdir supabase/migrations
+          mv supabase/migrations.staged supabase/migrations
 
       - name: Install psql client
         run: |

--- a/.github/workflows/rpc-registry-sync.yml
+++ b/.github/workflows/rpc-registry-sync.yml
@@ -43,15 +43,25 @@ jobs:
           version: latest
 
       # `supabase start` auto-applies any migrations in supabase/migrations/
-      # on first init (confirmed by failing log on the prior CI run). Move the
-      # directory aside before start so the container boots with no migrations,
-      # then restore for the phased manual apply below. Without this, the May
-      # 6 postcondition migration runs before our seed step has a chance.
-      - name: Move migrations aside (prevent supabase start auto-apply)
+      # on first init AND requires the `api` schema to exist for PostgREST
+      # health checks to pass. Strategy: keep ONLY baseline_v4 in the dir
+      # during supabase start (it creates the `api` schema and the foundational
+      # structures), stage the rest aside. After start succeeds, restore the
+      # rest and apply via the phased manual flow below. Without this, either:
+      #   (a) all migrations apply and the May 6 postcondition fails, or
+      #   (b) no migrations apply and PostgREST health check times out (503).
+      - name: Stage post-baseline migrations aside
         working-directory: infrastructure/supabase
         run: |
-          mv supabase/migrations supabase/migrations.staged
-          mkdir supabase/migrations  # supabase CLI requires the directory to exist
+          mkdir supabase/migrations.staged
+          # Move every migration EXCEPT baseline_v4 to the staged dir
+          for f in supabase/migrations/*.sql; do
+            base=$(basename "$f")
+            if [[ "$base" != "20260212010625_baseline_v4.sql" ]]; then
+              mv "$f" supabase/migrations.staged/
+            fi
+          done
+          ls supabase/migrations/
 
       - name: Start local Supabase container
         working-directory: infrastructure/supabase
@@ -60,11 +70,11 @@ jobs:
           # Wait for the container to be fully ready (status reports DB URL)
           supabase status
 
-      - name: Restore migrations directory
+      - name: Restore staged migrations
         working-directory: infrastructure/supabase
         run: |
-          rmdir supabase/migrations
-          mv supabase/migrations.staged supabase/migrations
+          mv supabase/migrations.staged/*.sql supabase/migrations/
+          rmdir supabase/migrations.staged
 
       - name: Install psql client
         run: |
@@ -98,15 +108,23 @@ jobs:
         run: |
           PSQL_CMD="psql -h 127.0.0.1 -p 54322 -U postgres -d postgres -v ON_ERROR_STOP=1"
 
-          # Boundary timestamp: apply migrations through and INCLUDING this one
-          # before seeding. The postcondition migration 20260506190626 must run
-          # AFTER the seed.
+          # Baseline (20260212010625_baseline_v4.sql) is ALREADY APPLIED by
+          # `supabase start` above (we kept it in the migrations dir so PostgREST
+          # health checks pass). Phase 1 applies post-baseline migrations through
+          # and INCLUDING the boundary timestamp; the postcondition migration
+          # 20260506190626 runs in Phase 3 after the permissions seed.
+          BASELINE_TS="20260212010625"
           BOUNDARY_TS="20260506012315"
 
-          echo "::group::Phase 1 - Migrations through and including ${BOUNDARY_TS}"
+          echo "::group::Phase 1 - Post-baseline migrations through and including ${BOUNDARY_TS}"
           for f in $(ls supabase/migrations/*.sql | sort); do
             base=$(basename "$f")
             ts=${base%%_*}
+            # Skip baseline (already applied by supabase start)
+            if [[ "$ts" == "$BASELINE_TS" ]]; then
+              echo "Skipping $base (already applied by supabase start)"
+              continue
+            fi
             if [[ "$ts" > "$BOUNDARY_TS" ]]; then
               echo "Stopping at $base (will apply after seed)"
               break

--- a/.github/workflows/rpc-registry-sync.yml
+++ b/.github/workflows/rpc-registry-sync.yml
@@ -49,9 +49,83 @@ jobs:
           # Wait for the container to be fully ready (status reports DB URL)
           supabase status
 
-      - name: Apply migrations to local container
+      - name: Install psql client
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq postgresql-client
+
+      # Migrations applied in three phases with a permissions seed step in
+      # between. Rationale:
+      #
+      # 20260506190626_add_role_management_view_ou_implications.sql ends with a
+      # DO $$ ... ASSERT $$ postcondition that requires 6 implication rows to
+      # exist, which depends on permissions_projection being populated. On
+      # dev/prod, permissions were populated via the post-baseline seed file
+      # `infrastructure/supabase/sql/99-seeds/001-permissions-seed.sql` (it
+      # emits permission.defined events that the trigger projects into the
+      # projection). On a fresh CI container, that seed never runs (the CLI's
+      # supabase/seed.sql doesn't exist; the 99-seeds/*.sql files aren't
+      # auto-applied).
+      #
+      # The prior `supabase db reset --local` step blindly ran every migration
+      # in lexical order and failed at 20260506190626 with
+      # "Postcondition violated: expected 6 implication rows, found 0".
+      #
+      # Replacement: drive migrations manually via psql, applying baseline +
+      # early migrations first, seeding permissions, then applying remaining
+      # migrations.
+      - name: Apply migrations and seed permissions in phased order
         working-directory: infrastructure/supabase
-        run: supabase db reset --local
+        env:
+          PGPASSWORD: postgres
+        run: |
+          PSQL_CMD="psql -h 127.0.0.1 -p 54322 -U postgres -d postgres -v ON_ERROR_STOP=1"
+
+          # Boundary timestamp: apply migrations through and INCLUDING this one
+          # before seeding. The postcondition migration 20260506190626 must run
+          # AFTER the seed.
+          BOUNDARY_TS="20260506012315"
+
+          echo "::group::Phase 1 - Migrations through and including ${BOUNDARY_TS}"
+          for f in $(ls supabase/migrations/*.sql | sort); do
+            base=$(basename "$f")
+            ts=${base%%_*}
+            if [[ "$ts" > "$BOUNDARY_TS" ]]; then
+              echo "Stopping at $base (will apply after seed)"
+              break
+            fi
+            echo "Applying $base"
+            ${PSQL_CMD} -f "$f"
+          done
+          echo "::endgroup::"
+
+          echo "::group::Phase 2 - Seed permissions (mirrors dev/prod post-baseline state)"
+          ${PSQL_CMD} -f sql/99-seeds/001-permissions-seed.sql
+          echo "::endgroup::"
+
+          echo "::group::Phase 3 - Apply remaining migrations after ${BOUNDARY_TS}"
+          for f in $(ls supabase/migrations/*.sql | sort); do
+            base=$(basename "$f")
+            ts=${base%%_*}
+            if [[ "$ts" > "$BOUNDARY_TS" ]]; then
+              echo "Applying $base"
+              ${PSQL_CMD} -f "$f"
+            fi
+          done
+          echo "::endgroup::"
+
+          echo "::group::Phase 4 - Record applied migrations in supabase_migrations.schema_migrations"
+          # supabase db reset normally writes each migration's version into
+          # supabase_migrations.schema_migrations after applying it. We applied
+          # via psql, so we record them manually for consistency. The registry
+          # generator doesn't actually consult this table, but keeping it
+          # consistent prevents confusion in any subsequent step that might.
+          for f in $(ls supabase/migrations/*.sql | sort); do
+            base=$(basename "$f")
+            ts=${base%%_*}
+            ${PSQL_CMD} -c "INSERT INTO supabase_migrations.schema_migrations (version, name) VALUES ('${ts}', '${base%.sql}') ON CONFLICT DO NOTHING;" 2>/dev/null || true
+          done
+          echo "::endgroup::"
 
       - name: Regenerate registry against local container
         working-directory: frontend

--- a/frontend/docs-validation-report.json
+++ b/frontend/docs-validation-report.json
@@ -129,7 +129,7 @@
     "componentsDocumented": 0,
     "apisDocumented": 0
   },
-  "timestamp": "2026-05-06T03:24:20.923Z",
+  "timestamp": "2026-05-08T17:10:13.998Z",
   "summary": {
     "hasErrors": false,
     "hasWarnings": false,

--- a/frontend/src/pages/organizations/AcceptInvitationPage.tsx
+++ b/frontend/src/pages/organizations/AcceptInvitationPage.tsx
@@ -21,16 +21,10 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
   InvitationAcceptanceViewModel,
-  type AuthMethodSelection
+  type AuthMethodSelection,
 } from '@/viewModels/organization/InvitationAcceptanceViewModel';
 import { getAuthProvider } from '@/services/auth/AuthProviderFactory';
-import {
-  Building,
-  Mail,
-  AlertCircle,
-  CheckCircle,
-  Loader2
-} from 'lucide-react';
+import { Building, Mail, AlertCircle, CheckCircle, Loader2 } from 'lucide-react';
 import { Logger } from '@/utils/logger';
 
 const log = Logger.getLogger('component');
@@ -105,7 +99,7 @@ export const AcceptInvitationPage: React.FC = observer(() => {
 
     if (result?.redirectUrl) {
       log.info('Invitation accepted, redirecting', {
-        redirectUrl: result.redirectUrl
+        redirectUrl: result.redirectUrl,
       });
       handleRedirect(result.redirectUrl);
     }
@@ -140,13 +134,11 @@ export const AcceptInvitationPage: React.FC = observer(() => {
           backdropFilter: 'blur(20px)',
           WebkitBackdropFilter: 'blur(20px)',
           border: '1px solid rgba(255, 255, 255, 0.3)',
-          boxShadow: '0 8px 32px rgba(0, 0, 0, 0.1)'
+          boxShadow: '0 8px 32px rgba(0, 0, 0, 0.1)',
         }}
       >
         <CardHeader>
-          <CardTitle className="text-2xl text-center">
-            Accept Organization Invitation
-          </CardTitle>
+          <CardTitle className="text-2xl text-center">Accept Organization Invitation</CardTitle>
         </CardHeader>
 
         <CardContent>
@@ -164,16 +156,14 @@ export const AcceptInvitationPage: React.FC = observer(() => {
               className="p-4 rounded-lg mb-6"
               style={{
                 background: 'rgba(254, 242, 242, 0.9)',
-                border: '1px solid rgba(239, 68, 68, 0.3)'
+                border: '1px solid rgba(239, 68, 68, 0.3)',
               }}
             >
               <div className="flex items-center gap-3">
                 <AlertCircle className="text-red-500" size={24} />
                 <div>
                   <h4 className="font-semibold text-red-900">Invalid Invitation</h4>
-                  <p className="text-red-700 text-sm">
-                    {viewModel.validationError}
-                  </p>
+                  <p className="text-red-700 text-sm">{viewModel.validationError}</p>
                 </div>
               </div>
             </div>
@@ -187,7 +177,7 @@ export const AcceptInvitationPage: React.FC = observer(() => {
                 className="p-4 rounded-lg mb-6"
                 style={{
                   background: 'rgba(239, 246, 255, 0.9)',
-                  border: '1px solid rgba(59, 130, 246, 0.2)'
+                  border: '1px solid rgba(59, 130, 246, 0.2)',
                 }}
               >
                 <div className="flex items-center gap-3">
@@ -195,7 +185,7 @@ export const AcceptInvitationPage: React.FC = observer(() => {
                     className="p-2 rounded-full"
                     style={{
                       background: 'rgba(59, 130, 246, 0.2)',
-                      border: '1px solid rgba(59, 130, 246, 0.3)'
+                      border: '1px solid rgba(59, 130, 246, 0.3)',
                     }}
                   >
                     <Building className="text-blue-600" size={24} />
@@ -204,9 +194,15 @@ export const AcceptInvitationPage: React.FC = observer(() => {
                     <h3 className="font-semibold text-gray-900">
                       {viewModel.invitationDetails.orgName}
                     </h3>
-                    <p className="text-sm text-gray-600">
-                      Role: {viewModel.invitationDetails.role}
-                    </p>
+                    {viewModel.invitationDetails.roles.length > 0 && (
+                      <p className="text-sm text-gray-600">
+                        {viewModel.invitationDetails.roles.length === 1 ? 'Role' : 'Roles'}:{' '}
+                        {viewModel.invitationDetails.roles
+                          .map((r) => r.role_name)
+                          .filter(Boolean)
+                          .join(', ')}
+                      </p>
+                    )}
                     {viewModel.invitationDetails.inviterName && (
                       <p className="text-xs text-gray-500">
                         Invited by: {viewModel.invitationDetails.inviterName}
@@ -242,12 +238,7 @@ export const AcceptInvitationPage: React.FC = observer(() => {
                         : 'border-gray-200 hover:border-gray-300'
                     }`}
                   >
-                    <svg
-                      className="mx-auto mb-2"
-                      width="24"
-                      height="24"
-                      viewBox="0 0 24 24"
-                    >
+                    <svg className="mx-auto mb-2" width="24" height="24" viewBox="0 0 24 24">
                       <path
                         fill="#4285F4"
                         d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
@@ -288,9 +279,7 @@ export const AcceptInvitationPage: React.FC = observer(() => {
                       className={viewModel.emailError ? 'border-red-500' : ''}
                     />
                     {viewModel.emailError && (
-                      <p className="text-sm text-red-500">
-                        {viewModel.emailError}
-                      </p>
+                      <p className="text-sm text-red-500">{viewModel.emailError}</p>
                     )}
                   </div>
 
@@ -308,9 +297,7 @@ export const AcceptInvitationPage: React.FC = observer(() => {
                       className={viewModel.passwordError ? 'border-red-500' : ''}
                     />
                     {viewModel.passwordError && (
-                      <p className="text-sm text-red-500">
-                        {viewModel.passwordError}
-                      </p>
+                      <p className="text-sm text-red-500">{viewModel.passwordError}</p>
                     )}
                   </div>
 
@@ -325,14 +312,10 @@ export const AcceptInvitationPage: React.FC = observer(() => {
                       value={viewModel.confirmPassword}
                       onChange={(e) => viewModel.setConfirmPassword(e.target.value)}
                       placeholder="Confirm your password"
-                      className={
-                        viewModel.confirmPasswordError ? 'border-red-500' : ''
-                      }
+                      className={viewModel.confirmPasswordError ? 'border-red-500' : ''}
                     />
                     {viewModel.confirmPasswordError && (
-                      <p className="text-sm text-red-500">
-                        {viewModel.confirmPasswordError}
-                      </p>
+                      <p className="text-sm text-red-500">{viewModel.confirmPasswordError}</p>
                     )}
                   </div>
 
@@ -375,9 +358,7 @@ export const AcceptInvitationPage: React.FC = observer(() => {
                       className={viewModel.emailError ? 'border-red-500' : ''}
                     />
                     {viewModel.emailError && (
-                      <p className="text-sm text-red-500">
-                        {viewModel.emailError}
-                      </p>
+                      <p className="text-sm text-red-500">{viewModel.emailError}</p>
                     )}
                     <p className="text-xs text-gray-500">
                       Use the email associated with your Google account
@@ -416,12 +397,10 @@ export const AcceptInvitationPage: React.FC = observer(() => {
                   className="mt-4 p-3 rounded-lg"
                   style={{
                     background: 'rgba(254, 242, 242, 0.9)',
-                    border: '1px solid rgba(239, 68, 68, 0.3)'
+                    border: '1px solid rgba(239, 68, 68, 0.3)',
                   }}
                 >
-                  <p className="text-sm text-red-700">
-                    {viewModel.acceptanceError}
-                  </p>
+                  <p className="text-sm text-red-700">{viewModel.acceptanceError}</p>
                 </div>
               )}
             </div>

--- a/frontend/src/services/invitation/MockInvitationService.ts
+++ b/frontend/src/services/invitation/MockInvitationService.ts
@@ -20,7 +20,7 @@ import type { IInvitationService } from './IInvitationService';
 import type {
   InvitationDetails,
   UserCredentials,
-  AcceptInvitationResult
+  AcceptInvitationResult,
 } from '@/types/organization.types';
 
 /**
@@ -28,7 +28,7 @@ import type {
  */
 const STORAGE_KEYS = {
   INVITATIONS: 'mock_invitations',
-  ACCEPTED: 'mock_accepted_invitations'
+  ACCEPTED: 'mock_accepted_invitations',
 } as const;
 
 /**
@@ -38,7 +38,7 @@ interface MockInvitationData {
   token: string;
   orgName: string;
   orgId: string;
-  role: string;
+  roles: Array<{ role_id: string | null; role_name: string | null }>;
   inviterName: string;
   expiresAt: Date;
   email?: string;
@@ -82,10 +82,10 @@ export class MockInvitationService implements IInvitationService {
 
     return {
       orgName: invitation.orgName,
-      role: invitation.role,
+      roles: invitation.roles,
       inviterName: invitation.inviterName,
       expiresAt: new Date(invitation.expiresAt),
-      email: invitation.email
+      email: invitation.email,
     };
   }
 
@@ -122,13 +122,13 @@ export class MockInvitationService implements IInvitationService {
     // Mark invitation as accepted
     this.markInvitationAccepted(token);
 
-    // Determine redirect URL based on role
-    const redirectUrl = this.getRedirectUrlForRole(invitation.role);
+    // Determine redirect URL based on the first role (if any)
+    const redirectUrl = this.getRedirectUrlForRole(invitation.roles?.[0]?.role_name ?? null);
 
     return {
       userId,
       orgId: invitationData.orgId,
-      redirectUrl
+      redirectUrl,
     };
   }
 
@@ -162,10 +162,10 @@ export class MockInvitationService implements IInvitationService {
         token,
         orgName: 'Demo Organization',
         orgId: `org-${Date.now()}`,
-        role: 'provider_admin',
+        roles: [{ role_id: null, role_name: 'provider_admin' }],
         inviterName: 'System Administrator',
         expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000), // 7 days
-        email: `user-${Date.now()}@example.com`
+        email: `user-${Date.now()}@example.com`,
       };
 
       invitations.set(token, invitation);
@@ -222,24 +222,23 @@ export class MockInvitationService implements IInvitationService {
   private markInvitationAccepted(token: string): void {
     const accepted = this.getAcceptedInvitations();
     accepted.add(token);
-    localStorage.setItem(
-      STORAGE_KEYS.ACCEPTED,
-      JSON.stringify(Array.from(accepted))
-    );
+    localStorage.setItem(STORAGE_KEYS.ACCEPTED, JSON.stringify(Array.from(accepted)));
   }
 
   /**
-   * Get redirect URL based on user role
+   * Get redirect URL based on the user's first role name (or null if none).
    */
-  private getRedirectUrlForRole(role: string): string {
+  private getRedirectUrlForRole(roleName: string | null): string {
+    if (!roleName) return '/dashboard';
+
     const roleRedirects: Record<string, string> = {
       provider_admin: '/organizations/dashboard',
       organization_member: '/clients',
       clinician: '/clients',
-      viewer: '/dashboard'
+      viewer: '/dashboard',
     };
 
-    return roleRedirects[role] || '/dashboard';
+    return roleRedirects[roleName] || '/dashboard';
   }
 
   /**

--- a/frontend/src/services/invitation/SupabaseInvitationService.ts
+++ b/frontend/src/services/invitation/SupabaseInvitationService.ts
@@ -80,18 +80,18 @@ export class SupabaseInvitationService implements IInvitationService {
         throw new Error(errorWithRef);
       }
 
-      if (!data?.orgName || !data?.role) {
+      if (!data?.orgName || !Array.isArray(data?.roles)) {
         throw new Error('Invalid invitation response');
       }
 
       log.info('Invitation validated', {
         orgName: data.orgName,
-        role: data.role,
+        roleCount: data.roles.length,
       });
 
       return {
         orgName: data.orgName,
-        role: data.role,
+        roles: data.roles,
         inviterName: data.inviterName,
         expiresAt: new Date(data.expiresAt),
         email: data.email,

--- a/frontend/src/types/database.types.ts
+++ b/frontend/src/types/database.types.ts
@@ -627,7 +627,6 @@ export type Database = {
           organization_id: string
           organization_name: string
           phones: Json
-          role: string
           roles: Json
           status: string
           token: string
@@ -3225,7 +3224,6 @@ export type Database = {
           notification_preferences: Json
           organization_id: string
           phones: Json | null
-          role: string | null
           roles: Json | null
           status: string
           tags: string[] | null
@@ -3248,7 +3246,6 @@ export type Database = {
           notification_preferences?: Json
           organization_id: string
           phones?: Json | null
-          role?: string | null
           roles?: Json | null
           status?: string
           tags?: string[] | null
@@ -3271,7 +3268,6 @@ export type Database = {
           notification_preferences?: Json
           organization_id?: string
           phones?: Json | null
-          role?: string | null
           roles?: Json | null
           status?: string
           tags?: string[] | null

--- a/frontend/src/types/organization.types.ts
+++ b/frontend/src/types/organization.types.ts
@@ -266,11 +266,18 @@ export interface DraftSummary {
 }
 
 /**
- * Invitation details returned from token validation
+ * Invitation details returned from token validation.
+ *
+ * `roles` mirrors the JSONB array on `invitations_projection.roles`. Each
+ * entry can have `role_name: null` for invitations created without a role
+ * (the "permissions assigned later" path supported by `invite-user`). An
+ * empty array means no role was specified at invitation time. The deprecated
+ * singular `role` column was dropped 2026-05-08 (migration
+ * 20260508170054_drop_invitations_deprecated_role_column).
  */
 export interface InvitationDetails {
   orgName: string;
-  role: string;
+  roles: Array<{ role_id: string | null; role_name: string | null }>;
   inviterName: string;
   expiresAt: Date;
   email?: string; // Pre-fill email if available

--- a/frontend/src/viewModels/organization/InvitationAcceptanceViewModel.ts
+++ b/frontend/src/viewModels/organization/InvitationAcceptanceViewModel.ts
@@ -26,11 +26,7 @@ import { makeAutoObservable, runInAction } from 'mobx';
 import type { IInvitationService } from '@/services/invitation/IInvitationService';
 import { InvitationServiceFactory } from '@/services/invitation/InvitationServiceFactory';
 import type { IAuthProvider } from '@/services/auth/IAuthProvider';
-import type {
-  InvitationDetails,
-  UserCredentials,
-  AcceptInvitationResult
-} from '@/types';
+import type { InvitationDetails, UserCredentials, AcceptInvitationResult } from '@/types';
 import type { OAuthProvider, InvitationAuthContext } from '@/types/auth.types';
 import { getAuthContextStorage } from '@/services/storage';
 import { detectPlatform, getCallbackUrl } from '@/utils/platform';
@@ -82,9 +78,7 @@ export class InvitationAcceptanceViewModel {
    *
    * @param invitationService - Invitation operations (defaults to factory-created instance)
    */
-  constructor(
-    private invitationService: IInvitationService = InvitationServiceFactory.create()
-  ) {
+  constructor(private invitationService: IInvitationService = InvitationServiceFactory.create()) {
     makeAutoObservable(this);
     log.debug('InvitationAcceptanceViewModel initialized');
   }
@@ -119,16 +113,13 @@ export class InvitationAcceptanceViewModel {
 
         log.info('Invitation token validated', {
           orgName: details.orgName,
-          role: details.role
+          roleCount: details.roles.length,
         });
       });
 
       return true;
     } catch (error) {
-      const errorMessage =
-        error instanceof Error
-          ? error.message
-          : 'Failed to validate invitation';
+      const errorMessage = error instanceof Error ? error.message : 'Failed to validate invitation';
 
       runInAction(() => {
         this.isValidatingToken = false;
@@ -243,7 +234,7 @@ export class InvitationAcceptanceViewModel {
 
     return this.acceptInvitation({
       email: this.email,
-      password: this.password
+      password: this.password,
     });
   }
 
@@ -285,7 +276,7 @@ export class InvitationAcceptanceViewModel {
       flow: 'invitation_acceptance',
       authMethod: { type: 'oauth', provider },
       platform,
-      createdAt: Date.now(),  // For TTL validation
+      createdAt: Date.now(), // For TTL validation
     };
 
     try {
@@ -338,13 +329,10 @@ export class InvitationAcceptanceViewModel {
     try {
       log.info('Accepting invitation', {
         authMethod: this.authMethodSelection,
-        email: credentials.email
+        email: credentials.email,
       });
 
-      const result = await this.invitationService.acceptInvitation(
-        this.token,
-        credentials
-      );
+      const result = await this.invitationService.acceptInvitation(this.token, credentials);
 
       runInAction(() => {
         this.acceptanceResult = result;
@@ -353,13 +341,12 @@ export class InvitationAcceptanceViewModel {
 
       log.info('Invitation accepted successfully', {
         userId: result.userId,
-        orgId: result.orgId
+        orgId: result.orgId,
       });
 
       return result;
     } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Failed to accept invitation';
+      const errorMessage = error instanceof Error ? error.message : 'Failed to accept invitation';
 
       runInAction(() => {
         this.isAccepting = false;
@@ -412,11 +399,7 @@ export class InvitationAcceptanceViewModel {
    * Computed: Can submit
    */
   get canSubmit(): boolean {
-    return (
-      this.isTokenValid &&
-      !this.isAccepting &&
-      this.email.trim().length > 0
-    );
+    return this.isTokenValid && !this.isAccepting && this.email.trim().length > 0;
   }
 
   /**

--- a/infrastructure/supabase/handlers/user/handle_user_invited.sql
+++ b/infrastructure/supabase/handlers/user/handle_user_invited.sql
@@ -10,7 +10,7 @@ BEGIN
 
   INSERT INTO invitations_projection (
     invitation_id, organization_id, email, first_name, last_name,
-    role, roles, token, expires_at, status,
+    roles, token, expires_at, status,
     access_start_date, access_expiration_date, notification_preferences,
     phones, correlation_id, tags, created_at, updated_at
   ) VALUES (
@@ -19,7 +19,6 @@ BEGIN
     safe_jsonb_extract_text(p_event.event_data, 'email'),
     safe_jsonb_extract_text(p_event.event_data, 'first_name'),
     safe_jsonb_extract_text(p_event.event_data, 'last_name'),
-    safe_jsonb_extract_text(p_event.event_data, 'role'),
     COALESCE(p_event.event_data->'roles', '[]'::jsonb),
     safe_jsonb_extract_text(p_event.event_data, 'token'),
     safe_jsonb_extract_timestamp(p_event.event_data, 'expires_at'),

--- a/infrastructure/supabase/supabase/functions/accept-invitation/index.ts
+++ b/infrastructure/supabase/supabase/functions/accept-invitation/index.ts
@@ -27,7 +27,7 @@ import {
 import { buildEventMetadata } from '../_shared/emit-event.ts';
 
 // Deployment version tracking
-const DEPLOY_VERSION = 'v21-frontend-index-space-fix';
+const DEPLOY_VERSION = 'v22-roles-array';
 
 // CORS headers for frontend requests
 const corsHeaders = standardCorsHeaders;
@@ -707,16 +707,15 @@ serve(async (req) => {
     // This populates user_roles_projection via process_user_event() trigger
     // ==========================================================================
 
-    // Get roles from new format (roles array) or legacy format (single role string)
+    // Roles to assign on acceptance. The legacy singular `role` fallback was
+    // removed 2026-05-08 along with the deprecated invitations_projection.role
+    // column (migration 20260508170054). Empty array is a legitimate state
+    // ("permissions assigned later" — the invite-user contract supports this).
     interface RoleRef {
       role_id: string | null;
       role_name: string;
     }
-    const roles: RoleRef[] = invitation.roles?.length > 0
-      ? invitation.roles
-      : invitation.role
-        ? [{ role_id: null, role_name: invitation.role }]
-        : [];
+    const roles: RoleRef[] = Array.isArray(invitation.roles) ? invitation.roles : [];
 
     console.log(`[accept-invitation v${DEPLOY_VERSION}] Processing ${roles.length} role(s) from invitation`);
 
@@ -925,7 +924,11 @@ serve(async (req) => {
       console.log(`[accept-invitation v${DEPLOY_VERSION}] ✓ Notification preferences set for user ${userId}, event_id=${prefsEventId}`);
     }
 
-    // Emit invitation.accepted event per AsyncAPI contract
+    // Emit invitation.accepted event per AsyncAPI contract.
+    // Note: the deprecated singular `role` field is intentionally NOT emitted -
+    // the AsyncAPI contract for InvitationAcceptedData only specifies the fields
+    // below (no `role` and no `roles`). Removed 2026-05-08 alongside the
+    // invitations_projection.role column drop.
     const { data: _acceptedEventId, error: acceptedEventError } = await supabase
       .rpc('emit_domain_event', {
         p_stream_id: invitation.id,
@@ -936,7 +939,6 @@ serve(async (req) => {
           org_id: invitation.organization_id,
           user_id: userId,
           email: invitation.email,
-          role: invitation.role,
           accepted_at: new Date().toISOString(),
         },
         p_event_metadata: buildEventMetadata(tracingContext, 'invitation.accepted', req, {

--- a/infrastructure/supabase/supabase/functions/accept-invitation/index.ts
+++ b/infrastructure/supabase/supabase/functions/accept-invitation/index.ts
@@ -27,7 +27,7 @@ import {
 import { buildEventMetadata } from '../_shared/emit-event.ts';
 
 // Deployment version tracking
-const DEPLOY_VERSION = 'v22-roles-array';
+const DEPLOY_VERSION = 'v23-asyncapi-roles-emit';
 
 // CORS headers for frontend requests
 const corsHeaders = standardCorsHeaders;
@@ -711,28 +711,58 @@ serve(async (req) => {
     // removed 2026-05-08 along with the deprecated invitations_projection.role
     // column (migration 20260508170054). Empty array is a legitimate state
     // ("permissions assigned later" — the invite-user contract supports this).
+    //
+    // RoleRef.role_name is intentionally `string | null` to align with the upstream
+    // type surface (InvitationDetails.roles[].role_name, validate-invitation's
+    // InvitationRoleRef, MockInvitationData). Both fields nullable means a
+    // malformed entry can carry no identifying info; we guard for that explicitly
+    // below.
     interface RoleRef {
       role_id: string | null;
-      role_name: string;
+      role_name: string | null;
     }
     const roles: RoleRef[] = Array.isArray(invitation.roles) ? invitation.roles : [];
 
     console.log(`[accept-invitation v${DEPLOY_VERSION}] Processing ${roles.length} role(s) from invitation`);
 
+    // Track resolved roles for the AsyncAPI-required `roles` field on the
+    // invitation.accepted emit below. Each entry MUST have a non-null role_id
+    // (RoleAssignment schema requires it). `role_name` is optional in the schema
+    // and is OMITTED rather than emitted as null when missing - the schema's
+    // `role_name: type: string` does not declare nullable, so absent-when-null
+    // is the correct conformance shape.
+    const resolvedRoles: Array<{ role_id: string; role_name?: string }> = [];
+
     for (const role of roles) {
       const roleName = role.role_name;
       let roleId = role.role_id;
 
+      // Malformed entry: no identifying info. Fail noisily rather than passing
+      // NULL to api.get_role_by_name (which would silently return zero rows and
+      // surface as a confusing role_lookup_failed for "null"). Aligns the actual
+      // failure mode with what an operator can act on.
+      if (!roleId && !roleName) {
+        console.error(`[accept-invitation v${DEPLOY_VERSION}] Malformed role entry on invitation ${invitation.id}: both role_id and role_name are null`);
+        return new Response(
+          JSON.stringify({
+            error: 'malformed_role_entry',
+            message: 'Invitation contains a role entry with no role_id and no role_name. Contact administrator.',
+          }),
+          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+
       // CRITICAL: role_id is NOT NULL in user_roles_projection
       // Must resolve role_id if not provided
       if (!roleId) {
+        // roleName is non-null here (the malformed-entry guard above ensures it).
         console.log(`[accept-invitation v${DEPLOY_VERSION}] Looking up role_id for role_name: ${roleName}, org: ${invitation.organization_id}`);
 
         // Use RPC function in api schema (follows CQRS pattern)
         const { data: roleResults, error: lookupError } = await supabase
           .rpc('get_role_by_name', {
             p_org_id: invitation.organization_id,
-            p_role_name: roleName
+            p_role_name: roleName as string,
           });
 
         const roleData = roleResults?.[0];
@@ -752,6 +782,17 @@ serve(async (req) => {
         roleId = roleData.id;
         console.log(`[accept-invitation v${DEPLOY_VERSION}] Resolved role "${roleName}" to id: ${roleId}`);
       }
+
+      // Track for the invitation.accepted event_data emit below.
+      // roleId is non-null here (either pre-supplied or just resolved above).
+      // role_name is omitted when null per the AsyncAPI RoleAssignment schema.
+      const resolvedEntry: { role_id: string; role_name?: string } = {
+        role_id: roleId as string,
+      };
+      if (roleName !== null) {
+        resolvedEntry.role_name = roleName;
+      }
+      resolvedRoles.push(resolvedEntry);
 
       // Emit user.role.assigned event
       const { data: roleEventId, error: roleError } = await supabase
@@ -925,10 +966,12 @@ serve(async (req) => {
     }
 
     // Emit invitation.accepted event per AsyncAPI contract.
-    // Note: the deprecated singular `role` field is intentionally NOT emitted -
-    // the AsyncAPI contract for InvitationAcceptedData only specifies the fields
-    // below (no `role` and no `roles`). Removed 2026-05-08 alongside the
-    // invitations_projection.role column drop.
+    // Required fields per infrastructure/supabase/contracts/asyncapi/domains/invitation.yaml
+    // InvitationAcceptedData: invitation_id, org_id, user_id, email, roles, accepted_at.
+    // The `roles` snapshot uses RESOLVED role_ids (the AsyncAPI RoleAssignment schema
+    // requires a non-null role_id; we resolve any null IDs above via api.get_role_by_name).
+    // The deprecated singular `role` field is no longer emitted - not in the schema.
+    // Updated 2026-05-08 alongside the invitations_projection.role column drop.
     const { data: _acceptedEventId, error: acceptedEventError } = await supabase
       .rpc('emit_domain_event', {
         p_stream_id: invitation.id,
@@ -939,6 +982,7 @@ serve(async (req) => {
           org_id: invitation.organization_id,
           user_id: userId,
           email: invitation.email,
+          roles: resolvedRoles,
           accepted_at: new Date().toISOString(),
         },
         p_event_metadata: buildEventMetadata(tracingContext, 'invitation.accepted', req, {

--- a/infrastructure/supabase/supabase/functions/validate-invitation/index.ts
+++ b/infrastructure/supabase/supabase/functions/validate-invitation/index.ts
@@ -22,10 +22,15 @@ import {
 import { extractTracingContext } from '../_shared/tracing-context.ts';
 
 // Deployment version tracking
-const DEPLOY_VERSION = 'v10-tracing';
+const DEPLOY_VERSION = 'v11-roles-array';
 
 // CORS headers for frontend requests
 const corsHeaders = standardCorsHeaders;
+
+interface InvitationRoleRef {
+  role_id: string | null;
+  role_name: string | null;
+}
 
 interface InvitationValidation {
   valid: boolean;
@@ -33,7 +38,9 @@ interface InvitationValidation {
   email: string;
   orgName: string;  // Frontend expects orgName, not organizationName
   organizationId: string;
-  role: string;  // Frontend expects role
+  // `roles` mirrors the JSONB array on invitations_projection.roles.
+  // Empty array is a legitimate state ("permissions assigned later").
+  roles: InvitationRoleRef[];
   expiresAt: string;
   expired: boolean;
   alreadyAccepted: boolean;
@@ -133,14 +140,16 @@ serve(async (req) => {
     const alreadyAccepted = invitation.accepted_at !== null;
 
     // Build validation response
-    // Frontend expects: orgName, role (not organizationName)
+    // Frontend expects: orgName, roles[] (the JSONB array from invitations_projection.roles).
+    // The deprecated singular `role` column was dropped 2026-05-08
+    // (migration 20260508170054_drop_invitations_deprecated_role_column).
     const response: InvitationValidation = {
       valid: !expired && !alreadyAccepted,
       token,
       email: invitation.email,
       orgName,
       organizationId: invitation.organization_id,
-      role: invitation.role,
+      roles: Array.isArray(invitation.roles) ? invitation.roles : [],
       expiresAt: invitation.expires_at,
       expired,
       alreadyAccepted,

--- a/infrastructure/supabase/supabase/migrations/20260508170054_drop_invitations_deprecated_role_column.sql
+++ b/infrastructure/supabase/supabase/migrations/20260508170054_drop_invitations_deprecated_role_column.sql
@@ -1,0 +1,170 @@
+-- =============================================================================
+-- Drop deprecated `role` column from invitations_projection
+-- =============================================================================
+-- The singular `role` column was deprecated at the Day 0 v4 baseline (see
+-- comment at baseline_v4.sql:12918) but kept for "backward compatibility with
+-- bootstrap workflow." In practice no current emitter populates it:
+--   - invite-user Edge Function emits `roles[]` only.
+--   - bootstrap workflow (workflows/.../generate-invitations.ts) emits
+--     `roles: [{role_id, role_name}]`.
+--   - handle_user_invited writes safe_jsonb_extract_text(event_data, 'role')
+--     which is always NULL for the above emitters.
+--
+-- The column's continued presence created a contract bug: api.get_invitation_by_token
+-- COALESCEd from i.role first, returned NULL, the validate-invitation Edge Function
+-- forwarded `role: null`, and the frontend's SupabaseInvitationService threw
+-- "Invalid invitation response" on `!data?.role`. Fix is to drop the column,
+-- update the read RPC and handler, and migrate the frontend to consume the
+-- existing `roles` JSONB array directly.
+--
+-- WRITE-SITE AUDIT (verified before this migration):
+--   * public.handle_user_invited(record)                      - writes role; UPDATED HERE.
+--   * public.process_invitation_event(record) WHEN 'user.invited' (baseline_v4:11064)
+--       - second INSERT site, but does NOT reference role. Verified dead code:
+--       all current emitters set stream_type='user', which routes via
+--       process_user_event -> handle_user_invited; this branch is never reached.
+--   * public.process_invitation_event(record) WHEN 'invitation.accepted/revoked/expired'
+--       (baseline_v4:11116/11127/11137) - UPDATEs only status/accepted_at/updated_at.
+--       No role reference.
+--
+-- READ-SITE AUDIT:
+--   * api.get_invitation_by_token(text)        - returns role; DROP+CREATE HERE.
+--   * api.get_invitation_by_org_and_email(...)  - verified, does NOT return role.
+--   * api.list_invitations(...)                 - verified, does NOT return role.
+--
+-- This migration is destructive (DROP COLUMN). A defensive backfill step
+-- ensures any legacy row with role IS NOT NULL gets its data preserved into
+-- the roles[] array before the column is dropped.
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- Step 1: Update handle_user_invited to stop writing the role column.
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.handle_user_invited(p_event record)
+ RETURNS void
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $function$
+DECLARE
+  v_correlation_id UUID;
+BEGIN
+  v_correlation_id := (p_event.event_metadata->>'correlation_id')::UUID;
+
+  INSERT INTO invitations_projection (
+    invitation_id, organization_id, email, first_name, last_name,
+    roles, token, expires_at, status,
+    access_start_date, access_expiration_date, notification_preferences,
+    phones, correlation_id, tags, created_at, updated_at
+  ) VALUES (
+    safe_jsonb_extract_uuid(p_event.event_data, 'invitation_id'),
+    safe_jsonb_extract_uuid(p_event.event_data, 'org_id'),
+    safe_jsonb_extract_text(p_event.event_data, 'email'),
+    safe_jsonb_extract_text(p_event.event_data, 'first_name'),
+    safe_jsonb_extract_text(p_event.event_data, 'last_name'),
+    COALESCE(p_event.event_data->'roles', '[]'::jsonb),
+    safe_jsonb_extract_text(p_event.event_data, 'token'),
+    safe_jsonb_extract_timestamp(p_event.event_data, 'expires_at'),
+    'pending',
+    (p_event.event_data->>'access_start_date')::DATE,
+    (p_event.event_data->>'access_expiration_date')::DATE,
+    COALESCE(
+      p_event.event_data->'notification_preferences',
+      '{"email": true, "sms": {"enabled": false, "phoneId": null}, "inApp": false}'::jsonb
+    ),
+    COALESCE(p_event.event_data->'phones', '[]'::jsonb),
+    v_correlation_id,
+    COALESCE(ARRAY(SELECT jsonb_array_elements_text(p_event.event_data->'tags')), '{}'::TEXT[]),
+    p_event.created_at,
+    p_event.created_at
+  ) ON CONFLICT (invitation_id) DO UPDATE SET
+    token = EXCLUDED.token,
+    expires_at = EXCLUDED.expires_at,
+    status = 'pending',
+    phones = EXCLUDED.phones,
+    notification_preferences = EXCLUDED.notification_preferences,
+    correlation_id = COALESCE(invitations_projection.correlation_id, EXCLUDED.correlation_id),
+    updated_at = EXCLUDED.updated_at;
+END;
+$function$;
+
+-- -----------------------------------------------------------------------------
+-- Step 2: DROP + CREATE api.get_invitation_by_token without `role` field.
+--
+-- Signature change requires DROP. Re-issue grants and the @a4c-rpc-shape
+-- tag (DROP loses both per supabase/CLAUDE.md § "DROP + CREATE re-tag rule").
+-- -----------------------------------------------------------------------------
+DROP FUNCTION IF EXISTS api.get_invitation_by_token(text);
+
+CREATE OR REPLACE FUNCTION api.get_invitation_by_token(p_token text)
+RETURNS TABLE(
+  "id" uuid,
+  "token" text,
+  "email" text,
+  "organization_id" uuid,
+  "organization_name" text,
+  "roles" jsonb,
+  "first_name" text,
+  "last_name" text,
+  "status" text,
+  "expires_at" timestamp with time zone,
+  "accepted_at" timestamp with time zone,
+  "correlation_id" uuid,
+  "contact_id" uuid,
+  "phones" jsonb,
+  "notification_preferences" jsonb
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    i.id,
+    i.token,
+    i.email,
+    i.organization_id,
+    o.name AS organization_name,
+    COALESCE(i.roles, '[]'::jsonb) AS roles,
+    i.first_name,
+    i.last_name,
+    i.status,
+    i.expires_at,
+    i.accepted_at,
+    i.correlation_id,
+    i.contact_id,
+    COALESCE(i.phones, '[]'::jsonb) AS phones,
+    COALESCE(i.notification_preferences, '{"email": true, "sms": {"enabled": false, "phoneId": null}, "inApp": false}'::jsonb) AS notification_preferences
+  FROM public.invitations_projection i
+  LEFT JOIN public.organizations_projection o ON o.id = i.organization_id
+  WHERE i.token = p_token;
+END;
+$$;
+
+ALTER FUNCTION api.get_invitation_by_token(text) OWNER TO postgres;
+
+GRANT EXECUTE ON FUNCTION api.get_invitation_by_token(text) TO anon;
+GRANT EXECUTE ON FUNCTION api.get_invitation_by_token(text) TO authenticated;
+GRANT EXECUTE ON FUNCTION api.get_invitation_by_token(text) TO service_role;
+
+COMMENT ON FUNCTION api.get_invitation_by_token(text) IS
+$comment$Get invitation details by token for validation. Returns correlation_id for lifecycle tracing, contact_id for contact-user linking, first_name/last_name/roles for user creation, and phones/notification_preferences for Phase 6 invitation flow.
+
+@a4c-rpc-shape: read$comment$;
+
+-- -----------------------------------------------------------------------------
+-- Step 3: Defensive backfill - preserve any legacy role-only data into roles[]
+-- before dropping the column. No-op on a clean DB; protects against any
+-- unknown legacy rows that have role IS NOT NULL with empty roles[].
+-- -----------------------------------------------------------------------------
+UPDATE public.invitations_projection
+SET roles = jsonb_build_array(
+  jsonb_build_object('role_id', NULL, 'role_name', role)
+)
+WHERE role IS NOT NULL
+  AND (roles IS NULL OR roles = '[]'::jsonb);
+
+-- -----------------------------------------------------------------------------
+-- Step 4: Drop the deprecated column.
+-- -----------------------------------------------------------------------------
+ALTER TABLE public.invitations_projection DROP COLUMN IF EXISTS role;

--- a/workflows/src/scripts/query-dev.ts
+++ b/workflows/src/scripts/query-dev.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck - Schema mismatch with generated types (status/subdomain columns changed)
 /**
  * Query Development Entities
@@ -41,10 +42,18 @@ interface Invitation {
   email: string;
   organization_id: string;
   status: string;
-  role: string;
+  roles: Array<{ role_id: string | null; role_name: string | null }>;
   tags: string[];
   created_at: string;
   expires_at: string;
+}
+
+function formatRoles(roles: Invitation['roles']): string {
+  if (!roles || roles.length === 0) return '(no roles)';
+  return roles
+    .map(r => r.role_name)
+    .filter((n): n is string => Boolean(n))
+    .join(';');
 }
 
 interface QueryResult {
@@ -192,7 +201,7 @@ function formatAsTable(result: QueryResult, tag: string): void {
       console.log(
         email.padEnd(35) +
         (isExpired ? inv.status + ' (EXPIRED)' : inv.status).padEnd(15) +
-        inv.role.padEnd(20) +
+        formatRoles(inv.roles).padEnd(20) +
         expiresStr
       );
 
@@ -253,7 +262,7 @@ function formatAsCSV(result: QueryResult): void {
 
   console.log('');
   console.log('# Invitations');
-  console.log('invitation_id,email,organization_id,status,role,created_at,expires_at,tags');
+  console.log('invitation_id,email,organization_id,status,roles,created_at,expires_at,tags');
 
   result.invitations.forEach(inv => {
     console.log([
@@ -261,7 +270,7 @@ function formatAsCSV(result: QueryResult): void {
       inv.email,
       inv.organization_id,
       inv.status,
-      inv.role,
+      `"${formatRoles(inv.roles)}"`,
       inv.created_at,
       inv.expires_at,
       `"${inv.tags.join(';')}"`
@@ -321,7 +330,7 @@ async function main() {
 
 // Run if executed directly
 if (require.main === module) {
-  main();
+  void main();
 }
 
 export { query, queryDevelopmentEntities };

--- a/workflows/src/types/database.types.ts
+++ b/workflows/src/types/database.types.ts
@@ -627,7 +627,6 @@ export type Database = {
           organization_id: string
           organization_name: string
           phones: Json
-          role: string
           roles: Json
           status: string
           token: string
@@ -3225,7 +3224,6 @@ export type Database = {
           notification_preferences: Json
           organization_id: string
           phones: Json | null
-          role: string | null
           roles: Json | null
           status: string
           tags: string[] | null
@@ -3248,7 +3246,6 @@ export type Database = {
           notification_preferences?: Json
           organization_id: string
           phones?: Json | null
-          role?: string | null
           roles?: Json | null
           status?: string
           tags?: string[] | null
@@ -3271,7 +3268,6 @@ export type Database = {
           notification_preferences?: Json
           organization_id?: string
           phones?: Json | null
-          role?: string | null
           roles?: Json | null
           status?: string
           tags?: string[] | null


### PR DESCRIPTION
## Summary

- Drops the deprecated `invitations_projection.role` column (tagged DEPRECATED in baseline_v4 line 12918, never populated by any current emitter).
- Migrates the validate-invitation Edge Function response and the frontend `InvitationDetails` type from singular `role: string` to plural `roles: Array<{role_id, role_name}>`, matching the existing JSONB column and the AsyncAPI contracts (which already use `roles[]` exclusively).
- Removes a silent AsyncAPI conformance violation in `accept-invitation` (the `invitation.accepted` event_data was emitting `role: invitation.role` despite the contract for `InvitationAcceptedData` never specifying that field).

## Defect

When a user clicks an invitation email link, the page rendered:

> Invalid Invitation
> Invalid invitation response

Root cause: `api.get_invitation_by_token` returned `role: null` (the singular column was always NULL for current emitters). The frontend's `SupabaseInvitationService` threw on `!data?.role`, even though `role: null` is a legitimate state per the `invite-user` contract ("permissions assigned later" - empty `roles[]`).

## Changes

| Layer | File | Change |
|---|---|---|
| **Migration** | `infrastructure/supabase/supabase/migrations/20260508170054_drop_invitations_deprecated_role_column.sql` | NEW: handler update + RPC DROP/CREATE + defensive backfill + DROP COLUMN |
| **Handler ref** | `infrastructure/supabase/handlers/user/handle_user_invited.sql` | Removed `role` from INSERT |
| **Edge Fn** | `infrastructure/supabase/supabase/functions/validate-invitation/index.ts` | Response shape `role` → `roles[]`; v11-roles-array |
| **Edge Fn** | `infrastructure/supabase/supabase/functions/accept-invitation/index.ts` | Dropped singular fallback + `role` from event_data; v22-roles-array |
| **Frontend** | `frontend/src/types/organization.types.ts` | `InvitationDetails.role` → `roles[]` |
| **Frontend** | `frontend/src/services/invitation/SupabaseInvitationService.ts` | Guard + mapping |
| **Frontend** | `frontend/src/services/invitation/MockInvitationService.ts` | 5 sites |
| **Frontend** | `frontend/src/pages/organizations/AcceptInvitationPage.tsx` | Conditional list render |
| **Frontend** | `frontend/src/viewModels/organization/InvitationAcceptanceViewModel.ts` | Logging field |
| **Workflows** | `workflows/src/scripts/query-dev.ts` | Type + table + CSV |
| **Both** | `*/types/database.types.ts` | Regen (byte-identical) |

## Architect review

Reviewed by `software-architect-dbc` agent during plan mode. Ten findings; all incorporated:
- **#1 BLOCKER**: write-site audit added to migration header (verified `process_invitation_event` `WHEN 'user.invited'` INSERT at baseline_v4:11064 is dead code and already correct).
- **#3 HIGH**: removed legacy `'roleName'` (camelCase) COALESCE arm from new RPC body too.
- **#5 MEDIUM**: `MockInvitationService` site count corrected from 2 to 5.
- **#8 MEDIUM**: defensive `UPDATE` backfill before `DROP COLUMN` (no-op on this DB; safety net for legacy rows).
- Other findings: confirmed in plan or addressed mechanically.

## Deployment status (already applied to dev)

The destructive operations were already executed against the linked dev project as part of the in-band fix flow:

- ✅ Migration applied (`supabase db push --linked`).
- ✅ Both Edge Functions deployed (`supabase functions deploy validate-invitation`, `supabase functions deploy accept-invitation`).
- ✅ `database.types.ts` regenerated (frontend + workflows byte-identical).

This PR is the source-of-truth commit for those already-shipped changes plus the frontend/workflows code that must deploy via CI to take effect on `firstovertheline.com`.

## Verification

**Live wire-level check** (post-deploy):
```bash
$ curl -sS -X POST "$SUPABASE_URL/functions/v1/validate-invitation" \
    -H "Authorization: Bearer $ANON_KEY" -H "apikey: $ANON_KEY" \
    -d '{"token":"<failing-token>"}'
{"valid":true,"orgName":"TestOrg-20260329","roles":[],...}
```

No more `role: null`; `roles: []` is the new shape.

**Local gates** (all passing on this branch):
- `frontend`: typecheck ✓, lint ✓, build ✓, docs:check ✓
- `workflows`: build ✓, 12/12 tests ✓

## Test plan

- [ ] Frontend deploys via `frontend-deploy.yml` on merge.
- [ ] Reload the failing invitation URL on `firstovertheline.com` → page renders org name "TestOrg-20260329", omits the role line (since `roles[]` is empty), shows the auth-method picker. No red "Invalid Invitation" banner.
- [ ] Test a fresh invitation **with** a role assigned → role line renders correctly.
- [ ] DB sanity: `SELECT event_data ? 'role' FROM domain_events WHERE event_type = 'invitation.accepted' ORDER BY created_at DESC LIMIT 5` returns all `false` for new acceptance events.
- [ ] CI gates: rpc-registry-sync workflow stays green (registry already lists `get_invitation_by_token` as `read`; my migration re-issued the same tag).
- [ ] Resume modify_user_roles UAT (Scenarios 1, 3, 4, 6, 7, 8, 9, 10) which was blocked by this defect.

## What this kills

- Dead column in production schema.
- Always-null event_data field (silent AsyncAPI conformance violation).
- COALESCE-from-array fallback in `get_invitation_by_token` whose first argument was always NULL.
- Dead-code fallback in `accept-invitation` defending against an impossible state.
- The data-model lie that "an invitation has one role string."

🤖 Generated with [Claude Code](https://claude.com/claude-code)