### PR TITLE
refactor(services): PR-A pilots — migrate Entity + Role to apiRpcEnvelope/apiRpc

### DIFF
--- a/dev/active/migrate-services-to-api-rpc-envelope/inventory.md
+++ b/dev/active/migrate-services-to-api-rpc-envelope/inventory.md
@@ -1,0 +1,212 @@
+# Phase 0 Inventory — Direct `api.*` RPC Call Sites
+
+**Generated**: 2026-05-11 during PR-A planning
+**Source of truth**: `frontend/src/services/api/rpc-registry.generated.ts` (M3 enforcement — `EnvelopeRpcs` and `ReadRpcs` string-literal unions emitted from `COMMENT ON FUNCTION api.<name> IS '... @a4c-rpc-shape: envelope|read'` tags)
+**Total**: 85 production sites across 11 service files (65 envelope + 20 read; 2 SDK helper definitions and 5 doc-example matches in `services/CLAUDE.md` excluded)
+
+---
+
+## Per-service breakdown
+
+### organization/
+
+#### `SupabaseOrganizationQueryService.ts` (4 read)
+
+| Line | Method | RPC | Shape |
+|---|---|---|---|
+| 87  | `getOrganizations`         | `get_organizations`         | read |
+| 117 | `getOrganizationById`      | `get_organization_by_id`    | read |
+| 145 | `getChildOrganizations`    | `get_child_organizations`   | read |
+| 177 | `getOrganizationsPaginated`| `get_organizations_paginated` | read |
+
+#### `SupabaseOrganizationCommandService.ts` (4 envelope)
+
+| Line | Method | RPC | Shape |
+|---|---|---|---|
+| 32  | `updateOrganization`     | `update_organization`     | env |
+| 63  | `deactivateOrganization` | `deactivate_organization` | env |
+| 90  | `reactivateOrganization` | `reactivate_organization` | env |
+| 116 | `deleteOrganization`     | `delete_organization`     | env |
+
+Note: uses `{data: result, error}` destructure variant.
+
+#### `SupabaseOrganizationEntityService.ts` (1 envelope; only real dynamic-name site)
+
+| Line | Method | RPC | Shape |
+|---|---|---|---|
+| 104 | `callEntityRpc` (private wrapper) | `<dynamic: rpcName>` | env |
+
+The 9 public methods (`createContact`, `updateContact`, `deleteContact`, `createAddress`, `updateAddress`, `deleteAddress`, `createPhone`, `updatePhone`, `deletePhone`) all dispatch to `callEntityRpc` with static literal RPC names. All 9 literals are members of `EnvelopeRpcs`, so re-typing `rpcName: EnvelopeRpcs` keeps the polymorphism while routing through `apiRpcEnvelope`.
+
+#### `SupabaseOrganizationUnitService.ts` (5 envelope + 2 read)
+
+| Line | Method | RPC | Shape |
+|---|---|---|---|
+| 190 | `getUnits`        | `get_organization_units`         | read |
+| 217 | `getUnitById`     | `get_organization_unit_by_id`    | read |
+| 277 | `createUnit`      | `create_organization_unit`       | env |
+| 350 | `updateUnit`      | `update_organization_unit`       | env |
+| 421 | `deactivateUnit`  | `deactivate_organization_unit`   | env |
+| 488 | `reactivateUnit`  | `reactivate_organization_unit`   | env |
+| 556 | `deleteUnit`      | `delete_organization_unit`       | env |
+
+#### `getOrganizationSubdomainInfo.ts` (1 read, special)
+
+| Line | Method | RPC | Shape | Notes |
+|---|---|---|---|---|
+| 54-55 | `getOrganizationSubdomainInfo` (top-level fn) | `get_organization_by_id` | read | **`.single<T>()` chained.** Refactor in place per Q5: `apiRpc<Organization[]>(...)` + `data?.[0] ?? null`. UUID lookup makes multi-row case impossible. |
+
+### client-fields/
+
+#### `SupabaseClientFieldService.ts` (13 envelope + 1 read)
+
+| Line | Method | RPC | Shape |
+|---|---|---|---|
+| 50  | `batchUpdateFieldDefinitions` | `batch_update_field_definitions` | env |
+| 72  | `createFieldDefinition`       | `create_field_definition`       | env |
+| 100 | `updateFieldDefinition`       | `update_field_definition`       | env |
+| 126 | `deactivateFieldDefinition`   | `deactivate_field_definition`   | env |
+| 148 | `reactivateFieldDefinition`   | `reactivate_field_definition`   | env |
+| 170 | `deleteFieldDefinition`       | `delete_field_definition`       | env |
+| 188 | `listFieldCategories`         | `list_field_categories`         | read |
+| 208 | `createFieldCategory`         | `create_field_category`         | env |
+| 232 | `updateFieldCategory`         | `update_field_category`         | env |
+| 255 | `deactivateFieldCategory`     | `deactivate_field_category`     | env |
+| 277 | `reactivateFieldCategory`     | `reactivate_field_category`     | env |
+| 299 | `deleteFieldCategory`         | `delete_field_category`         | env |
+| 317 | `getFieldUsageCount`          | `get_field_usage_count`         | **env** (per registry; service currently does not check `result.success`) |
+| 336 | `getCategoryFieldCount`       | `get_category_field_count`     | **env** (per registry; service currently does not check `result.success`) |
+
+The two `get_*_count` envelopes are an architectural note: the service constructs `{success: true, count: result?.count ?? 0}` from raw `result` without validating the envelope's success bit. Migration via `apiRpcEnvelope<{count: number}>` will surface a real failure case if/when the RPC ever returns `success: false`.
+
+Test file `__tests__/SupabaseClientFieldService.test.ts:14-20` mocks `@/lib/supabase` chain directly — refactor to mock the helpers (Q2).
+
+### roles/
+
+#### `SupabaseRoleService.ts` (5 envelope + 8 read)
+
+| Line | Method | RPC | Shape |
+|---|---|---|---|
+| 284 | `getRoles`                       | `get_roles`                       | read |
+| 311 | `getRoleById`                    | `get_role_by_id`                  | read |
+| 341 | `getPermissions`                 | `get_permissions`                 | read |
+| 365 | `getUserPermissions`             | `get_user_permissions`            | read |
+| 402 | `createRole`                     | `create_role`                     | env |
+| 486 | `updateRole`                     | `update_role`                     | env |
+| 581 | `deactivateRole`                 | `deactivate_role`                 | env |
+| 630 | `reactivateRole`                 | `reactivate_role`                 | env |
+| 679 | `deleteRole`                     | `delete_role`                     | env |
+| 734 | `listUsersForBulkAssignment`     | `list_users_for_bulk_assignment`  | read |
+| 787 | `bulkAssignRole`                 | `bulk_assign_role`                | **read** (registry — agent's plan-stage claim of envelope was wrong; method doesn't check `response.success`, treats `data` as bulk-result shape directly) |
+| 848 | `listUsersForRoleManagement`     | `list_users_for_role_management`  | read |
+| 902 | `syncRoleAssignments`            | `sync_role_assignments`           | **read** (registry — same as `bulk_assign_role`) |
+
+All read methods THROW on error (`throw new Error(...)` after `if (error)`). Migration must preserve throw contract (use `error` from `apiRpc` return tuple).
+
+### schedule/
+
+#### `SupabaseScheduleService.ts` (9 envelope + 2 read)
+
+| Line | Method | RPC | Shape | Notes |
+|---|---|---|---|---|
+| 64  | `listTemplates`                 | `list_schedule_templates`             | env  | `parseOrThrow` THROWS on `!success` |
+| 82  | `getTemplate`                   | `get_schedule_template`               | env  | `parseOrThrow` |
+| 118 | `createTemplate`                | `create_schedule_template`            | env  | `parseOrThrow` |
+| 143 | `updateTemplate`                | `update_schedule_template`            | env  | `parseOrThrow` |
+| 162 | `deactivateTemplate`            | `deactivate_schedule_template`        | env  | `parseOrThrow` |
+| 179 | `reactivateTemplate`            | `reactivate_schedule_template`        | env  | `parseOrThrow` |
+| 198 | `deleteTemplate`                | `delete_schedule_template`            | env  | `parseRpcResult` — RETURNS on `!success` |
+| 238 | `assignUser`                    | `assign_user_to_schedule`             | env  | `parseOrThrow` |
+| 267 | `unassignUser`                  | `unassign_user_from_schedule`         | env  | `parseOrThrow` |
+| 290 | `listUsersForScheduleManagement`| `list_users_for_schedule_management`  | read | array data |
+| 326 | `syncScheduleAssignments`       | `sync_schedule_assignments`           | read | array data |
+
+Throw-vs-return split per Q6: methods using `parseOrThrow` keep throwing (`if (!env.success) throw new Error(env.error)`); `deleteTemplate` (using `parseRpcResult`) keeps returning.
+
+### clients/
+
+#### `SupabaseClientService.ts` (25 envelope)
+
+All 25 sites are writes routed through local `parseResponse(data)` helper which is mechanically replaced by direct `apiRpcEnvelope<T>` consumption. RPCs: `list_clients`, `get_client`, `register_client`, `update_client`, `admit_client`, `discharge_client`, `add_client_phone`, `update_client_phone`, `remove_client_phone`, `add_client_email`, `update_client_email`, `remove_client_email`, `add_client_address`, `update_client_address`, `remove_client_address`, `add_client_insurance`, `update_client_insurance`, `remove_client_insurance`, `change_client_placement`, `end_client_placement`, `add_client_funding_source`, `update_client_funding_source`, `remove_client_funding_source`, `assign_client_contact`, `unassign_client_contact`. (Note: `list_clients` and `get_client` are in `EnvelopeRpcs` per registry — same Pattern A v2 read envelope variant as Schedule's list/get.)
+
+### direct-care/
+
+#### `SupabaseDirectCareSettingsService.ts` (1 envelope + 1 read)
+
+| Line | Method | RPC | Shape | Notes |
+|---|---|---|---|---|
+| 28-29  | `getSettings`    | `get_organization_direct_care_settings`    | read | multi-line chained `.schema('api')\n.rpc(...)` |
+| 65-66+ | `updateSettings` | `update_organization_direct_care_settings` | env  | multi-line chained; **L84-95 has legacy/v2 dual-shape parse** — confirm v1 path is dead before deleting |
+
+### assignment/
+
+#### `SupabaseAssignmentService.ts` (2 envelope + 1 read)
+
+| Line | Method | RPC | Shape | Notes |
+|---|---|---|---|---|
+| 29  | `listUserClientAssignments` | `list_user_client_assignments` | **env** (per registry — Pattern A v2 read envelope variant) | multi-line chained |
+| 61  | `assignClientToUser`        | `assign_client_to_user`        | env  | multi-line chained |
+| 93  | `unassignClientFromUser`    | `unassign_client_from_user`    | env  | multi-line chained |
+
+### auth/ (SDK helpers — excluded from migration)
+
+#### `supabase.service.ts` (2 helper definitions)
+
+| Line | Method | RPC | Shape | Status |
+|---|---|---|---|---|
+| 126 | `apiRpc<T>` | `<dynamic: functionName: ReadRpcs>` | read | **must not migrate** — implements the boundary |
+| 167 | `apiRpcEnvelope<T>` | `<dynamic: functionName: EnvelopeRpcs>` | env | **must not migrate** — implements the boundary |
+
+### Excluded: documentation examples
+
+`services/CLAUDE.md` contains 5 `.schema('api').rpc(` matches in code examples — these are doc snippets, not call sites.
+
+---
+
+## Aggregate totals
+
+| Service | Env | Read | Total |
+|---|---:|---:|---:|
+| OrgQuery | 0 | 4 | 4 |
+| OrgCommand | 4 | 0 | 4 |
+| OrgEntity | 1 | 0 | 1 |
+| OrgUnit | 5 | 2 | 7 |
+| OrgSubdomain | 0 | 1 | 1 |
+| ClientFields | 13 | 1 | 14 |
+| Roles | 5 | 8 | 13 |
+| Schedule | 9 | 2 | 11 |
+| Clients | 25 | 0 | 25 |
+| DirectCare | 1 | 1 | 2 |
+| Assignment | 2 | 1 | 3 |
+| **TOTAL** | **65** | **20** | **85** |
+
+---
+
+## Already-migrated services (no work)
+
+These services already consume `supabaseService.apiRpc` / `apiRpcEnvelope`:
+
+- `frontend/src/services/users/SupabaseUserCommandService.ts` (migrated by PR #44)
+- `frontend/src/services/users/SupabaseUserQueryService.ts`
+- `frontend/src/services/admin/EventMonitoringService.ts`
+- `frontend/src/services/admin/OrphanedDeletionService.ts`
+
+---
+
+## PR scope
+
+- **PR-A pilots (14 sites)**: OrgEntity (1 env) + Roles (5 env + 8 read = 13)
+- **PR-B bulk (41 sites)**: OrgCommand (4) + OrgUnit (5+2) + ClientFields (13+1) + Schedule (9+2) + DirectCare (1+1) + Assignment (2+1)
+- **PR-C closeout (30 sites + rule)**: Clients (25) + OrgQuery (4) + OrgSubdomain (1 — refactor in place) + activate ESLint rule
+
+## Open question resolutions
+
+Documented in the plan file (`~/.claude/plans/ddoes-it-make-sense-lucky-dongarra.md`). Summarized:
+
+- **Q1 dynamic names**: `rpcName: EnvelopeRpcs` on Entity wrapper
+- **Q2 test mocks**: refactor `SupabaseClientFieldService.test.ts` to helper-mock pattern
+- **Q3 dead imports**: drop `@/lib/supabase` per file if unused
+- **Q4 lint lifecycle**: accept the window — rule activates only in PR-C
+- **Q5 `.single<T>()`**: refactor in place to `apiRpc<T[]>` + `[0] ?? null`
+- **Q6 Schedule throw/return**: preserve throw-on-`!success` for `parseOrThrow` methods
+- **Q7 selector scope**: matches any `.schema(*).rpc(...)`; comment notes today's assumption that no `public` schema calls exist

--- a/dev/active/migrate-services-to-api-rpc-envelope/tasks.md
+++ b/dev/active/migrate-services-to-api-rpc-envelope/tasks.md
@@ -2,9 +2,24 @@
 
 ## Current Status
 
-**Phase**: ACTIVE (2026-04-30)
-**Status**: 🟢 READY — awaiting bandwidth
+**Phase**: PR-A in progress (2026-05-11)
+**Status**: 🟢 ACTIVE
 **Priority**: Medium
+**Branch**: `refactor/migrate-services-to-api-rpc-envelope`
+
+## Plan reference
+
+`~/.claude/plans/ddoes-it-make-sense-lucky-dongarra.md` (v2, post-architect-review) and `inventory.md` in this directory.
+
+## Open question resolutions (Phase 0)
+
+- **Q1 (dynamic RPC names)**: Solved by `rpcName: EnvelopeRpcs` typing on `SupabaseOrganizationEntityService.callEntityRpc`. The 9 public methods continue passing static literals; TypeScript narrows without `as const`. No `eslint-disable` needed.
+- **Q2 (test mocks)**: Refactor `SupabaseClientFieldService.test.ts:14-20` to mock `supabaseService.apiRpc` / `apiRpcEnvelope` mirroring `SupabaseUserCommandService.mapping.test.ts:18-47`. Confirmed mechanical.
+- **Q3 (dead `@/lib/supabase` imports)**: Drop per-file if unused after migration.
+- **Q4 (ESLint lifecycle)**: Accept the window (user controls cadence). PR-A and PR-B leave eslint config untouched; PR-C activates the rule.
+- **Q5 (`.single<T>()` site)**: Refactor `getOrganizationSubdomainInfo.ts:54-55` in place to `apiRpc<Organization[]>(...)` + `data?.[0] ?? null`. UUID lookup makes multi-row case impossible.
+- **Q6 (Schedule throw-vs-return)**: Preserve throw-on-`!success` for `parseOrThrow` methods; preserve return-on-failure for `parseRpcResult` methods.
+- **Q7 (ESLint selector scope)**: Selector matches any `.schema(*).rpc(...)`. Repo has zero non-`api` schema RPC calls today — comment notes the assumption.
 
 ## Tasks
 
@@ -12,39 +27,48 @@
 
 ### Phase 0 — Inventory
 
-- [ ] Grep `frontend/src/services/` for `.schema('api').rpc(` and produce a complete call-site list grouped by service.
-- [ ] Per service method, classify each call as envelope-shaped vs read-shape and record the current return-shape contract for verification.
+- [x] Grep `frontend/src/services/` for `.schema('api').rpc(` and produce a complete call-site list grouped by service.
+- [x] Per service method, classify each call as envelope-shaped vs read-shape via M3 registry (source of truth) and record current return-shape contract.
+- [x] Persist as `inventory.md` in this directory (85 sites across 11 service files, 65 env + 20 read).
 
-### Phase 1 — Pilot service
+### Phase 1 — Pilots (PR-A)
 
-- [ ] Migrate `SupabaseRoleService` envelope-shaped writes to `apiRpcEnvelope<T>`. Run typecheck + Vitest. PR-local commit message: `refactor(services): migrate role service to apiRpcEnvelope (1/N)`.
+- [x] `SupabaseOrganizationEntityService.ts` (1 envelope site via `callEntityRpc` wrapper). Re-typed `rpcName: EnvelopeRpcs`; all 9 callers continue passing static literals.
+- [x] `SupabaseRoleService.ts` (5 envelope + 8 read = 13 sites). All read methods preserve throw-on-error contract. `bulkAssignRole` and `sync_role_assignments` correctly classified as read per registry (agent inventory had these as envelope; M3 registry is authoritative).
+- [x] `envelope.ts` — added `count?: number` to `EnvelopeErrorDetails` (preserves real-world contract used by `OrganizationUnitsManagePage.tsx:562` cannot-delete dialog; minimal scope addition).
+- [ ] Verify: typecheck + tests + build
+- [ ] Commit, push, open PR-A
 
-### Phase 2 — Bulk service migration
+### Phase 2 — Bulk wave (PR-B)
 
-- [ ] `SupabaseUserCommandService` (envelope writes) — highest PHI surface.
-- [ ] `SupabaseClientService` (envelope writes) — PHI: addresses, names, DOB.
-- [ ] `SupabaseClientFieldService` (envelope writes).
-- [ ] `SupabaseScheduleService` (envelope writes).
-- [ ] `SupabaseOrganizationCommandService` (envelope writes).
-- [ ] `SupabaseOrganizationEntityService` (envelope writes; resolve dynamic-name Q1).
-- [ ] `SupabaseOrganizationUnitService` (envelope writes).
-- [ ] `OrphanedDeletionService` (envelope writes).
+- [ ] `SupabaseOrganizationCommandService.ts` (4 env) — handle `{data: result, error}` destructure variant
+- [ ] `SupabaseOrganizationUnitService.ts` (5 env + 2 read)
+- [ ] `SupabaseClientFieldService.ts` (13 env + 1 read) + Q2 test-mock refactor at `__tests__/SupabaseClientFieldService.test.ts`
+- [ ] `SupabaseScheduleService.ts` (9 env + 2 read) — preserve throw-on-failure contract for `parseOrThrow` methods (Q6)
+- [ ] `SupabaseDirectCareSettingsService.ts` (1 env + 1 read) — verify v1 path is dead before deleting dual-shape parse at L84-95
+- [ ] `SupabaseAssignmentService.ts` (2 env + 1 read)
 
-### Phase 3 — Read-shape migration
+### Phase 3 — Closeout + rule (PR-C)
 
-- [ ] `SupabaseUserQueryService` reads → `supabaseService.apiRpc<T>(...)`.
-- [ ] `SupabaseOrganizationQueryService` reads → `supabaseService.apiRpc<T>(...)`.
+- [ ] `SupabaseClientService.ts` (25 env) — replace `parseResponse` with direct `apiRpcEnvelope` consumption
+- [ ] `SupabaseOrganizationQueryService.ts` (4 read)
+- [ ] `getOrganizationSubdomainInfo.ts` (1 read) — refactor in place per Q5
+- [ ] Pre-merge inventory refresh — `grep -rEn ".schema\(['\"]api['\"]\)\.rpc" frontend/src/` + multi-line grep
+- [ ] Activate ESLint rule at `frontend/eslint.config.js:124-131` + files-glob override for SDK helpers
+- [ ] Confirm `npm run lint -- --max-warnings 0` green
 
-### Phase 4 — ESLint rule
+### Phase 4 — Verification (per PR)
 
-- [ ] Replace placeholder comment in `frontend/eslint.config.js` with the actual `no-restricted-syntax` rule + file-level override allow-listing the 2 SDK files.
-- [ ] Audit any test files that mock direct `.rpc()` calls (Q2) and either migrate the mocks or add to allow-list.
+- [ ] `cd frontend && npm run typecheck` green
+- [ ] `cd frontend && npm run test -- --run` green
+- [ ] `cd frontend && npm run build` green
+- [ ] PR-C only: `cd frontend && npm run lint` green with `--max-warnings 0`
+- [ ] Manual smoke on one envelope flow per PR
 
-### Phase 5 — Verification
+## Cross-references
 
-- [ ] `npm run typecheck` green for `frontend/`.
-- [ ] `npm run lint` green with `--max-warnings 0`.
-- [ ] `npm run build` green.
-- [ ] All Vitest suites green.
-- [ ] Manual smoke test on at least one envelope-shaped UI flow (role assignment / user update).
-- [ ] PR opened referencing this card.
+- Plan file: `~/.claude/plans/ddoes-it-make-sense-lucky-dongarra.md`
+- Inventory artifact: `./inventory.md`
+- Origin PR: PR #43 (HIPAA PII sanitization)
+- ADR: `documentation/architecture/decisions/adr-rpc-readback-pattern.md` § PII handling
+- Service-side conventions: `frontend/src/services/CLAUDE.md` §3

--- a/frontend/src/services/api/__tests__/envelope.test.ts
+++ b/frontend/src/services/api/__tests__/envelope.test.ts
@@ -1,0 +1,105 @@
+/**
+ * unwrapApiEnvelope — boundary masking + field-preservation tests
+ *
+ * Addresses architect review NT-3 on PR #56: the `count` field on
+ * EnvelopeErrorDetails was added to preserve the real-world contract for
+ * blocking-dependency errors (HAS_USERS / HAS_ROLES → cannot-delete dialog
+ * at OrganizationUnitsManagePage.tsx:562). Without a test, PR-B/PR-C could
+ * re-strip the field unintentionally.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { PostgrestSingleResponse } from '@supabase/supabase-js';
+import { unwrapApiEnvelope } from '../envelope';
+
+// Stub maskPii to be identity so tests assert on shape, not masking behavior.
+vi.mock('@/utils/maskPii', () => ({
+  maskPii: (s: string) => s,
+}));
+
+function rpcOk<T>(data: T): PostgrestSingleResponse<unknown> {
+  return {
+    data: data as unknown,
+    error: null,
+    count: null,
+    status: 200,
+    statusText: 'OK',
+  } as PostgrestSingleResponse<unknown>;
+}
+
+describe('unwrapApiEnvelope', () => {
+  describe('count preservation (NT-3 — regression guard)', () => {
+    it('preserves errorDetails.count on envelope failure (HAS_USERS path)', () => {
+      const result = unwrapApiEnvelope(
+        rpcOk({
+          success: false,
+          error: 'Role has users assigned',
+          errorDetails: {
+            code: 'HAS_USERS',
+            count: 5,
+            message: 'Cannot delete: 5 users assigned',
+          },
+        })
+      );
+
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.errorDetails?.code).toBe('HAS_USERS');
+      expect(result.errorDetails?.count).toBe(5);
+      expect(result.errorDetails?.message).toBe('Cannot delete: 5 users assigned');
+    });
+
+    it('preserves errorDetails.count = 0 (falsy but defined)', () => {
+      const result = unwrapApiEnvelope(
+        rpcOk({
+          success: false,
+          error: 'No blocking deps',
+          errorDetails: { code: 'NONE', count: 0, message: 'm' },
+        })
+      );
+      if (result.success) return;
+      expect(result.errorDetails?.count).toBe(0);
+    });
+
+    it('leaves errorDetails.count undefined when RPC omits it', () => {
+      const result = unwrapApiEnvelope(
+        rpcOk({
+          success: false,
+          error: 'Validation failed',
+          errorDetails: { code: 'VALIDATION_ERROR', message: 'm' },
+        })
+      );
+      if (result.success) return;
+      expect(result.errorDetails?.count).toBeUndefined();
+    });
+  });
+
+  describe('success-path intersection', () => {
+    it('spreads success-path fields onto {success: true}', () => {
+      const result = unwrapApiEnvelope<{ role: { id: string }; event_id: string }>(
+        rpcOk({ success: true, role: { id: 'r1' }, event_id: 'e1' })
+      );
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.role.id).toBe('r1');
+      expect(result.event_id).toBe('e1');
+    });
+  });
+
+  describe('PostgREST-level failure', () => {
+    it('surfaces postgrestError on wrapper-level error', () => {
+      const result = unwrapApiEnvelope({
+        data: null,
+        error: { code: '42501', message: 'permission denied', details: '', hint: '' },
+        count: null,
+        status: 403,
+        statusText: 'Forbidden',
+      } as unknown as PostgrestSingleResponse<unknown>);
+
+      expect(result.success).toBe(false);
+      if (result.success) return;
+      expect(result.postgrestError?.code).toBe('42501');
+      expect(result.error).toBe('permission denied');
+    });
+  });
+});

--- a/frontend/src/services/api/envelope.ts
+++ b/frontend/src/services/api/envelope.ts
@@ -30,6 +30,13 @@ export interface EnvelopeErrorDetails {
   message: string;
   context?: Record<string, unknown>;
   correlationId?: string;
+  /**
+   * Optional count emitted by RPCs that return blocking-dependency errors
+   * (e.g. `delete_role` with `HAS_USERS` returns `count: 5` so the UI can
+   * say "Cannot delete: 5 users assigned"). Consumed by OrganizationUnits
+   * manage page (cannot-delete dialog) and Role service error mapper.
+   */
+  count?: number;
 }
 
 /**
@@ -143,6 +150,7 @@ export function unwrapApiEnvelope<T extends Record<string, unknown> = Record<str
         message: maskPii(data.errorDetails.message),
         context: data.errorDetails.context,
         correlationId: data.errorDetails.correlationId,
+        count: data.errorDetails.count,
       };
     }
     if (data.violations !== undefined) {

--- a/frontend/src/services/organization/SupabaseOrganizationEntityService.ts
+++ b/frontend/src/services/organization/SupabaseOrganizationEntityService.ts
@@ -5,8 +5,9 @@
  * Each method calls a dedicated RPC for contact/address/phone CRUD.
  */
 
-import { supabase } from '@/lib/supabase';
+import { supabaseService } from '@/services/auth/supabase.service';
 import { Logger } from '@/utils/logger';
+import type { EnvelopeRpcs } from '@/services/api/rpc-registry.generated';
 import type {
   OrganizationEntityResult,
   ContactData,
@@ -16,6 +17,18 @@ import type {
 import type { IOrganizationEntityService } from './IOrganizationEntityService';
 
 const log = Logger.getLogger('api');
+
+/**
+ * Envelope shape returned by every `api.{create,update,delete}_organization_{contact,address,phone}` RPC.
+ *
+ * `apiRpcEnvelope<T>` spreads success-path fields onto `{success: true}` (intersection-type contract).
+ * On failure, returns `{success: false, error: string, ...}` with `error` already masked.
+ */
+type OrganizationEntityRpcSuccess = {
+  contact?: unknown;
+  address?: unknown;
+  phone?: unknown;
+};
 
 export class SupabaseOrganizationEntityService implements IOrganizationEntityService {
   // ---------------------------------------------------------------------------
@@ -94,31 +107,31 @@ export class SupabaseOrganizationEntityService implements IOrganizationEntitySer
   // Shared RPC caller
   // ---------------------------------------------------------------------------
 
+  // rpcName is narrowed to EnvelopeRpcs — calling with a name not in the registry
+  // is a TypeScript compile error at the caller.
   private async callEntityRpc(
-    rpcName: string,
+    rpcName: EnvelopeRpcs,
     params: Record<string, unknown>
   ): Promise<OrganizationEntityResult> {
     try {
       log.debug(`Calling ${rpcName}`, params);
 
-      const { data: result, error } = await supabase.schema('api').rpc(rpcName, params);
+      const env = await supabaseService.apiRpcEnvelope<OrganizationEntityRpcSuccess>(
+        rpcName,
+        params
+      );
 
-      if (error) {
-        log.error(`Failed to call ${rpcName}`, { error, params });
-        return { success: false, error: error.message };
+      if (!env.success) {
+        log.warn(`${rpcName} returned failure`, { error: env.error });
+        return { success: false, error: env.error };
       }
 
-      if (!result?.success) {
-        log.warn(`${rpcName} returned failure`, { result });
-        return { success: false, error: result?.error ?? 'Operation failed' };
-      }
-
-      log.info(`${rpcName} succeeded`, { result });
+      log.info(`${rpcName} succeeded`);
       return {
         success: true,
-        contact: result.contact,
-        address: result.address,
-        phone: result.phone,
+        contact: env.contact as OrganizationEntityResult['contact'],
+        address: env.address as OrganizationEntityResult['address'],
+        phone: env.phone as OrganizationEntityResult['phone'],
       };
     } catch (error) {
       log.error(`Error in ${rpcName}`, { error, params });

--- a/frontend/src/services/organization/__tests__/SupabaseOrganizationEntityService.test.ts
+++ b/frontend/src/services/organization/__tests__/SupabaseOrganizationEntityService.test.ts
@@ -1,0 +1,121 @@
+/**
+ * SupabaseOrganizationEntityService — callEntityRpc pattern tests
+ *
+ * Addresses architect review NT-2a on PR #56: the typed-dynamic-name wrapper
+ * is the pilot for PR-B/PR-C to replicate (~70 more sites). Lock the failure
+ * + success paths before the bulk wave inherits the pattern.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockApiRpcEnvelope } = vi.hoisted(() => ({
+  mockApiRpcEnvelope: vi.fn(),
+}));
+
+vi.mock('@/services/auth/supabase.service', () => ({
+  supabaseService: { apiRpcEnvelope: mockApiRpcEnvelope },
+}));
+
+import { SupabaseOrganizationEntityService } from '../SupabaseOrganizationEntityService';
+
+describe('SupabaseOrganizationEntityService', () => {
+  let service: SupabaseOrganizationEntityService;
+
+  beforeEach(() => {
+    mockApiRpcEnvelope.mockReset();
+    service = new SupabaseOrganizationEntityService();
+  });
+
+  describe('callEntityRpc — failure path', () => {
+    it('propagates env.error from envelope failure', async () => {
+      mockApiRpcEnvelope.mockResolvedValueOnce({
+        success: false,
+        error: 'Contact email already exists',
+        errorDetails: { code: 'DUPLICATE_EMAIL', message: 'm' },
+      });
+
+      const result = await service.createContact('org-1', {
+        label: 'Primary',
+        type: 'admin',
+        first_name: 'A',
+        last_name: 'B',
+        email: 'a@b.com',
+      } as never);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Contact email already exists');
+    });
+
+    it('returns error message on thrown exception', async () => {
+      mockApiRpcEnvelope.mockRejectedValueOnce(new Error('network down'));
+
+      const result = await service.createContact('org-1', { label: 'x' } as never);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('network down');
+    });
+  });
+
+  describe('callEntityRpc — success path', () => {
+    it('spreads contact onto result on createContact success', async () => {
+      const contact = { id: 'c1', label: 'Primary', email: 'a@b.com' };
+      mockApiRpcEnvelope.mockResolvedValueOnce({ success: true, contact });
+
+      const result = await service.createContact('org-1', { label: 'Primary' } as never);
+
+      expect(result.success).toBe(true);
+      expect(result.contact).toEqual(contact);
+      expect(result.address).toBeUndefined();
+      expect(result.phone).toBeUndefined();
+    });
+
+    it('spreads address onto result on createAddress success', async () => {
+      const address = { id: 'a1', street: '1 Main St' };
+      mockApiRpcEnvelope.mockResolvedValueOnce({ success: true, address });
+
+      const result = await service.createAddress('org-1', { street: '1 Main St' } as never);
+
+      expect(result.success).toBe(true);
+      expect(result.address).toEqual(address);
+    });
+
+    it('spreads phone onto result on createPhone success', async () => {
+      const phone = { id: 'p1', phone: '+15551234567' };
+      mockApiRpcEnvelope.mockResolvedValueOnce({ success: true, phone });
+
+      const result = await service.createPhone('org-1', { phone: '+15551234567' } as never);
+
+      expect(result.success).toBe(true);
+      expect(result.phone).toEqual(phone);
+    });
+  });
+
+  describe('callEntityRpc — typed dynamic name', () => {
+    it('forwards the static-literal rpcName through to apiRpcEnvelope (9 callers)', async () => {
+      mockApiRpcEnvelope.mockResolvedValue({ success: true });
+
+      await service.createContact('o1', {} as never);
+      await service.updateContact('c1', {} as never);
+      await service.deleteContact('c1');
+      await service.createAddress('o1', {} as never);
+      await service.updateAddress('a1', {} as never);
+      await service.deleteAddress('a1');
+      await service.createPhone('o1', {} as never);
+      await service.updatePhone('p1', {} as never);
+      await service.deletePhone('p1');
+
+      const calls = mockApiRpcEnvelope.mock.calls.map((c: unknown[]) => c[0]);
+      expect(calls).toEqual([
+        'create_organization_contact',
+        'update_organization_contact',
+        'delete_organization_contact',
+        'create_organization_address',
+        'update_organization_address',
+        'delete_organization_address',
+        'create_organization_phone',
+        'update_organization_phone',
+        'delete_organization_phone',
+      ]);
+    });
+  });
+});

--- a/frontend/src/services/roles/SupabaseRoleService.ts
+++ b/frontend/src/services/roles/SupabaseRoleService.ts
@@ -26,6 +26,7 @@
  */
 
 import { supabaseService } from '@/services/auth/supabase.service';
+import type { EnvelopeErrorDetails } from '@/services/api/envelope';
 import { Logger } from '@/utils/logger';
 import type { IRoleService } from './IRoleService';
 import type {
@@ -121,17 +122,6 @@ interface UserPermissionRow {
   permission_id: string;
 }
 
-/**
- * Errors returned by `api.*` envelope RPCs in this service. Used only as the
- * input type for `mapErrorDetails` (the envelope helper's `errorDetails` shape
- * is structurally compatible with this).
- */
-interface RoleRpcErrorDetails {
-  code: string;
-  count?: number;
-  message: string;
-}
-
 export class SupabaseRoleService implements IRoleService {
   constructor() {
     log.info('SupabaseRoleService initialized');
@@ -201,7 +191,9 @@ export class SupabaseRoleService implements IRoleService {
   /**
    * Maps error details from RPC response to operation result format
    */
-  private mapErrorDetails(errorDetails?: RoleRpcErrorDetails): RoleOperationResult['errorDetails'] {
+  private mapErrorDetails(
+    errorDetails?: EnvelopeErrorDetails
+  ): RoleOperationResult['errorDetails'] {
     if (!errorDetails) return undefined;
 
     type ErrorCode = NonNullable<RoleOperationResult['errorDetails']>['code'];
@@ -374,6 +366,33 @@ export class SupabaseRoleService implements IRoleService {
       });
 
       const elapsed = Date.now() - startTime;
+
+      // Distinguish PostgREST-level failure (401, 42501, ...) from handler-
+      // returned envelope failure. Preserves the pre-migration DIAG_RPC_ERROR
+      // signal that's lost if we collapse both into one log line.
+      if (!env.success && env.postgrestError) {
+        log.error(`[DIAG:createRole:RPC_ERROR] requestId=${requestId} elapsed=${elapsed}ms`, {
+          error: env.error,
+          code: env.postgrestError.code,
+          details: env.postgrestError.details,
+          hint: env.postgrestError.hint,
+        });
+        return {
+          success: false,
+          error: env.error,
+          errorDetails: { code: 'UNKNOWN', message: env.error },
+        };
+      }
+
+      // Pre-branch observation log — fires for every non-PostgREST response
+      // (success and envelope-failure). Restores the pre-migration
+      // DIAG_RPC_RESPONSE signal.
+      log.info(`[DIAG:createRole:RPC_RESPONSE] requestId=${requestId} elapsed=${elapsed}ms`, {
+        success: env.success,
+        roleId: env.success ? env.role?.id : undefined,
+        error: env.success ? undefined : env.error,
+        errorDetails: env.success ? undefined : env.errorDetails,
+      });
 
       if (!env.success) {
         log.warn(`[DIAG:createRole:EXIT:FAILED] requestId=${requestId} elapsed=${elapsed}ms`, {

--- a/frontend/src/services/roles/SupabaseRoleService.ts
+++ b/frontend/src/services/roles/SupabaseRoleService.ts
@@ -25,7 +25,7 @@
  * @see documentation/architecture/authorization/rbac-architecture.md
  */
 
-import { supabase } from '@/lib/supabase';
+import { supabaseService } from '@/services/auth/supabase.service';
 import { Logger } from '@/utils/logger';
 import type { IRoleService } from './IRoleService';
 import type {
@@ -122,61 +122,14 @@ interface UserPermissionRow {
 }
 
 /**
- * JSONB response type for mutation operations.
- *
- * `api.create_role` returns camelCase keys via an explicit jsonb_build_object.
- * `api.update_role` (Pattern A v2) returns the raw `roles_projection` row via
- * `row_to_json(v_row)` — snake_case, no computed `permission_count`/`user_count`
- * — plus `permission_ids` from the role_permissions_projection read-back.
- *
- * The two response shapes coexist here; consumers pick the one their RPC emits.
+ * Errors returned by `api.*` envelope RPCs in this service. Used only as the
+ * input type for `mapErrorDetails` (the envelope helper's `errorDetails` shape
+ * is structurally compatible with this).
  */
-interface MutationResponse {
-  success: boolean;
-  /** Populated by api.create_role (camelCase) */
-  role?: {
-    id: string;
-    name: string;
-    description: string;
-    organizationId: string | null;
-    orgHierarchyScope: string | null;
-    isActive: boolean;
-    createdAt: string;
-    updatedAt: string;
-  };
-  error?: string;
-  errorDetails?: {
-    code: string;
-    count?: number;
-    message: string;
-  };
-}
-
-/**
- * JSONB response type for api.update_role (Pattern A v2 read-back shape).
- * `role` is the raw roles_projection row (snake_case, no computed columns);
- * `permission_ids` is the permission set AFTER grant/revoke processing.
- */
-interface UpdateRoleResponse {
-  success: boolean;
-  role?: {
-    id: string;
-    name: string;
-    description: string;
-    organization_id: string | null;
-    org_hierarchy_scope: string | null;
-    is_active: boolean;
-    deleted_at: string | null;
-    created_at: string;
-    updated_at: string;
-  };
-  permission_ids?: string[];
-  error?: string;
-  errorDetails?: {
-    code: string;
-    count?: number;
-    message: string;
-  };
+interface RoleRpcErrorDetails {
+  code: string;
+  count?: number;
+  message: string;
 }
 
 export class SupabaseRoleService implements IRoleService {
@@ -248,9 +201,7 @@ export class SupabaseRoleService implements IRoleService {
   /**
    * Maps error details from RPC response to operation result format
    */
-  private mapErrorDetails(
-    errorDetails?: MutationResponse['errorDetails']
-  ): RoleOperationResult['errorDetails'] {
+  private mapErrorDetails(errorDetails?: RoleRpcErrorDetails): RoleOperationResult['errorDetails'] {
     if (!errorDetails) return undefined;
 
     type ErrorCode = NonNullable<RoleOperationResult['errorDetails']>['code'];
@@ -281,7 +232,7 @@ export class SupabaseRoleService implements IRoleService {
     log.debug('getRoles called', { filters });
 
     try {
-      const { data, error } = await supabase.schema('api').rpc('get_roles', {
+      const { data, error } = await supabaseService.apiRpc<RoleRow[]>('get_roles', {
         p_status: filters?.status || 'all',
         p_search_term: filters?.searchTerm || null,
       });
@@ -291,7 +242,7 @@ export class SupabaseRoleService implements IRoleService {
         throw new Error(`Failed to fetch roles: ${error.message}`);
       }
 
-      const rows = (data as RoleRow[]) || [];
+      const rows = data || [];
       log.debug(`Fetched ${rows.length} roles`);
 
       return rows.map((row) => this.mapRowToRole(row));
@@ -308,16 +259,17 @@ export class SupabaseRoleService implements IRoleService {
     log.debug('getRoleById called', { roleId });
 
     try {
-      const { data, error } = await supabase.schema('api').rpc('get_role_by_id', {
-        p_role_id: roleId,
-      });
+      const { data, error } = await supabaseService.apiRpc<RoleWithPermissionsRow[]>(
+        'get_role_by_id',
+        { p_role_id: roleId }
+      );
 
       if (error) {
         log.error('Error fetching role by ID', error);
         throw new Error(`Failed to fetch role: ${error.message}`);
       }
 
-      const rows = (data as RoleWithPermissionsRow[]) || [];
+      const rows = data || [];
 
       if (rows.length === 0) {
         log.debug('Role not found', { roleId });
@@ -338,14 +290,14 @@ export class SupabaseRoleService implements IRoleService {
     log.debug('getPermissions called');
 
     try {
-      const { data, error } = await supabase.schema('api').rpc('get_permissions');
+      const { data, error } = await supabaseService.apiRpc<PermissionRow[]>('get_permissions', {});
 
       if (error) {
         log.error('Error fetching permissions', error);
         throw new Error(`Failed to fetch permissions: ${error.message}`);
       }
 
-      const rows = (data as PermissionRow[]) || [];
+      const rows = data || [];
       log.debug(`Fetched ${rows.length} permissions`);
 
       return rows.map((row) => this.mapRowToPermission(row));
@@ -362,14 +314,17 @@ export class SupabaseRoleService implements IRoleService {
     log.debug('getUserPermissions called');
 
     try {
-      const { data, error } = await supabase.schema('api').rpc('get_user_permissions');
+      const { data, error } = await supabaseService.apiRpc<UserPermissionRow[]>(
+        'get_user_permissions',
+        {}
+      );
 
       if (error) {
         log.error('Error fetching user permissions', error);
         throw new Error(`Failed to fetch user permissions: ${error.message}`);
       }
 
-      const rows = (data as UserPermissionRow[]) || [];
+      const rows = data || [];
       log.debug(`Fetched ${rows.length} user permission IDs`);
 
       return rows.map((row) => row.permission_id);
@@ -399,7 +354,18 @@ export class SupabaseRoleService implements IRoleService {
     try {
       log.debug(`[DIAG:createRole:RPC_CALL] requestId=${requestId}`);
 
-      const { data, error } = await supabase.schema('api').rpc('create_role', {
+      const env = await supabaseService.apiRpcEnvelope<{
+        role?: {
+          id: string;
+          name: string;
+          description: string;
+          organizationId: string | null;
+          orgHierarchyScope: string | null;
+          isActive: boolean;
+          createdAt: string;
+          updatedAt: string;
+        };
+      }>('create_role', {
         p_name: request.name,
         p_description: request.description,
         p_org_hierarchy_scope: request.orgHierarchyScope || null,
@@ -409,54 +375,33 @@ export class SupabaseRoleService implements IRoleService {
 
       const elapsed = Date.now() - startTime;
 
-      if (error) {
-        log.error(`[DIAG:createRole:RPC_ERROR] requestId=${requestId} elapsed=${elapsed}ms`, {
-          error: error.message,
-          code: error.code,
-          details: error.details,
-          hint: error.hint,
+      if (!env.success) {
+        log.warn(`[DIAG:createRole:EXIT:FAILED] requestId=${requestId} elapsed=${elapsed}ms`, {
+          error: env.error,
+          errorDetails: env.errorDetails,
         });
         return {
           success: false,
-          error: error.message,
-          errorDetails: {
-            code: 'UNKNOWN',
-            message: error.message,
-          },
+          error: env.error,
+          errorDetails: this.mapErrorDetails(env.errorDetails),
         };
       }
 
-      const response = data as MutationResponse;
-
-      log.info(`[DIAG:createRole:RPC_RESPONSE] requestId=${requestId} elapsed=${elapsed}ms`, {
-        success: response.success,
-        roleId: response.role?.id,
-        error: response.error,
-        errorDetails: response.errorDetails,
+      log.info(`[DIAG:createRole:EXIT:SUCCESS] requestId=${requestId} elapsed=${elapsed}ms`, {
+        roleId: env.role?.id,
       });
-
-      if (!response.success) {
-        log.warn(`[DIAG:createRole:EXIT:FAILED] requestId=${requestId}`, { response });
-        return {
-          success: false,
-          error: response.error,
-          errorDetails: this.mapErrorDetails(response.errorDetails),
-        };
-      }
-
-      log.info(`[DIAG:createRole:EXIT:SUCCESS] requestId=${requestId} roleId=${response.role?.id}`);
       return {
         success: true,
-        role: response.role
+        role: env.role
           ? {
-              id: response.role.id,
-              name: response.role.name,
-              description: response.role.description,
-              organizationId: response.role.organizationId,
-              orgHierarchyScope: response.role.orgHierarchyScope,
-              isActive: response.role.isActive,
-              createdAt: new Date(response.role.createdAt),
-              updatedAt: new Date(response.role.updatedAt),
+              id: env.role.id,
+              name: env.role.name,
+              description: env.role.description,
+              organizationId: env.role.organizationId,
+              orgHierarchyScope: env.role.orgHierarchyScope,
+              isActive: env.role.isActive,
+              createdAt: new Date(env.role.createdAt),
+              updatedAt: new Date(env.role.updatedAt),
               permissionCount: request.permissionIds.length,
               userCount: 0,
             }
@@ -483,33 +428,32 @@ export class SupabaseRoleService implements IRoleService {
     log.debug('updateRole called', { request });
 
     try {
-      const { data, error } = await supabase.schema('api').rpc('update_role', {
+      const env = await supabaseService.apiRpcEnvelope<{
+        role?: {
+          id: string;
+          name: string;
+          description: string;
+          organization_id: string | null;
+          org_hierarchy_scope: string | null;
+          is_active: boolean;
+          deleted_at: string | null;
+          created_at: string;
+          updated_at: string;
+        };
+        permission_ids?: string[];
+      }>('update_role', {
         p_role_id: request.id,
         p_name: request.name || null,
         p_description: request.description || null,
         p_permission_ids: request.permissionIds || null,
       });
 
-      if (error) {
-        log.error('Error updating role', error);
+      if (!env.success) {
+        log.warn('Update role failed', { error: env.error, errorDetails: env.errorDetails });
         return {
           success: false,
-          error: error.message,
-          errorDetails: {
-            code: 'UNKNOWN',
-            message: error.message,
-          },
-        };
-      }
-
-      const response = data as UpdateRoleResponse;
-
-      if (!response.success) {
-        log.warn('Update role failed', { response });
-        return {
-          success: false,
-          error: response.error,
-          errorDetails: this.mapErrorDetails(response.errorDetails),
+          error: env.error,
+          errorDetails: this.mapErrorDetails(env.errorDetails),
         };
       }
 
@@ -521,27 +465,23 @@ export class SupabaseRoleService implements IRoleService {
       // (computed at query time via LEFT JOIN) and isn't affected by this
       // operation, so we omit it — callers merging into an existing list
       // should preserve their current userCount for this role.
-      if (!response.role) {
+      if (!env.role) {
         // Silent-fallback observability per logging-standards.md +
         // event-observability.md anti-silent-failure posture. Under
         // Pattern A v2 this branch should never fire; if it does, the
         // backend RPC predates the v2 read-back or a migration is missing.
-        // responseKeys + hasPermissionIds make the regression
-        // self-diagnosable (distinguishes pre-v2 backend from a partial
-        // service-mapper bug from an unknown envelope shape).
         log.warn(
           'updateRole success without role read-back — VM will not patch its list. ' +
             'Backend RPC may be pre-Pattern-A-v2 or on a failed migration.',
           {
             roleId: request.id,
-            responseKeys: Object.keys(response),
-            hasPermissionIds: Array.isArray(response.permission_ids),
+            hasPermissionIds: Array.isArray(env.permission_ids),
           }
         );
         return { success: true };
       }
-      const row = response.role;
-      const permissionIds = response.permission_ids ?? [];
+      const row = env.role;
+      const permissionIds = env.permission_ids ?? [];
       return {
         success: true,
         role: {
@@ -578,30 +518,14 @@ export class SupabaseRoleService implements IRoleService {
     log.debug('deactivateRole called', { roleId });
 
     try {
-      const { data, error } = await supabase.schema('api').rpc('deactivate_role', {
-        p_role_id: roleId,
-      });
+      const env = await supabaseService.apiRpcEnvelope('deactivate_role', { p_role_id: roleId });
 
-      if (error) {
-        log.error('Error deactivating role', error);
+      if (!env.success) {
+        log.warn('Deactivate role failed', { error: env.error, errorDetails: env.errorDetails });
         return {
           success: false,
-          error: error.message,
-          errorDetails: {
-            code: 'UNKNOWN',
-            message: error.message,
-          },
-        };
-      }
-
-      const response = data as MutationResponse;
-
-      if (!response.success) {
-        log.warn('Deactivate role failed', { response });
-        return {
-          success: false,
-          error: response.error,
-          errorDetails: this.mapErrorDetails(response.errorDetails),
+          error: env.error,
+          errorDetails: this.mapErrorDetails(env.errorDetails),
         };
       }
 
@@ -627,30 +551,14 @@ export class SupabaseRoleService implements IRoleService {
     log.debug('reactivateRole called', { roleId });
 
     try {
-      const { data, error } = await supabase.schema('api').rpc('reactivate_role', {
-        p_role_id: roleId,
-      });
+      const env = await supabaseService.apiRpcEnvelope('reactivate_role', { p_role_id: roleId });
 
-      if (error) {
-        log.error('Error reactivating role', error);
+      if (!env.success) {
+        log.warn('Reactivate role failed', { error: env.error, errorDetails: env.errorDetails });
         return {
           success: false,
-          error: error.message,
-          errorDetails: {
-            code: 'UNKNOWN',
-            message: error.message,
-          },
-        };
-      }
-
-      const response = data as MutationResponse;
-
-      if (!response.success) {
-        log.warn('Reactivate role failed', { response });
-        return {
-          success: false,
-          error: response.error,
-          errorDetails: this.mapErrorDetails(response.errorDetails),
+          error: env.error,
+          errorDetails: this.mapErrorDetails(env.errorDetails),
         };
       }
 
@@ -676,30 +584,14 @@ export class SupabaseRoleService implements IRoleService {
     log.debug('deleteRole called', { roleId });
 
     try {
-      const { data, error } = await supabase.schema('api').rpc('delete_role', {
-        p_role_id: roleId,
-      });
+      const env = await supabaseService.apiRpcEnvelope('delete_role', { p_role_id: roleId });
 
-      if (error) {
-        log.error('Error deleting role', error);
+      if (!env.success) {
+        log.warn('Delete role failed', { error: env.error, errorDetails: env.errorDetails });
         return {
           success: false,
-          error: error.message,
-          errorDetails: {
-            code: 'UNKNOWN',
-            message: error.message,
-          },
-        };
-      }
-
-      const response = data as MutationResponse;
-
-      if (!response.success) {
-        log.warn('Delete role failed', { response });
-        return {
-          success: false,
-          error: response.error,
-          errorDetails: this.mapErrorDetails(response.errorDetails),
+          error: env.error,
+          errorDetails: this.mapErrorDetails(env.errorDetails),
         };
       }
 
@@ -731,7 +623,16 @@ export class SupabaseRoleService implements IRoleService {
     log.debug('listUsersForBulkAssignment called', { params });
 
     try {
-      const { data, error } = await supabase.schema('api').rpc('list_users_for_bulk_assignment', {
+      const { data, error } = await supabaseService.apiRpc<
+        Array<{
+          id: string;
+          email: string;
+          display_name: string;
+          is_active: boolean;
+          current_roles: string[];
+          is_already_assigned: boolean;
+        }>
+      >('list_users_for_bulk_assignment', {
         p_role_id: params.roleId,
         p_scope_path: params.scopePath,
         p_search_term: params.searchTerm || null,
@@ -744,15 +645,7 @@ export class SupabaseRoleService implements IRoleService {
         throw new Error(`Failed to list users: ${error.message}`);
       }
 
-      const rows =
-        (data as Array<{
-          id: string;
-          email: string;
-          display_name: string;
-          is_active: boolean;
-          current_roles: string[];
-          is_already_assigned: boolean;
-        }>) || [];
+      const rows = data || [];
 
       log.debug(`Fetched ${rows.length} users for bulk assignment`);
 
@@ -784,7 +677,14 @@ export class SupabaseRoleService implements IRoleService {
     });
 
     try {
-      const { data, error } = await supabase.schema('api').rpc('bulk_assign_role', {
+      const { data, error } = await supabaseService.apiRpc<{
+        successful: string[];
+        failed: Array<{ userId: string; reason: string; sqlstate?: string }>;
+        totalRequested: number;
+        totalSucceeded: number;
+        totalFailed: number;
+        correlationId: string;
+      }>('bulk_assign_role', {
         p_role_id: params.roleId,
         p_user_ids: params.userIds,
         p_scope_path: params.scopePath,
@@ -800,28 +700,23 @@ export class SupabaseRoleService implements IRoleService {
         throw new Error(`Bulk assignment failed (Ref: ${correlationId}): ${error.message}`);
       }
 
-      const response = data as {
-        successful: string[];
-        failed: Array<{ userId: string; reason: string; sqlstate?: string }>;
-        totalRequested: number;
-        totalSucceeded: number;
-        totalFailed: number;
-        correlationId: string;
-      };
+      if (!data) {
+        throw new Error(`Bulk assignment failed (Ref: ${correlationId}): no response data`);
+      }
 
       log.info('Bulk assignment completed', {
-        totalSucceeded: response.totalSucceeded,
-        totalFailed: response.totalFailed,
-        correlationId: response.correlationId,
+        totalSucceeded: data.totalSucceeded,
+        totalFailed: data.totalFailed,
+        correlationId: data.correlationId,
       });
 
       return {
-        successful: response.successful || [],
-        failed: response.failed || [],
-        totalRequested: response.totalRequested || params.userIds.length,
-        totalSucceeded: response.totalSucceeded || 0,
-        totalFailed: response.totalFailed || 0,
-        correlationId: response.correlationId || correlationId,
+        successful: data.successful || [],
+        failed: data.failed || [],
+        totalRequested: data.totalRequested || params.userIds.length,
+        totalSucceeded: data.totalSucceeded || 0,
+        totalFailed: data.totalFailed || 0,
+        correlationId: data.correlationId || correlationId,
       };
     } catch (err) {
       log.error('Exception in bulkAssignRole', {
@@ -845,7 +740,16 @@ export class SupabaseRoleService implements IRoleService {
     log.debug('listUsersForRoleManagement called', { params });
 
     try {
-      const { data, error } = await supabase.schema('api').rpc('list_users_for_role_management', {
+      const { data, error } = await supabaseService.apiRpc<
+        Array<{
+          id: string;
+          email: string;
+          display_name: string;
+          is_active: boolean;
+          current_roles: string[];
+          is_assigned: boolean;
+        }>
+      >('list_users_for_role_management', {
         p_role_id: params.roleId,
         p_scope_path: params.scopePath,
         p_search_term: params.searchTerm || null,
@@ -858,15 +762,7 @@ export class SupabaseRoleService implements IRoleService {
         throw new Error(`Failed to list users: ${error.message}`);
       }
 
-      const rows =
-        (data as Array<{
-          id: string;
-          email: string;
-          display_name: string;
-          is_active: boolean;
-          current_roles: string[];
-          is_assigned: boolean;
-        }>) || [];
+      const rows = data || [];
 
       log.debug(`Fetched ${rows.length} users for role management`);
 
@@ -899,7 +795,17 @@ export class SupabaseRoleService implements IRoleService {
     });
 
     try {
-      const { data, error } = await supabase.schema('api').rpc('sync_role_assignments', {
+      const { data, error } = await supabaseService.apiRpc<{
+        added: {
+          successful: string[];
+          failed: Array<{ userId: string; reason: string; sqlstate?: string }>;
+        };
+        removed: {
+          successful: string[];
+          failed: Array<{ userId: string; reason: string; sqlstate?: string }>;
+        };
+        correlationId: string;
+      }>('sync_role_assignments', {
         p_role_id: params.roleId,
         p_user_ids_to_add: params.userIdsToAdd,
         p_user_ids_to_remove: params.userIdsToRemove,
@@ -916,36 +822,28 @@ export class SupabaseRoleService implements IRoleService {
         throw new Error(`Sync assignment failed (Ref: ${correlationId}): ${error.message}`);
       }
 
-      const response = data as {
-        added: {
-          successful: string[];
-          failed: Array<{ userId: string; reason: string; sqlstate?: string }>;
-        };
-        removed: {
-          successful: string[];
-          failed: Array<{ userId: string; reason: string; sqlstate?: string }>;
-        };
-        correlationId: string;
-      };
+      if (!data) {
+        throw new Error(`Sync assignment failed (Ref: ${correlationId}): no response data`);
+      }
 
       log.info('Sync assignments completed', {
-        addedSuccessful: response.added.successful.length,
-        addedFailed: response.added.failed.length,
-        removedSuccessful: response.removed.successful.length,
-        removedFailed: response.removed.failed.length,
-        correlationId: response.correlationId,
+        addedSuccessful: data.added.successful.length,
+        addedFailed: data.added.failed.length,
+        removedSuccessful: data.removed.successful.length,
+        removedFailed: data.removed.failed.length,
+        correlationId: data.correlationId,
       });
 
       return {
         added: {
-          successful: response.added.successful || [],
-          failed: response.added.failed || [],
+          successful: data.added.successful || [],
+          failed: data.added.failed || [],
         },
         removed: {
-          successful: response.removed.successful || [],
-          failed: response.removed.failed || [],
+          successful: data.removed.successful || [],
+          failed: data.removed.failed || [],
         },
-        correlationId: response.correlationId || correlationId,
+        correlationId: data.correlationId || correlationId,
       };
     } catch (err) {
       log.error('Exception in syncRoleAssignments', {

--- a/frontend/src/services/roles/__tests__/SupabaseRoleService.test.ts
+++ b/frontend/src/services/roles/__tests__/SupabaseRoleService.test.ts
@@ -1,0 +1,184 @@
+/**
+ * SupabaseRoleService — error mapping + count round-trip tests
+ *
+ * Addresses architect review NT-2b on PR #56: `mapErrorDetails` is the only
+ * place `count` (preserved via envelope.ts NT-3 fix) enters the service-level
+ * result. End-to-end test locks the count-preservation chain before PR-B/PR-C
+ * replicate the mapping pattern across more services (e.g. OrganizationUnits
+ * has structurally identical mapErrorDetails with HAS_ROLES + count).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockApiRpcEnvelope, mockApiRpc } = vi.hoisted(() => ({
+  mockApiRpcEnvelope: vi.fn(),
+  mockApiRpc: vi.fn(),
+}));
+
+vi.mock('@/services/auth/supabase.service', () => ({
+  supabaseService: { apiRpcEnvelope: mockApiRpcEnvelope, apiRpc: mockApiRpc },
+}));
+
+import { SupabaseRoleService } from '../SupabaseRoleService';
+
+describe('SupabaseRoleService', () => {
+  let service: SupabaseRoleService;
+
+  beforeEach(() => {
+    mockApiRpcEnvelope.mockReset();
+    mockApiRpc.mockReset();
+    service = new SupabaseRoleService();
+  });
+
+  describe('deleteRole — count round-trip (NT-2b regression guard)', () => {
+    it('preserves errorDetails.count for HAS_USERS blocking error', async () => {
+      mockApiRpcEnvelope.mockResolvedValueOnce({
+        success: false,
+        error: 'Cannot delete: role has users assigned',
+        errorDetails: {
+          code: 'HAS_USERS',
+          count: 5,
+          message: 'Cannot delete: 5 users assigned',
+        },
+      });
+
+      const result = await service.deleteRole('role-1');
+
+      expect(result.success).toBe(false);
+      expect(result.errorDetails?.code).toBe('HAS_USERS');
+      expect(result.errorDetails?.count).toBe(5);
+      expect(result.errorDetails?.message).toBe('Cannot delete: 5 users assigned');
+    });
+
+    it('preserves count = 0 (falsy but defined)', async () => {
+      mockApiRpcEnvelope.mockResolvedValueOnce({
+        success: false,
+        error: 'err',
+        errorDetails: { code: 'HAS_USERS', count: 0, message: 'm' },
+      });
+
+      const result = await service.deleteRole('role-1');
+      expect(result.errorDetails?.count).toBe(0);
+    });
+
+    it('handles missing errorDetails (undefined mapping)', async () => {
+      mockApiRpcEnvelope.mockResolvedValueOnce({ success: false, error: 'bare error' });
+
+      const result = await service.deleteRole('role-1');
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('bare error');
+      expect(result.errorDetails).toBeUndefined();
+    });
+  });
+
+  describe('mapErrorDetails — code translation', () => {
+    it('maps known error codes', async () => {
+      const cases: Array<[string, string]> = [
+        ['NOT_FOUND', 'NOT_FOUND'],
+        ['ALREADY_ACTIVE', 'ALREADY_ACTIVE'],
+        ['ALREADY_INACTIVE', 'ALREADY_INACTIVE'],
+        ['HAS_USERS', 'HAS_USERS'],
+        ['SUBSET_ONLY_VIOLATION', 'SUBSET_ONLY_VIOLATION'],
+        ['PERMISSION_DENIED', 'PERMISSION_DENIED'],
+      ];
+
+      for (const [input, expected] of cases) {
+        mockApiRpcEnvelope.mockResolvedValueOnce({
+          success: false,
+          error: 'e',
+          errorDetails: { code: input, message: 'm' },
+        });
+        const result = await service.deleteRole('r1');
+        expect(result.errorDetails?.code).toBe(expected);
+      }
+    });
+
+    it('falls back to UNKNOWN for unrecognized code', async () => {
+      mockApiRpcEnvelope.mockResolvedValueOnce({
+        success: false,
+        error: 'e',
+        errorDetails: { code: 'SOMETHING_NEW', message: 'm' },
+      });
+
+      const result = await service.deleteRole('r1');
+      expect(result.errorDetails?.code).toBe('UNKNOWN');
+    });
+  });
+
+  describe('PostgREST-level failure path (NT-1 — DIAG_RPC_ERROR signal)', () => {
+    it('createRole returns UNKNOWN errorDetails when env.postgrestError is set', async () => {
+      mockApiRpcEnvelope.mockResolvedValueOnce({
+        success: false,
+        error: 'permission denied',
+        postgrestError: { code: '42501', message: 'permission denied', details: '', hint: '' },
+      });
+
+      const result = await service.createRole({
+        name: 'r',
+        description: 'd',
+        permissionIds: [],
+      } as never);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('permission denied');
+      expect(result.errorDetails?.code).toBe('UNKNOWN');
+    });
+  });
+
+  describe('read-path throw contract', () => {
+    it('getRoles throws on apiRpc error', async () => {
+      mockApiRpc.mockResolvedValueOnce({
+        data: null,
+        error: { code: '500', message: 'db down', details: '', hint: '' },
+      });
+
+      await expect(service.getRoles()).rejects.toThrow('Failed to fetch roles: db down');
+    });
+
+    it('listUsersForBulkAssignment throws on apiRpc error', async () => {
+      mockApiRpc.mockResolvedValueOnce({
+        data: null,
+        error: { code: '500', message: 'db down', details: '', hint: '' },
+      });
+
+      await expect(
+        service.listUsersForBulkAssignment({
+          roleId: 'r1',
+          scopePath: 'org_root',
+          limit: 10,
+          offset: 0,
+        } as never)
+      ).rejects.toThrow('Failed to list users: db down');
+    });
+  });
+
+  describe('success path mapping', () => {
+    it('createRole maps camelCase RPC fields to camelCase Role with permissionCount', async () => {
+      mockApiRpcEnvelope.mockResolvedValueOnce({
+        success: true,
+        role: {
+          id: 'r1',
+          name: 'Provider Admin',
+          description: 'd',
+          organizationId: 'o1',
+          orgHierarchyScope: null,
+          isActive: true,
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+      });
+
+      const result = await service.createRole({
+        name: 'Provider Admin',
+        description: 'd',
+        permissionIds: ['p1', 'p2', 'p3'],
+      } as never);
+
+      expect(result.success).toBe(true);
+      expect(result.role?.id).toBe('r1');
+      expect(result.role?.permissionCount).toBe(3); // from request, not from RPC
+      expect(result.role?.userCount).toBe(0);
+      expect(result.role?.createdAt).toBeInstanceOf(Date);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

PR-A of 3 (defense-in-depth migration of frontend services to use the typed `supabaseService.apiRpc<T>` / `apiRpcEnvelope<T>` helpers introduced by PR #43). Pilots the typed-dynamic-name pattern (Entity) and the mixed-shape pattern (Roles) before the bulk wave (PR-B) and closeout + ESLint rule activation (PR-C).

**Card**: `dev/active/migrate-services-to-api-rpc-envelope/`
**Plan**: incorporated architect-dbc review (verdict APPROVE WITH IN-PR FIXES); see commit message body.

## Migrations in this PR

| Service | Sites | Pattern proven |
|---|---|---|
| `SupabaseOrganizationEntityService.ts` | 1 envelope (via shared `callEntityRpc`) | Typed dynamic-name: `rpcName: EnvelopeRpcs` |
| `SupabaseRoleService.ts` | 5 envelope + 8 read | Mixed-shape; throw-on-error preserved for reads |

**Total**: 14 sites of the 85 total to migrate across 3 PRs.

## Scope additions vs. plan

- `frontend/src/services/api/envelope.ts` — added `count?: number` to `EnvelopeErrorDetails`. Plan v2 said envelope.ts must not be modified; this single-field addition was necessary to preserve the real-world `delete_role` / `deactivate_organization_unit` contract (`HAS_USERS` / `HAS_ROLES` errors emit `count` consumed by `OrganizationUnitsManagePage.tsx:562` cannot-delete dialog). Without the field, the count was silently stripped at the SDK boundary.

## Phase 0 inventory corrections

The persisted inventory (`dev/active/migrate-services-to-api-rpc-envelope/inventory.md`) corrects the original Explore-agent count from 76 to **85 sites** across **11 service files** (architect-dbc BLOCKER finding #1). The 9-site delta came from:

- **6 multi-line chained-form sites missed by single-line regex**: `direct-care/SupabaseDirectCareSettingsService.ts` (2), `assignment/SupabaseAssignmentService.ts` (3), `organization/getOrganizationSubdomainInfo.ts` (1, with `.single<T>()`).
- **3 misclassifications**: `bulk_assign_role` and `sync_role_assignments` are **read** per M3 registry (Explore agent said envelope; service code never checks `data.success`); `get_field_usage_count` and `get_category_field_count` are **envelope** per M3 registry. The M3 registry is the source of truth — wrong-helper-for-shape is a TypeScript compile error.

## Test plan

- [x] `npm run typecheck` green
- [x] `npm run test -- --run` — 56 fails / 522 pass, **exact match** to pre-existing baseline per `dev/active/frontend-test-stabilization-seed.md` (Playwright spec mis-collection + 4 unrelated test files with pre-existing failures). Zero regressions from this PR.
- [x] `npm run build` green
- [ ] Manual smoke (post-deploy): role creation / role update / single role deletion on dev — confirm rich error display on `HAS_USERS` (the cannot-delete dialog uses the preserved `count` field).

## Open question resolutions (Phase 0)

Documented in detail at `dev/active/migrate-services-to-api-rpc-envelope/tasks.md`. Summary:

- **Q1 dynamic names**: `rpcName: EnvelopeRpcs` typing on Entity wrapper
- **Q2 test mocks**: deferred to PR-B (Client Fields)
- **Q3 dead imports**: dropped per file
- **Q4 lint lifecycle**: accept the window — rule activates only in PR-C, user controls cadence
- **Q5 `.single<T>()`**: refactor in place — deferred to PR-C
- **Q6 Schedule throw/return**: deferred to PR-B
- **Q7 selector scope**: noted for PR-C

## What's NOT in this PR

- ESLint rule activation (PR-C)
- Bulk wave services (PR-B): OrgCommand, OrgUnit, ClientFields, Schedule, DirectCare, Assignment
- Closeout services (PR-C): Clients (25 sites), OrgQuery, getOrganizationSubdomainInfo

🤖 Generated with [Claude Code](https://claude.com/claude-code)