### PR TITLE
fix(users): rich error surfacing on user-edit form (PR #54 follow-up, UAT S4)

### DIFF
--- a/frontend/docs-validation-report.json
+++ b/frontend/docs-validation-report.json
@@ -129,7 +129,7 @@
     "componentsDocumented": 0,
     "apisDocumented": 0
   },
-  "timestamp": "2026-05-08T17:10:13.998Z",
+  "timestamp": "2026-05-11T18:20:09.487Z",
   "summary": {
     "hasErrors": false,
     "hasWarnings": false,

--- a/frontend/docs-validation-report.json
+++ b/frontend/docs-validation-report.json
@@ -129,7 +129,7 @@
     "componentsDocumented": 0,
     "apisDocumented": 0
   },
-  "timestamp": "2026-05-11T18:20:09.487Z",
+  "timestamp": "2026-05-11T19:32:42.708Z",
   "summary": {
     "hasErrors": false,
     "hasWarnings": false,

--- a/frontend/src/pages/users/UsersManagePage.tsx
+++ b/frontend/src/pages/users/UsersManagePage.tsx
@@ -343,7 +343,11 @@ export const UsersManagePage: React.FC = observer(() => {
       if (!formViewModel) return;
 
       const commandService = getUserCommandService();
-      const result = await formViewModel.submit(commandService);
+      // Pass the page VM as the second arg so that role-modification failures
+      // (violations / partial) populate `viewModel.lastRoleViolations` and
+      // `viewModel.lastRolePartialFailure` for the rich UsersErrorBanner.
+      // See UserFormViewModel.submit's JSDoc for the funnel-through rationale.
+      const result = await formViewModel.submit(commandService, viewModel);
 
       if (result.success) {
         log.info('Form submitted successfully', { mode: panelMode });

--- a/frontend/src/viewModels/users/UserFormViewModel.ts
+++ b/frontend/src/viewModels/users/UserFormViewModel.ts
@@ -32,12 +32,13 @@ import type {
   RoleReference,
   InviteUserResult,
   UpdateUserResult,
-  UserVoidResult,
+  ModifyUserRolesResult,
   EmailLookupResult,
   NotificationPreferences,
   InvitationPhone,
   UserListItem,
 } from '@/types/user.types';
+import type { UsersViewModel } from './UsersViewModel';
 import {
   validateEmail,
   validateFirstName,
@@ -893,20 +894,24 @@ export class UserFormViewModel {
    * Submit the form
    *
    * In create mode: Sends invitation via commandService.inviteUser()
-   * In edit mode: Updates user profile via commandService.updateUser()
+   * In edit mode: Updates user profile via commandService.updateUser(), then
+   * (if profile update succeeded and roles changed) delegates role modification
+   * to `usersViewModel.modifyRoles(...)` — the page-level handler that owns
+   * `lastRoleViolations` / `lastRolePartialFailure` state for the rich
+   * `UsersErrorBanner` rendering. Going through the page VM (instead of calling
+   * `commandService.modifyRoles` directly) is the single source of truth for
+   * role-modification error surfacing: violation/partial detail flows to the
+   * page banner, the form's `submissionError` is suppressed when the banner
+   * owns it.
    *
-   * Return union intentionally contains UserVoidResult: on edit mode, if
-   * profile update succeeds but subsequent modifyRoles() fails, `result` is
-   * reassigned to the modifyRoles UserVoidResult so consumers see the
-   * role-modification error (see the `result = roleResult` reassignment
-   * around line 969 below). Dropping UserVoidResult here would force a
-   * later consumer to either cast or narrow via success-property access.
-   * PR #32 review item 6 proposed removing this arm as "phantom"; it is
-   * structurally necessary.
+   * Return union: on edit mode with role changes, `result` is reassigned to
+   * the modifyRoles result when role modification fails, so callers see the
+   * role error (rich `violations` / `partial` fields on `ModifyUserRolesResult`).
    */
   async submit(
-    commandService: IUserCommandService
-  ): Promise<InviteUserResult | UpdateUserResult | UserVoidResult> {
+    commandService: IUserCommandService,
+    usersViewModel: UsersViewModel
+  ): Promise<InviteUserResult | UpdateUserResult | ModifyUserRolesResult> {
     // Touch all fields to show validation errors
     this.touchAllFields();
 
@@ -945,7 +950,7 @@ export class UserFormViewModel {
     });
 
     try {
-      let result: InviteUserResult | UpdateUserResult | UserVoidResult;
+      let result: InviteUserResult | UpdateUserResult | ModifyUserRolesResult;
 
       if (this.mode === 'create') {
         // Create mode: Send invitation
@@ -962,33 +967,35 @@ export class UserFormViewModel {
         log.debug('Updating user profile', { userId: updateRequest.userId });
         result = await commandService.updateUser(updateRequest);
 
-        // Handle role changes (if profile update succeeded and roles changed)
+        // Handle role changes (if profile update succeeded and roles changed).
+        // Delegate to the page VM's modifyRoles handler — it captures
+        // `lastRoleViolations` and `lastRolePartialFailure` on itself so the
+        // page-level UsersErrorBanner can render the rich violation list
+        // (`data-testid="role-modification-violation"`) or partial-failure
+        // recovery banner (`data-testid="role-modification-partial-warning"`).
+        // The page VM also logs structured warnings for both failure modes.
         if (result.success && this.hasRoleChanges) {
           log.debug('Processing role changes', {
             userId: this.editingUserId,
             rolesToAdd: this.rolesToAdd,
             rolesToRemove: this.rolesToRemove,
           });
-          const roleResult = await commandService.modifyRoles({
+          const roleResult = await usersViewModel.modifyRoles({
             userId: this.editingUserId!,
             roleIdsToAdd: this.rolesToAdd,
             roleIdsToRemove: this.rolesToRemove,
           });
 
           if (!roleResult.success) {
-            // Role modification failed - return role error instead
+            // Role modification failed — return role error so caller can react.
+            // The page VM has already populated `lastRoleViolations` /
+            // `lastRolePartialFailure` for the banner; the failure branch below
+            // suppresses the form's inline submissionError to avoid duplicate
+            // error surfaces.
             result = roleResult;
-            log.warn('Role modification failed', {
-              userId: this.editingUserId,
-              error: roleResult.error,
-            });
-          } else {
-            log.info('Role modification successful', {
-              userId: this.editingUserId,
-              added: this.rolesToAdd.length,
-              removed: this.rolesToRemove.length,
-            });
           }
+          // Success path: page VM has already set `successMessage = 'Roles
+          // updated'`; no additional log here (the page VM logs internally).
         }
       }
 
@@ -1002,22 +1009,40 @@ export class UserFormViewModel {
             log.info('User profile updated successfully', { userId: this.editingUserId });
           }
         } else {
-          this.submissionError = result.error ?? 'An error occurred';
-          // Extract detailed error info for display
-          // The context contains the full errorDetails from the Edge Function
-          const ctx = result.errorDetails?.context as Record<string, unknown> | undefined;
-          if (ctx) {
-            this.submissionErrorDetails = {
-              code: result.errorDetails?.code ?? (ctx.code as string),
-              details: this.formatViolationDetails(ctx),
-            };
-          } else {
+          // If the page VM has captured structured role-modification state
+          // (violations or partial-failure), that surface owns the error
+          // display. Suppress the form's inline submissionError to avoid
+          // rendering the same error twice (architect Finding #2).
+          const handledByPageBanner =
+            usersViewModel.lastRoleViolations !== null ||
+            usersViewModel.lastRolePartialFailure !== null;
+
+          if (handledByPageBanner) {
+            this.submissionError = null;
             this.submissionErrorDetails = null;
+          } else {
+            // Non-role failures (profile-update error, network error, etc.)
+            // still surface inline in the form. Prefer the rich
+            // `errorDetails.message` over the bare `error` code string.
+            this.submissionError =
+              result.errorDetails?.message ?? result.error ?? 'An error occurred';
+            // Extract detailed error info for display.
+            // The context contains the full errorDetails from the Edge Function.
+            const ctx = result.errorDetails?.context as Record<string, unknown> | undefined;
+            if (ctx) {
+              this.submissionErrorDetails = {
+                code: result.errorDetails?.code ?? (ctx.code as string),
+                details: this.formatViolationDetails(ctx),
+              };
+            } else {
+              this.submissionErrorDetails = null;
+            }
           }
           log.warn('Form submission failed', {
             mode: this.mode,
             error: result.error,
             errorDetails: result.errorDetails,
+            handledByPageBanner,
           });
         }
       });

--- a/frontend/src/viewModels/users/UserFormViewModel.ts
+++ b/frontend/src/viewModels/users/UserFormViewModel.ts
@@ -949,6 +949,16 @@ export class UserFormViewModel {
       this.submissionError = null;
     });
 
+    // Snapshot the page VM's structured role-error state before submit. The
+    // suppression check below compares by reference: a fresh role failure on
+    // THIS submit makes `modifyRoles` assign a new array/object (see
+    // UsersViewModel lines 1205 and 1216), so reference equality only holds
+    // when this submit did NOT touch those fields. Without this snapshot,
+    // sticky state from a PRIOR submit would falsely trigger suppression of
+    // a fresh non-role failure on the current submit.
+    const initialRoleViolations = usersViewModel.lastRoleViolations;
+    const initialRolePartialFailure = usersViewModel.lastRolePartialFailure;
+
     try {
       let result: InviteUserResult | UpdateUserResult | ModifyUserRolesResult;
 
@@ -1013,9 +1023,17 @@ export class UserFormViewModel {
           // (violations or partial-failure), that surface owns the error
           // display. Suppress the form's inline submissionError to avoid
           // rendering the same error twice (architect Finding #2).
+          //
+          // Compare against the pre-submit snapshot by reference so that
+          // sticky state from a prior submit (e.g., a previous role-violation
+          // that the user has not dismissed) cannot falsely suppress a fresh
+          // non-role failure on this submit. `modifyRoles` always assigns a
+          // new array/object when it populates these fields, so reference
+          // inequality is a sound provenance check for "this submit caused
+          // the population."
           const handledByPageBanner =
-            usersViewModel.lastRoleViolations !== null ||
-            usersViewModel.lastRolePartialFailure !== null;
+            usersViewModel.lastRoleViolations !== initialRoleViolations ||
+            usersViewModel.lastRolePartialFailure !== initialRolePartialFailure;
 
           if (handledByPageBanner) {
             this.submissionError = null;

--- a/frontend/src/viewModels/users/__tests__/UserFormViewModel.submit.test.tsx
+++ b/frontend/src/viewModels/users/__tests__/UserFormViewModel.submit.test.tsx
@@ -1,0 +1,343 @@
+/**
+ * UserFormViewModel.submit — error-surfacing tests.
+ *
+ * Verifies the architect-Finding-#4 contract: in edit mode with role changes,
+ * the form VM delegates role-modification to the page-level `UsersViewModel`,
+ * which captures structured failure state on itself (`lastRoleViolations` /
+ * `lastRolePartialFailure`) for the page-level UsersErrorBanner. The form's
+ * inline `submissionError` is suppressed when the page banner owns the error.
+ *
+ * Covers (per architect Finding #6):
+ *   (a) Happy path — profile-only edit
+ *   (b) Role-violation path
+ *   (c) Partial-failure path
+ *   (d) Non-role failure regression guard
+ *   (e) Combined edit: profile-success + role-violation (the actual S4 shape)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { UserFormViewModel } from '../UserFormViewModel';
+import type { UsersViewModel } from '../UsersViewModel';
+import { UsersErrorBanner } from '@/components/users/UsersErrorBanner';
+import type { IUserCommandService } from '@/services/users/IUserCommandService';
+import type {
+  RoleReference,
+  UserListItem,
+  ModifyUserRolesResult,
+  UpdateUserResult,
+  RoleAssignmentViolation,
+} from '@/types/user.types';
+
+const SUBJECT_ID = '093c0e7b-5ace-49df-9632-d49858d54ef5';
+const PROVIDER_ADMIN_ROLE_ID = '4827a2c7-9c54-4f84-936e-02bbc53f1f32';
+const SEQUOIA_ROLE_ID = 'ee59942f-7a61-469b-9edf-1a7b684d14ed';
+
+const mockAssignableRoles: RoleReference[] = [
+  { roleId: PROVIDER_ADMIN_ROLE_ID, roleName: 'provider_admin' },
+  { roleId: SEQUOIA_ROLE_ID, roleName: 'Sequoia Med Admin' },
+];
+
+const mockExistingUser: UserListItem = {
+  id: SUBJECT_ID,
+  email: 'lars.tice+test2@gmail.com',
+  firstName: 'Lars',
+  lastName: 'Tice-Test2',
+  displayStatus: 'active',
+  roles: [{ roleId: SEQUOIA_ROLE_ID, roleName: 'Sequoia Med Admin' }],
+  createdAt: new Date('2026-04-29'),
+  expiresAt: null,
+  isInvitation: false,
+  invitationId: null,
+};
+
+function makeCommandService(): IUserCommandService {
+  return {
+    inviteUser: vi.fn(),
+    updateUser: vi.fn(),
+    modifyRoles: vi.fn(),
+    resendInvitation: vi.fn(),
+    revokeInvitation: vi.fn(),
+    deactivateUser: vi.fn(),
+    reactivateUser: vi.fn(),
+    deleteUser: vi.fn(),
+    resetPassword: vi.fn(),
+    addUserToOrganization: vi.fn(),
+    switchOrganization: vi.fn(),
+    updateAccessDates: vi.fn(),
+    addUserPhone: vi.fn(),
+    updateUserPhone: vi.fn(),
+    removeUserPhone: vi.fn(),
+    updateNotificationPreferences: vi.fn(),
+    addUserAddress: vi.fn(),
+    updateUserAddress: vi.fn(),
+    removeUserAddress: vi.fn(),
+  } as unknown as IUserCommandService;
+}
+
+/**
+ * Minimal page-VM stub that satisfies the funnel-through contract:
+ *   - `modifyRoles(req)` returns the mocked result.
+ *   - `lastRoleViolations` / `lastRolePartialFailure` get populated when the
+ *     page VM would have captured them (simulated in the mock to match real
+ *     behavior from UsersViewModel.modifyRoles).
+ */
+function makePageViewModel(
+  modifyRolesMock: (req: {
+    userId: string;
+    roleIdsToAdd: string[];
+    roleIdsToRemove: string[];
+  }) => Promise<ModifyUserRolesResult>
+): UsersViewModel {
+  const stub = {
+    lastRoleViolations: null as RoleAssignmentViolation[] | null,
+    lastRolePartialFailure: null as UsersViewModel['lastRolePartialFailure'],
+    modifyRoles: vi.fn(async (req) => {
+      const result = await modifyRolesMock(req);
+      // Simulate the real UsersViewModel.modifyRoles side effects (see
+      // UsersViewModel.ts:1202-1229 — captures violation / partial state).
+      if (!result.success && result.violations && result.violations.length > 0) {
+        stub.lastRoleViolations = result.violations;
+      } else if (!result.success && result.partial) {
+        stub.lastRolePartialFailure = {
+          failureSection: result.failureSection ?? 'add',
+          failureIndex: result.failureIndex ?? 0,
+          addedRoleEventIds: result.addedRoleEventIds ?? [],
+          removedRoleEventIds: result.removedRoleEventIds ?? [],
+          processingError: result.processingError,
+        };
+      }
+      return result;
+    }),
+  };
+  return stub as unknown as UsersViewModel;
+}
+
+describe('UserFormViewModel.submit — error surfacing', () => {
+  let cs: IUserCommandService;
+
+  beforeEach(() => {
+    cs = makeCommandService();
+  });
+
+  it('(a) happy path — profile-only edit succeeds without touching page VM', async () => {
+    const vm = new UserFormViewModel(mockAssignableRoles, 'edit', mockExistingUser);
+    // No role changes — leave selectedRoles unchanged.
+    (cs.updateUser as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+    } satisfies UpdateUserResult);
+    const pageVm = makePageViewModel(async () => {
+      throw new Error('modifyRoles should not be called when no role changes');
+    });
+
+    const result = await vm.submit(cs, pageVm);
+
+    expect(result.success).toBe(true);
+    expect(vm.submissionError).toBe(null);
+    expect(pageVm.lastRoleViolations).toBe(null);
+    expect(pageVm.lastRolePartialFailure).toBe(null);
+    expect(pageVm.modifyRoles).not.toHaveBeenCalled();
+  });
+
+  it('(b) role-violation path — page banner owns the error; form is silent', async () => {
+    const vm = new UserFormViewModel(mockAssignableRoles, 'edit', mockExistingUser);
+    // Trigger role change: add provider_admin
+    vm.toggleRole(PROVIDER_ADMIN_ROLE_ID);
+    expect(vm.hasRoleChanges).toBe(true);
+
+    (cs.updateUser as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+    } satisfies UpdateUserResult);
+
+    const violations: RoleAssignmentViolation[] = [
+      {
+        role_id: PROVIDER_ADMIN_ROLE_ID,
+        role_name: 'provider_admin',
+        error_code: 'SUBSET_ONLY_VIOLATION',
+        message: 'Role "provider_admin" has permissions you don\'t have',
+      },
+    ];
+    const pageVm = makePageViewModel(async () => ({
+      success: false,
+      error: 'VALIDATION_FAILED',
+      violations,
+      errorDetails: {
+        code: 'VALIDATION_FAILED',
+        message: violations[0].message,
+      },
+    }));
+
+    const result = await vm.submit(cs, pageVm);
+
+    expect(result.success).toBe(false);
+    // The role-failure shape replaces the profile result
+    expect((result as ModifyUserRolesResult).violations).toEqual(violations);
+    // Form's inline error is suppressed — page banner owns it
+    expect(vm.submissionError).toBe(null);
+    expect(vm.submissionErrorDetails).toBe(null);
+    // Page VM captured the violation
+    expect(pageVm.lastRoleViolations).toEqual(violations);
+  });
+
+  it('(c) partial-failure path — page banner shows recovery; form is silent', async () => {
+    const vm = new UserFormViewModel(mockAssignableRoles, 'edit', mockExistingUser);
+    vm.toggleRole(PROVIDER_ADMIN_ROLE_ID);
+
+    (cs.updateUser as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+    } satisfies UpdateUserResult);
+
+    const pageVm = makePageViewModel(async () => ({
+      success: false,
+      error: 'PARTIAL_FAILURE',
+      partial: true,
+      failureSection: 'remove',
+      failureIndex: 1,
+      processingError: 'handler raised mid-loop',
+      addedRoleEventIds: [],
+      removedRoleEventIds: ['evt-1'],
+    }));
+
+    const result = await vm.submit(cs, pageVm);
+
+    expect(result.success).toBe(false);
+    expect((result as ModifyUserRolesResult).partial).toBe(true);
+    // Form silent
+    expect(vm.submissionError).toBe(null);
+    expect(vm.submissionErrorDetails).toBe(null);
+    // Page VM captured partial state
+    expect(pageVm.lastRolePartialFailure).not.toBe(null);
+    expect(pageVm.lastRolePartialFailure?.failureSection).toBe('remove');
+    expect(pageVm.lastRolePartialFailure?.failureIndex).toBe(1);
+    expect(pageVm.lastRolePartialFailure?.processingError).toBe('handler raised mid-loop');
+  });
+
+  it('(d) non-role failure regression guard — surfaces inline in the form, not the banner', async () => {
+    const vm = new UserFormViewModel(mockAssignableRoles, 'edit', mockExistingUser);
+    // NO role changes — only profile update fails
+    (cs.updateUser as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: false,
+      error: 'PROCESSING_ERROR',
+      errorDetails: { code: 'PROCESSING_ERROR', message: 'Connection refused' },
+    } satisfies UpdateUserResult);
+    const pageVm = makePageViewModel(async () => {
+      throw new Error('modifyRoles should not be called');
+    });
+
+    const result = await vm.submit(cs, pageVm);
+
+    expect(result.success).toBe(false);
+    // Prefer the rich `errorDetails.message` over the bare error code
+    expect(vm.submissionError).toBe('Connection refused');
+    // Page VM untouched
+    expect(pageVm.lastRoleViolations).toBe(null);
+    expect(pageVm.lastRolePartialFailure).toBe(null);
+  });
+
+  /**
+   * (f) Integration render test — covers the end-to-end contract from
+   * architect Finding #4: form-submit failure → page VM captures violations
+   * → UsersErrorBanner mounted with that state renders the rich block with
+   * stable test-ids. Verifies the wiring between this test file's case (b)
+   * and UsersErrorBanner.test.tsx without requiring a full UsersManagePage
+   * harness (matches the project's existing manage-pages contract-test
+   * pattern at frontend/src/pages/__tests__/manage-pages-*.test.tsx).
+   */
+  it('(f) integration — page VM state after submit drives the rich UsersErrorBanner', async () => {
+    const vm = new UserFormViewModel(mockAssignableRoles, 'edit', mockExistingUser);
+    vm.toggleRole(PROVIDER_ADMIN_ROLE_ID);
+
+    (cs.updateUser as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+    } satisfies UpdateUserResult);
+
+    const violations: RoleAssignmentViolation[] = [
+      {
+        role_id: PROVIDER_ADMIN_ROLE_ID,
+        role_name: 'provider_admin',
+        error_code: 'SUBSET_ONLY_VIOLATION',
+        message: 'Role "provider_admin" has permissions you don\'t have',
+      },
+    ];
+    const pageVm = makePageViewModel(async () => ({
+      success: false,
+      error: 'VALIDATION_FAILED',
+      violations,
+      errorDetails: { code: 'VALIDATION_FAILED', message: violations[0].message },
+    }));
+
+    await vm.submit(cs, pageVm);
+
+    // Mount the real UsersErrorBanner with the state captured by the page VM.
+    render(
+      <UsersErrorBanner
+        error={violations[0].message}
+        operationError={null}
+        lastRoleViolations={pageVm.lastRoleViolations}
+        lastRolePartialFailure={pageVm.lastRolePartialFailure}
+        onDismiss={vi.fn()}
+      />
+    );
+
+    // Rich violation block renders with stable test-ids.
+    const banner = screen.getByTestId('users-error-banner');
+    expect(banner).not.toBeNull();
+    const violationBlock = within(banner).getByTestId('role-modification-violation');
+    expect(violationBlock).not.toBeNull();
+    const violationRow = within(violationBlock).getByTestId(
+      'role-violation-SUBSET_ONLY_VIOLATION'
+    );
+    expect(violationRow).not.toBeNull();
+    expect(violationRow.textContent).toContain(
+      'Role "provider_admin" has permissions you don\'t have'
+    );
+
+    // Negative assertion: the bare error code string never appears in the UI.
+    expect(within(banner).queryByText('VALIDATION_FAILED')).toBeNull();
+    // Negative assertion: form's inline submissionError is null (verified
+    // separately in case (b)) — the page banner is the ONLY error surface.
+    expect(vm.submissionError).toBe(null);
+  });
+
+  it('(e) combined edit — profile-success + role-violation (the actual S4 shape)', async () => {
+    const vm = new UserFormViewModel(mockAssignableRoles, 'edit', mockExistingUser);
+    vm.toggleRole(PROVIDER_ADMIN_ROLE_ID);
+
+    // Profile update succeeds
+    (cs.updateUser as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+    } satisfies UpdateUserResult);
+
+    const violations: RoleAssignmentViolation[] = [
+      {
+        role_id: PROVIDER_ADMIN_ROLE_ID,
+        role_name: 'provider_admin',
+        error_code: 'SUBSET_ONLY_VIOLATION',
+        message: 'Role "provider_admin" has permissions you don\'t have',
+      },
+    ];
+    const pageVm = makePageViewModel(async () => ({
+      success: false,
+      error: 'VALIDATION_FAILED',
+      violations,
+      errorDetails: { code: 'VALIDATION_FAILED', message: violations[0].message },
+    }));
+
+    const result = await vm.submit(cs, pageVm);
+
+    // Overall result is the role-modify result, not the profile success
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('VALIDATION_FAILED');
+    expect((result as ModifyUserRolesResult).violations).toEqual(violations);
+
+    // Form's inline error is silent — page banner displays the violation
+    expect(vm.submissionError).toBe(null);
+
+    // Page VM captured the rich state for UsersErrorBanner to render
+    expect(pageVm.lastRoleViolations).toEqual(violations);
+    expect(pageVm.lastRoleViolations?.[0].error_code).toBe('SUBSET_ONLY_VIOLATION');
+    expect(pageVm.lastRoleViolations?.[0].message).toBe(
+      'Role "provider_admin" has permissions you don\'t have'
+    );
+  });
+});

--- a/frontend/src/viewModels/users/__tests__/UserFormViewModel.submit.test.tsx
+++ b/frontend/src/viewModels/users/__tests__/UserFormViewModel.submit.test.tsx
@@ -284,9 +284,7 @@ describe('UserFormViewModel.submit — error surfacing', () => {
     expect(banner).not.toBeNull();
     const violationBlock = within(banner).getByTestId('role-modification-violation');
     expect(violationBlock).not.toBeNull();
-    const violationRow = within(violationBlock).getByTestId(
-      'role-violation-SUBSET_ONLY_VIOLATION'
-    );
+    const violationRow = within(violationBlock).getByTestId('role-violation-SUBSET_ONLY_VIOLATION');
     expect(violationRow).not.toBeNull();
     expect(violationRow.textContent).toContain(
       'Role "provider_admin" has permissions you don\'t have'
@@ -297,6 +295,100 @@ describe('UserFormViewModel.submit — error surfacing', () => {
     // Negative assertion: form's inline submissionError is null (verified
     // separately in case (b)) — the page banner is the ONLY error surface.
     expect(vm.submissionError).toBe(null);
+  });
+
+  it("(b') role-violation but page VM does NOT capture state → form surfaces inline", async () => {
+    // Negative control for case (b)'s suppression assertion: if the page VM
+    // returns a violation result but (e.g. due to a regression in
+    // UsersViewModel.modifyRoles) fails to populate `lastRoleViolations`, the
+    // suppression branch MUST NOT fire and the form's inline submissionError
+    // must appear. This is the causal-link assertion that case (b) alone
+    // doesn't make.
+    const vm = new UserFormViewModel(mockAssignableRoles, 'edit', mockExistingUser);
+    vm.toggleRole(PROVIDER_ADMIN_ROLE_ID);
+
+    (cs.updateUser as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+    } satisfies UpdateUserResult);
+
+    const violations: RoleAssignmentViolation[] = [
+      {
+        role_id: PROVIDER_ADMIN_ROLE_ID,
+        role_name: 'provider_admin',
+        error_code: 'SUBSET_ONLY_VIOLATION',
+        message: 'Role "provider_admin" has permissions you don\'t have',
+      },
+    ];
+    // Page VM returns the violation result but leaves its own state nulled.
+    const pageVm = {
+      lastRoleViolations: null,
+      lastRolePartialFailure: null,
+      modifyRoles: vi.fn(async () => ({
+        success: false,
+        error: 'VALIDATION_FAILED',
+        violations,
+        errorDetails: { code: 'VALIDATION_FAILED', message: violations[0].message },
+      })),
+    } as unknown as UsersViewModel;
+
+    await vm.submit(cs, pageVm);
+
+    // Without the page-VM capture, suppression does NOT fire — the form falls
+    // through to inline display.
+    expect(vm.submissionError).not.toBe(null);
+  });
+
+  it('(g) stale page-VM state from a prior submit does not suppress a fresh non-role failure', async () => {
+    // Defect this test guards against: `handledByPageBanner` originally read
+    // sticky state without a provenance check; a previous submit's violation
+    // would suppress a subsequent submit's non-role error. The snapshot-
+    // before-compare fix in UserFormViewModel.submit() keeps the suppression
+    // tied to *this* submit's effect on the page VM.
+    const vm = new UserFormViewModel(mockAssignableRoles, 'edit', mockExistingUser);
+    vm.toggleRole(PROVIDER_ADMIN_ROLE_ID);
+
+    // Submit #1: role-violation populates pageVm.lastRoleViolations
+    (cs.updateUser as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: true,
+    } satisfies UpdateUserResult);
+    const violations: RoleAssignmentViolation[] = [
+      {
+        role_id: PROVIDER_ADMIN_ROLE_ID,
+        role_name: 'provider_admin',
+        error_code: 'SUBSET_ONLY_VIOLATION',
+        message: 'Role "provider_admin" has permissions you don\'t have',
+      },
+    ];
+    const pageVm = makePageViewModel(async () => ({
+      success: false,
+      error: 'VALIDATION_FAILED',
+      violations,
+      errorDetails: { code: 'VALIDATION_FAILED', message: violations[0].message },
+    }));
+    await vm.submit(cs, pageVm);
+    expect(pageVm.lastRoleViolations).toEqual(violations); // sanity: captured
+
+    // User reverts the role change → no role changes on submit #2
+    vm.toggleRole(PROVIDER_ADMIN_ROLE_ID);
+    expect(vm.hasRoleChanges).toBe(false);
+
+    // Submit #2: profile update fails with a NON-role error. The page VM's
+    // stale `lastRoleViolations` is still set from submit #1.
+    (cs.updateUser as ReturnType<typeof vi.fn>).mockResolvedValue({
+      success: false,
+      error: 'PROCESSING_ERROR',
+      errorDetails: { code: 'PROCESSING_ERROR', message: 'Connection refused' },
+    } satisfies UpdateUserResult);
+
+    await vm.submit(cs, pageVm);
+
+    // The new non-role error MUST surface inline — the page banner's stale
+    // state is not what failed this time.
+    expect(vm.submissionError).toBe('Connection refused');
+    // pageVm.modifyRoles must not have been called on submit #2 (no role
+    // changes), so the sticky state is unchanged from submit #1.
+    expect((pageVm.modifyRoles as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1);
+    expect(pageVm.lastRoleViolations).toEqual(violations); // still sticky
   });
 
   it('(e) combined edit — profile-success + role-violation (the actual S4 shape)', async () => {


### PR DESCRIPTION
## Summary

Follow-up to PR #54. UAT Scenario 4 (SUBSET_ONLY_VIOLATION on `modify_user_roles` from the user-edit form) exposed a frontend defect: the form modal showed the bare error code "VALIDATION_FAILED" instead of the actionable violation message. The backend was correct; the frontend dropped violation detail.

Funnels the form's role-modify call through `UsersViewModel.modifyRoles()` (which already has rich-state handling for the page-level `UsersErrorBanner`) instead of calling `commandService.modifyRoles()` directly. Single source of truth for role-modification error surfacing.

## Defect trace

| Path | Handler | Rich rendering? |
|---|---|---|
| Role-only-edit dialog | `UsersViewModel.modifyRoles()` | ✅ wired (page banner with `role-modification-violation` testid) |
| User-edit form (profile+roles) | `UserFormViewModel.submit()` → direct service call | ❌ dropped violations |

## Architect review

Reviewed by `software-architect-dbc` agent (plan at `~/.claude/plans/uat-s4-frontend-error-surfacing-fix.md`). Eight findings — Finding #4 (funnel-through pattern) collapsed Findings #1, #2, #5, and #8 into a single coherent refactor. All addressed:

- **#1**: Refined `submit()` return type to `InviteUserResult | UpdateUserResult | ModifyUserRolesResult` — no anonymous-shape cast.
- **#2**: Single surface — when page banner captures violations/partial, form's `submissionError` is suppressed.
- **#3**: It's not a modal; corrected the plan.
- **#4** (adopted): Funnel through `UsersViewModel.modifyRoles()`.
- **#5**: PARTIAL_FAILURE shape gets the same treatment for free.
- **#6**: Expanded test plan from 2 cases to 6.
- **#7**: Scope discipline OK.
- **#8**: `formatViolationDetails` becomes dead code on role-modify branch (informational, follow-up sweep).

## Changes

| File | Change |
|---|---|
| `frontend/src/viewModels/users/UserFormViewModel.ts` | Inject `usersViewModel` param into `submit()`; funnel role-modify through page VM; suppress `submissionError` when page banner owns the error; prefer `errorDetails.message` over bare `error` in inline fallback |
| `frontend/src/pages/users/UsersManagePage.tsx` | Pass `viewModel` as new 2nd arg to `formViewModel.submit()` |
| `frontend/src/viewModels/users/__tests__/UserFormViewModel.submit.test.tsx` | NEW — 6 Vitest cases including integration render test |

## Test plan

- ✅ Frontend gates: typecheck, lint, build, docs:check all clean.
- ✅ Unit tests: 6/6 pass.
- [ ] Manual re-run of UAT Scenario 4 on dev after deploy:
  - Log in as Lars Tice-Test
  - Open Lars Tice-Test2 in edit panel
  - Try to add provider_admin → Save
  - **Expected**: Page banner appears with heading "Role assignment violation"; inside, `<li data-testid="role-violation-SUBSET_ONLY_VIOLATION">` contains "Role 'provider_admin' has permissions you don't have"; form inline error is gone; no "VALIDATION_FAILED" raw code anywhere
- [ ] Mark UAT Scenario 4 row as Pass in the test plan.

## Verification — 6 test cases

(a) Happy path — profile-only edit (page VM untouched)
(b) Role-violation path (form silent, page VM captures violations)
(c) Partial-failure path (form silent, page VM captures partial)
(d) Non-role failure regression (form surfaces inline, page VM untouched)
(e) Combined profile-success + role-violation (the actual S4 shape)
(f) Integration render — page-VM state drives `UsersErrorBanner` with `role-violation-SUBSET_ONLY_VIOLATION` test-id; bare error code never appears in rendered DOM

## Plan

`~/.claude/plans/uat-s4-frontend-error-surfacing-fix.md` (revised twice after architect review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)