### PR TITLE
refactor(services): PR-B bulk wave — migrate 6 services to apiRpcEnvelope/apiRpc

### DIFF
--- a/dev/active/migrate-services-to-api-rpc-envelope/inventory.md
+++ b/dev/active/migrate-services-to-api-rpc-envelope/inventory.md
@@ -2,7 +2,7 @@
 
 **Generated**: 2026-05-11 during PR-A planning
 **Source of truth**: `frontend/src/services/api/rpc-registry.generated.ts` (M3 enforcement — `EnvelopeRpcs` and `ReadRpcs` string-literal unions emitted from `COMMENT ON FUNCTION api.<name> IS '... @a4c-rpc-shape: envelope|read'` tags)
-**Total**: 85 production sites across 11 service files (65 envelope + 20 read; 2 SDK helper definitions and 5 doc-example matches in `services/CLAUDE.md` excluded)
+**Total**: 89 production sites across 11 service files (67 envelope + 22 read; 2 SDK helper definitions and 5 doc-example matches in `services/CLAUDE.md` excluded). _Revised during PR-B implementation 2026-05-11: original count of 85 missed 4 multi-line-chain sites in `OrgUnit.getDescendants` (1 read) and an extra read in `ClientFields.listFieldDefinitions` (1 read), plus the `OrgCommand`/`OrgUnit` Q6 throw guards revealed 2 additional envelope-success-path classifications that affected per-service splits in ClientFields (now 13+2=15 not 13+1=14)._
 
 ---
 

--- a/dev/active/migrate-services-to-api-rpc-envelope/inventory.md
+++ b/dev/active/migrate-services-to-api-rpc-envelope/inventory.md
@@ -2,7 +2,7 @@
 
 **Generated**: 2026-05-11 during PR-A planning
 **Source of truth**: `frontend/src/services/api/rpc-registry.generated.ts` (M3 enforcement — `EnvelopeRpcs` and `ReadRpcs` string-literal unions emitted from `COMMENT ON FUNCTION api.<name> IS '... @a4c-rpc-shape: envelope|read'` tags)
-**Total**: 89 production sites across 11 service files (67 envelope + 22 read; 2 SDK helper definitions and 5 doc-example matches in `services/CLAUDE.md` excluded). _Revised during PR-B implementation 2026-05-11: original count of 85 missed 4 multi-line-chain sites in `OrgUnit.getDescendants` (1 read) and an extra read in `ClientFields.listFieldDefinitions` (1 read), plus the `OrgCommand`/`OrgUnit` Q6 throw guards revealed 2 additional envelope-success-path classifications that affected per-service splits in ClientFields (now 13+2=15 not 13+1=14)._
+**Total**: 87 production sites across 11 service files (65 envelope + 22 read; 2 SDK helper definitions and 5 doc-example matches in `services/CLAUDE.md` excluded). _Revised during PR-B implementation 2026-05-11: original count of 85 missed 2 multi-line-chain sites — `OrgUnit.getDescendants` (1 read) and `ClientFields.listFieldDefinitions` (1 read) — both surfaced when migrating the affected services. The aggregate row and the affected per-service tables (OrgUnit, ClientFields) below reflect the corrected counts._
 
 ---
 
@@ -38,17 +38,18 @@ Note: uses `{data: result, error}` destructure variant.
 
 The 9 public methods (`createContact`, `updateContact`, `deleteContact`, `createAddress`, `updateAddress`, `deleteAddress`, `createPhone`, `updatePhone`, `deletePhone`) all dispatch to `callEntityRpc` with static literal RPC names. All 9 literals are members of `EnvelopeRpcs`, so re-typing `rpcName: EnvelopeRpcs` keeps the polymorphism while routing through `apiRpcEnvelope`.
 
-#### `SupabaseOrganizationUnitService.ts` (5 envelope + 2 read)
+#### `SupabaseOrganizationUnitService.ts` (5 envelope + 3 read)
 
 | Line | Method | RPC | Shape |
 |---|---|---|---|
-| 190 | `getUnits`        | `get_organization_units`         | read |
-| 217 | `getUnitById`     | `get_organization_unit_by_id`    | read |
-| 277 | `createUnit`      | `create_organization_unit`       | env |
-| 350 | `updateUnit`      | `update_organization_unit`       | env |
-| 421 | `deactivateUnit`  | `deactivate_organization_unit`   | env |
-| 488 | `reactivateUnit`  | `reactivate_organization_unit`   | env |
-| 556 | `deleteUnit`      | `delete_organization_unit`       | env |
+| 190 | `getUnits`        | `get_organization_units`              | read |
+| 217 | `getUnitById`     | `get_organization_unit_by_id`         | read |
+| 247 | `getDescendants`  | `get_organization_unit_descendants`   | read |
+| 277 | `createUnit`      | `create_organization_unit`            | env |
+| 350 | `updateUnit`      | `update_organization_unit`            | env |
+| 421 | `deactivateUnit`  | `deactivate_organization_unit`        | env |
+| 488 | `reactivateUnit`  | `reactivate_organization_unit`        | env |
+| 556 | `deleteUnit`      | `delete_organization_unit`            | env |
 
 #### `getOrganizationSubdomainInfo.ts` (1 read, special)
 
@@ -58,10 +59,11 @@ The 9 public methods (`createContact`, `updateContact`, `deleteContact`, `create
 
 ### client-fields/
 
-#### `SupabaseClientFieldService.ts` (13 envelope + 1 read)
+#### `SupabaseClientFieldService.ts` (13 envelope + 2 read)
 
 | Line | Method | RPC | Shape |
 |---|---|---|---|
+| 28  | `listFieldDefinitions`        | `list_field_definitions`         | read |
 | 50  | `batchUpdateFieldDefinitions` | `batch_update_field_definitions` | env |
 | 72  | `createFieldDefinition`       | `create_field_definition`       | env |
 | 100 | `updateFieldDefinition`       | `update_field_definition`       | env |
@@ -170,15 +172,15 @@ All 25 sites are writes routed through local `parseResponse(data)` helper which 
 | OrgQuery | 0 | 4 | 4 |
 | OrgCommand | 4 | 0 | 4 |
 | OrgEntity | 1 | 0 | 1 |
-| OrgUnit | 5 | 2 | 7 |
+| OrgUnit | 5 | 3 | 8 |
 | OrgSubdomain | 0 | 1 | 1 |
-| ClientFields | 13 | 1 | 14 |
+| ClientFields | 13 | 2 | 15 |
 | Roles | 5 | 8 | 13 |
 | Schedule | 9 | 2 | 11 |
 | Clients | 25 | 0 | 25 |
 | DirectCare | 1 | 1 | 2 |
 | Assignment | 2 | 1 | 3 |
-| **TOTAL** | **65** | **20** | **85** |
+| **TOTAL** | **65** | **22** | **87** |
 
 ---
 
@@ -198,6 +200,7 @@ These services already consume `supabaseService.apiRpc` / `apiRpcEnvelope`:
 - **PR-A pilots (14 sites)**: OrgEntity (1 env) + Roles (5 env + 8 read = 13)
 - **PR-B bulk (41 sites)**: OrgCommand (4) + OrgUnit (5+2) + ClientFields (13+1) + Schedule (9+2) + DirectCare (1+1) + Assignment (2+1)
 - **PR-C closeout (30 sites + rule)**: Clients (25) + OrgQuery (4) + OrgSubdomain (1 — refactor in place) + activate ESLint rule
+  - **Pre-PR-C inventory refresh methodology** (architect review F3, PR #57): the original Phase 0 single-line regex `\.schema\(['\"]api['\"]\)\.rpc` missed 4 multi-line chained-form sites across PR-A/B. Before opening PR-C, re-run the inventory with a multi-line-aware approach over all PR-C target files: `grep -Pzo "(?s)\.schema\(['\"]api['\"]\).*?\.rpc\(" frontend/src/services/clients/ frontend/src/services/organization/SupabaseOrganizationQueryService.ts frontend/src/services/organization/getOrganizationSubdomainInfo.ts` — or equivalent multi-line regex (`[\s\S]` rather than `.*`). `SupabaseClientService.ts` is the highest-risk target at 25 sites and may itself contain multi-line forms not visible to the single-line grep.
 
 ## Open question resolutions
 

--- a/frontend/src/services/api/__tests__/envelope.test.ts
+++ b/frontend/src/services/api/__tests__/envelope.test.ts
@@ -10,7 +10,8 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import type { PostgrestSingleResponse } from '@supabase/supabase-js';
-import { unwrapApiEnvelope } from '../envelope';
+import type { ApiEnvelope } from '../envelope';
+import { unwrapApiEnvelope, throwIfPostgrestError } from '../envelope';
 
 // Stub maskPii to be identity so tests assert on shape, not masking behavior.
 vi.mock('@/utils/maskPii', () => ({
@@ -101,5 +102,50 @@ describe('unwrapApiEnvelope', () => {
       expect(result.postgrestError?.code).toBe('42501');
       expect(result.error).toBe('permission denied');
     });
+  });
+});
+
+describe('throwIfPostgrestError', () => {
+  it('throws "Failed to <verb>: <error>" on PostgREST-shape failure', () => {
+    const env: ApiEnvelope<Record<string, unknown>> = {
+      success: false,
+      error: 'permission denied',
+      postgrestError: { code: '42501', message: 'permission denied', details: '', hint: '' },
+    };
+
+    expect(() => throwIfPostgrestError(env, 'create field')).toThrow(
+      'Failed to create field: permission denied'
+    );
+  });
+
+  it('does NOT throw on handler-driven envelope failure (no postgrestError)', () => {
+    const env: ApiEnvelope<Record<string, unknown>> = {
+      success: false,
+      error: 'Field key already exists',
+      errorDetails: { code: 'DUPLICATE_KEY', message: 'm' },
+    };
+
+    expect(() => throwIfPostgrestError(env, 'create field')).not.toThrow();
+  });
+
+  it('does NOT throw on success envelope', () => {
+    const env: ApiEnvelope<{ field_id: string }> = {
+      success: true,
+      field_id: 'f1',
+    };
+
+    expect(() => throwIfPostgrestError(env, 'create field')).not.toThrow();
+  });
+
+  it('passes through the verb verbatim in the thrown message', () => {
+    const env: ApiEnvelope<Record<string, unknown>> = {
+      success: false,
+      error: 'boom',
+      postgrestError: { code: '500', message: 'boom', details: '', hint: '' },
+    };
+
+    expect(() => throwIfPostgrestError(env, 'deactivate category')).toThrow(
+      'Failed to deactivate category: boom'
+    );
   });
 });

--- a/frontend/src/services/api/__tests__/envelope.test.ts
+++ b/frontend/src/services/api/__tests__/envelope.test.ts
@@ -8,7 +8,7 @@
  * re-strip the field unintentionally.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { PostgrestSingleResponse } from '@supabase/supabase-js';
 import type { ApiEnvelope } from '../envelope';
 import { unwrapApiEnvelope, throwIfPostgrestError } from '../envelope';
@@ -16,6 +16,21 @@ import { unwrapApiEnvelope, throwIfPostgrestError } from '../envelope';
 // Stub maskPii to be identity so tests assert on shape, not masking behavior.
 vi.mock('@/utils/maskPii', () => ({
   maskPii: (s: string) => s,
+}));
+
+// Stub Logger so tests can assert on the service-boundary error-emission contract
+// (architect-approved 2026-05-11). `mockLogError` is the only handle we need —
+// the helper only ever calls `log.error`.
+const { mockLogError } = vi.hoisted(() => ({ mockLogError: vi.fn() }));
+vi.mock('@/utils/logger', () => ({
+  Logger: {
+    getLogger: () => ({
+      error: mockLogError,
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+    }),
+  },
 }));
 
 function rpcOk<T>(data: T): PostgrestSingleResponse<unknown> {
@@ -106,6 +121,10 @@ describe('unwrapApiEnvelope', () => {
 });
 
 describe('throwIfPostgrestError', () => {
+  beforeEach(() => {
+    mockLogError.mockReset();
+  });
+
   it('throws "Failed to <verb>: <error>" on PostgREST-shape failure', () => {
     const env: ApiEnvelope<Record<string, unknown>> = {
       success: false,
@@ -147,5 +166,89 @@ describe('throwIfPostgrestError', () => {
     expect(() => throwIfPostgrestError(env, 'deactivate category')).toThrow(
       'Failed to deactivate category: boom'
     );
+  });
+
+  describe('log emission contract (architect-approved 2026-05-11)', () => {
+    it('calls log.error exactly once on PostgREST-shape failure', () => {
+      const env: ApiEnvelope<Record<string, unknown>> = {
+        success: false,
+        error: 'permission denied',
+        postgrestError: { code: '42501', message: 'permission denied', details: '', hint: '' },
+      };
+
+      expect(() => throwIfPostgrestError(env, 'create field')).toThrow();
+
+      expect(mockLogError).toHaveBeenCalledTimes(1);
+      expect(mockLogError).toHaveBeenCalledWith('Failed to create field', {
+        error: 'permission denied',
+      });
+    });
+
+    it('does NOT call log.error on handler-driven envelope failure', () => {
+      const env: ApiEnvelope<Record<string, unknown>> = {
+        success: false,
+        error: 'Field key already exists',
+        errorDetails: { code: 'DUPLICATE_KEY', message: 'm' },
+      };
+
+      expect(() => throwIfPostgrestError(env, 'create field')).not.toThrow();
+      expect(mockLogError).not.toHaveBeenCalled();
+    });
+
+    it('does NOT call log.error on success envelope', () => {
+      const env: ApiEnvelope<{ field_id: string }> = {
+        success: true,
+        field_id: 'f1',
+      };
+
+      expect(() => throwIfPostgrestError(env, 'create field')).not.toThrow();
+      expect(mockLogError).not.toHaveBeenCalled();
+    });
+
+    it('log.error count exactly tracks PostgREST-failure count across a mixed batch', () => {
+      // Three PostgREST failures interleaved with two success and one
+      // handler-driven failure; expect log.error to fire exactly 3×.
+      const pgFail = (): ApiEnvelope<Record<string, unknown>> => ({
+        success: false,
+        error: 'permission denied',
+        postgrestError: { code: '42501', message: 'permission denied', details: '', hint: '' },
+      });
+      const handlerFail: ApiEnvelope<Record<string, unknown>> = {
+        success: false,
+        error: 'business rule',
+        errorDetails: { code: 'X', message: 'm' },
+      };
+      const successEnv: ApiEnvelope<Record<string, unknown>> = { success: true };
+
+      try {
+        throwIfPostgrestError(pgFail(), 'a');
+      } catch {
+        /* expected */
+      }
+      throwIfPostgrestError(successEnv, 'b');
+      try {
+        throwIfPostgrestError(pgFail(), 'c');
+      } catch {
+        /* expected */
+      }
+      throwIfPostgrestError(handlerFail, 'd');
+      try {
+        throwIfPostgrestError(pgFail(), 'e');
+      } catch {
+        /* expected */
+      }
+      throwIfPostgrestError(successEnv, 'f');
+
+      expect(mockLogError).toHaveBeenCalledTimes(3);
+      expect(mockLogError).toHaveBeenNthCalledWith(1, 'Failed to a', {
+        error: 'permission denied',
+      });
+      expect(mockLogError).toHaveBeenNthCalledWith(2, 'Failed to c', {
+        error: 'permission denied',
+      });
+      expect(mockLogError).toHaveBeenNthCalledWith(3, 'Failed to e', {
+        error: 'permission denied',
+      });
+    });
   });
 });

--- a/frontend/src/services/api/envelope.ts
+++ b/frontend/src/services/api/envelope.ts
@@ -1,5 +1,8 @@
 import type { PostgrestError, PostgrestSingleResponse } from '@supabase/supabase-js';
 import { maskPii } from '@/utils/maskPii';
+import { Logger } from '@/utils/logger';
+
+const log = Logger.getLogger('api');
 
 /**
  * Typed boundary for `api.*` RPC envelopes (Pattern A v2).
@@ -111,6 +114,13 @@ export function throwIfPostgrestError(
   verb: string
 ): void {
   if (!env.success && env.postgrestError) {
+    // Service-boundary observability for PostgREST 4xx/5xx (auth, RLS, schema).
+    // Restored from the pre-promotion in-helper log on
+    // SupabaseClientFieldService — at the SDK boundary so all current and
+    // future callers (PR-C `SupabaseClientService` + any later migrations)
+    // get the signal automatically without per-caller boilerplate.
+    // Architect-approved 2026-05-11 (PR #57 re-review consultation).
+    log.error(`Failed to ${verb}`, { error: env.error });
     throw new Error(`Failed to ${verb}: ${env.error}`);
   }
 }

--- a/frontend/src/services/api/envelope.ts
+++ b/frontend/src/services/api/envelope.ts
@@ -88,6 +88,34 @@ export type ApiEnvelope<T extends Record<string, unknown> = Record<string, never
   | ApiEnvelopeFailure;
 
 /**
+ * Preserve the pre-migration throw-on-PostgREST-error contract used by services
+ * that historically threw `new Error('Failed to <verb>: <message>')` whenever
+ * the raw `.rpc()` call returned a non-null PostgREST `error` (401, 42501, 5xx).
+ *
+ * After routing through `apiRpcEnvelope<T>`, those failures surface as
+ * `{success: false, postgrestError: {...}, error: '<masked>'}`. Use this helper
+ * immediately after the `await` to short-circuit on PostgREST-shape failures
+ * while letting handler-driven envelope failures flow through as a typed
+ * `{success: false, ...}` return (callers pattern-match on `result.success`).
+ *
+ * Promoted from `SupabaseClientFieldService` to the SDK boundary (PR #57
+ * architect review P2) so PR-C's bulk wave can adopt the same contract without
+ * inline-helper drift across services.
+ *
+ * @throws Error with `Failed to ${verb}: ${env.error}` if `env.postgrestError`
+ *   is set on a failure envelope. Does nothing if `env.success` is `true` or if
+ *   the failure has no `postgrestError`.
+ */
+export function throwIfPostgrestError(
+  env: ApiEnvelope<Record<string, unknown>>,
+  verb: string
+): void {
+  if (!env.success && env.postgrestError) {
+    throw new Error(`Failed to ${verb}: ${env.error}`);
+  }
+}
+
+/**
  * Mask all PII-bearing string fields on a PostgrestError.
  * Returns a NEW object (does not mutate the input).
  */

--- a/frontend/src/services/assignment/SupabaseAssignmentService.ts
+++ b/frontend/src/services/assignment/SupabaseAssignmentService.ts
@@ -9,7 +9,7 @@
  * @see api.list_user_client_assignments()
  */
 
-import { supabase } from '@/lib/supabase';
+import { supabaseService } from '@/services/auth/supabase.service';
 import { Logger } from '@/utils/logger';
 import type { UserClientAssignment } from '@/types/client-assignment.types';
 import type { IAssignmentService } from './IAssignmentService';
@@ -25,27 +25,24 @@ export class SupabaseAssignmentService implements IAssignmentService {
   }): Promise<UserClientAssignment[]> {
     log.debug('Listing assignments', params);
 
-    const { data, error } = await supabase
-      .schema('api')
-      .rpc('list_user_client_assignments', {
+    // Registry-classified envelope (Pattern A v2 read envelope variant):
+    // returns `{success: true, data: UserClientAssignment[]}` on success.
+    const env = await supabaseService.apiRpcEnvelope<{ data?: UserClientAssignment[] }>(
+      'list_user_client_assignments',
+      {
         p_org_id: params.orgId ?? null,
         p_user_id: params.userId ?? null,
         p_client_id: params.clientId ?? null,
         p_active_only: params.activeOnly ?? true,
-      });
+      }
+    );
 
-    if (error) {
-      log.error('Failed to list assignments', { error });
-      throw new Error(`Failed to list assignments: ${error.message}`);
+    if (!env.success) {
+      log.error('Failed to list assignments', { error: env.error });
+      throw new Error(env.error ?? 'Failed to list assignments');
     }
 
-    const result = typeof data === 'string' ? JSON.parse(data) : data;
-
-    if (!result?.success) {
-      throw new Error(result?.error ?? 'Failed to list assignments');
-    }
-
-    return result.data ?? [];
+    return env.data ?? [];
   }
 
   async assignClient(params: {
@@ -57,29 +54,24 @@ export class SupabaseAssignmentService implements IAssignmentService {
   }): Promise<{ assignmentId: string }> {
     log.debug('Assigning client', { userId: params.userId, clientId: params.clientId });
 
-    const { data, error } = await supabase
-      .schema('api')
-      .rpc('assign_client_to_user', {
+    const env = await supabaseService.apiRpcEnvelope<{ assignment_id?: string }>(
+      'assign_client_to_user',
+      {
         p_user_id: params.userId,
         p_client_id: params.clientId,
         p_assigned_until: params.assignedUntil ?? null,
         p_notes: params.notes ?? null,
         p_reason: params.reason ?? null,
-      });
+      }
+    );
 
-    if (error) {
-      log.error('Failed to assign client', { error });
-      throw new Error(`Failed to assign client: ${error.message}`);
+    if (!env.success) {
+      log.error('Failed to assign client', { error: env.error });
+      throw new Error(env.error ?? 'Failed to assign client');
     }
 
-    const result = typeof data === 'string' ? JSON.parse(data) : data;
-
-    if (!result?.success) {
-      throw new Error(result?.error ?? 'Failed to assign client');
-    }
-
-    log.info('Client assigned', { assignmentId: result.assignment_id });
-    return { assignmentId: result.assignment_id };
+    log.info('Client assigned', { assignmentId: env.assignment_id });
+    return { assignmentId: env.assignment_id as string };
   }
 
   async unassignClient(params: {
@@ -89,23 +81,15 @@ export class SupabaseAssignmentService implements IAssignmentService {
   }): Promise<void> {
     log.debug('Unassigning client', { userId: params.userId, clientId: params.clientId });
 
-    const { data, error } = await supabase
-      .schema('api')
-      .rpc('unassign_client_from_user', {
-        p_user_id: params.userId,
-        p_client_id: params.clientId,
-        p_reason: params.reason ?? null,
-      });
+    const env = await supabaseService.apiRpcEnvelope('unassign_client_from_user', {
+      p_user_id: params.userId,
+      p_client_id: params.clientId,
+      p_reason: params.reason ?? null,
+    });
 
-    if (error) {
-      log.error('Failed to unassign client', { error });
-      throw new Error(`Failed to unassign client: ${error.message}`);
-    }
-
-    const result = typeof data === 'string' ? JSON.parse(data) : data;
-
-    if (!result?.success) {
-      throw new Error(result?.error ?? 'Failed to unassign client');
+    if (!env.success) {
+      log.error('Failed to unassign client', { error: env.error });
+      throw new Error(env.error ?? 'Failed to unassign client');
     }
 
     log.info('Client unassigned', { userId: params.userId, clientId: params.clientId });

--- a/frontend/src/services/client-fields/SupabaseClientFieldService.ts
+++ b/frontend/src/services/client-fields/SupabaseClientFieldService.ts
@@ -7,7 +7,7 @@
  */
 
 import { supabaseService } from '@/services/auth/supabase.service';
-import type { ApiEnvelope } from '@/services/api/envelope';
+import { throwIfPostgrestError } from '@/services/api/envelope';
 import { Logger } from '@/utils/logger';
 import type {
   FieldDefinition,
@@ -24,23 +24,6 @@ import type {
 import type { IClientFieldService } from './IClientFieldService';
 
 const log = Logger.getLogger('api');
-
-/**
- * Preserves the pre-migration throw-on-PostgREST-error contract.
- *
- * The pre-PR-B service threw `new Error('Failed to <verb>: <message>')` whenever
- * the raw `.rpc()` call returned a non-null `error` (PostgREST 4xx/5xx). After
- * routing through `apiRpcEnvelope<T>`, those failures surface as
- * `{success: false, postgrestError: {...}, error: '<masked>'}`. Envelope-driven
- * (handler-returned) failures still flow through as `{success: false, ...}` and
- * the caller pattern-matches on `result.success`.
- */
-function throwIfPostgrestError(env: ApiEnvelope<Record<string, unknown>>, verb: string): void {
-  if (!env.success && env.postgrestError) {
-    log.error(`Failed to ${verb}`, { error: env.error });
-    throw new Error(`Failed to ${verb}: ${env.error}`);
-  }
-}
 
 export class SupabaseClientFieldService implements IClientFieldService {
   async listFieldDefinitions(includeInactive = false): Promise<FieldDefinition[]> {

--- a/frontend/src/services/client-fields/SupabaseClientFieldService.ts
+++ b/frontend/src/services/client-fields/SupabaseClientFieldService.ts
@@ -6,7 +6,8 @@
  * All write methods accept optional correlationId for audit trail grouping.
  */
 
-import { supabase } from '@/lib/supabase';
+import { supabaseService } from '@/services/auth/supabase.service';
+import type { ApiEnvelope } from '@/services/api/envelope';
 import { Logger } from '@/utils/logger';
 import type {
   FieldDefinition,
@@ -24,20 +25,38 @@ import type { IClientFieldService } from './IClientFieldService';
 
 const log = Logger.getLogger('api');
 
+/**
+ * Preserves the pre-migration throw-on-PostgREST-error contract.
+ *
+ * The pre-PR-B service threw `new Error('Failed to <verb>: <message>')` whenever
+ * the raw `.rpc()` call returned a non-null `error` (PostgREST 4xx/5xx). After
+ * routing through `apiRpcEnvelope<T>`, those failures surface as
+ * `{success: false, postgrestError: {...}, error: '<masked>'}`. Envelope-driven
+ * (handler-returned) failures still flow through as `{success: false, ...}` and
+ * the caller pattern-matches on `result.success`.
+ */
+function throwIfPostgrestError(env: ApiEnvelope<Record<string, unknown>>, verb: string): void {
+  if (!env.success && env.postgrestError) {
+    log.error(`Failed to ${verb}`, { error: env.error });
+    throw new Error(`Failed to ${verb}: ${env.error}`);
+  }
+}
+
 export class SupabaseClientFieldService implements IClientFieldService {
   async listFieldDefinitions(includeInactive = false): Promise<FieldDefinition[]> {
     log.debug('Fetching field definitions', { includeInactive });
 
-    const { data, error } = await supabase
-      .schema('api')
-      .rpc('list_field_definitions', { p_include_inactive: includeInactive });
+    const { data, error } = await supabaseService.apiRpc<FieldDefinition[]>(
+      'list_field_definitions',
+      { p_include_inactive: includeInactive }
+    );
 
     if (error) {
       log.error('Failed to fetch field definitions', { error });
       throw new Error(`Failed to fetch field definitions: ${error.message}`);
     }
 
-    return (data ?? []) as FieldDefinition[];
+    return data ?? [];
   }
 
   async batchUpdateFieldDefinitions(
@@ -47,20 +66,18 @@ export class SupabaseClientFieldService implements IClientFieldService {
   ): Promise<BatchUpdateResult> {
     log.debug('Batch updating field definitions', { changeCount: changes.length, reason });
 
-    const { data, error } = await supabase.schema('api').rpc('batch_update_field_definitions', {
-      p_changes: changes,
-      p_reason: reason,
-      p_correlation_id: correlationId ?? null,
-    });
+    const env = await supabaseService.apiRpcEnvelope<Omit<BatchUpdateResult, 'success'>>(
+      'batch_update_field_definitions',
+      {
+        p_changes: changes,
+        p_reason: reason,
+        p_correlation_id: correlationId ?? null,
+      }
+    );
 
-    if (error) {
-      log.error('Failed to batch update field definitions', { error });
-      throw new Error(`Failed to batch update: ${error.message}`);
-    }
-
-    const result = typeof data === 'string' ? JSON.parse(data) : data;
-    log.info('Batch update complete', { result });
-    return result as BatchUpdateResult;
+    throwIfPostgrestError(env, 'batch update');
+    log.info('Batch update complete', { success: env.success });
+    return env as BatchUpdateResult;
   }
 
   async createFieldDefinition(
@@ -69,26 +86,24 @@ export class SupabaseClientFieldService implements IClientFieldService {
   ): Promise<FieldDefinitionResult> {
     log.debug('Creating field definition', { params });
 
-    const { data, error } = await supabase.schema('api').rpc('create_field_definition', {
-      p_field_key: params.field_key,
-      p_display_name: params.display_name,
-      p_category_id: params.category_id,
-      p_field_type: params.field_type ?? 'text',
-      p_is_visible: params.is_visible ?? true,
-      p_is_required: params.is_required ?? false,
-      p_is_dimension: params.is_dimension ?? false,
-      p_sort_order: params.sort_order ?? 0,
-      p_validation_rules: params.validation_rules ?? null,
-      p_correlation_id: correlationId ?? null,
-    });
+    const env = await supabaseService.apiRpcEnvelope<Omit<FieldDefinitionResult, 'success'>>(
+      'create_field_definition',
+      {
+        p_field_key: params.field_key,
+        p_display_name: params.display_name,
+        p_category_id: params.category_id,
+        p_field_type: params.field_type ?? 'text',
+        p_is_visible: params.is_visible ?? true,
+        p_is_required: params.is_required ?? false,
+        p_is_dimension: params.is_dimension ?? false,
+        p_sort_order: params.sort_order ?? 0,
+        p_validation_rules: params.validation_rules ?? null,
+        p_correlation_id: correlationId ?? null,
+      }
+    );
 
-    if (error) {
-      log.error('Failed to create field definition', { error });
-      throw new Error(`Failed to create field: ${error.message}`);
-    }
-
-    const result = typeof data === 'string' ? JSON.parse(data) : data;
-    return result as FieldDefinitionResult;
+    throwIfPostgrestError(env, 'create field');
+    return env as FieldDefinitionResult;
   }
 
   async updateFieldDefinition(
@@ -97,23 +112,21 @@ export class SupabaseClientFieldService implements IClientFieldService {
   ): Promise<FieldDefinitionResult> {
     log.debug('Updating field definition', { fieldId, params });
 
-    const { data, error } = await supabase.schema('api').rpc('update_field_definition', {
-      p_field_id: fieldId,
-      p_display_name: params.display_name ?? null,
-      p_category_id: params.category_id ?? null,
-      p_is_required: params.is_required ?? null,
-      p_validation_rules: params.validation_rules ?? null,
-      p_reason: params.reason ?? 'Field definition updated',
-      p_correlation_id: params.correlation_id ?? null,
-    });
+    const env = await supabaseService.apiRpcEnvelope<Omit<FieldDefinitionResult, 'success'>>(
+      'update_field_definition',
+      {
+        p_field_id: fieldId,
+        p_display_name: params.display_name ?? null,
+        p_category_id: params.category_id ?? null,
+        p_is_required: params.is_required ?? null,
+        p_validation_rules: params.validation_rules ?? null,
+        p_reason: params.reason ?? 'Field definition updated',
+        p_correlation_id: params.correlation_id ?? null,
+      }
+    );
 
-    if (error) {
-      log.error('Failed to update field definition', { error });
-      throw new Error(`Failed to update field: ${error.message}`);
-    }
-
-    const result = typeof data === 'string' ? JSON.parse(data) : data;
-    return result as FieldDefinitionResult;
+    throwIfPostgrestError(env, 'update field');
+    return env as FieldDefinitionResult;
   }
 
   async deactivateFieldDefinition(
@@ -123,19 +136,17 @@ export class SupabaseClientFieldService implements IClientFieldService {
   ): Promise<FieldDefinitionResult> {
     log.debug('Deactivating field definition', { fieldId, reason });
 
-    const { data, error } = await supabase.schema('api').rpc('deactivate_field_definition', {
-      p_field_id: fieldId,
-      p_reason: reason,
-      p_correlation_id: correlationId ?? null,
-    });
+    const env = await supabaseService.apiRpcEnvelope<Omit<FieldDefinitionResult, 'success'>>(
+      'deactivate_field_definition',
+      {
+        p_field_id: fieldId,
+        p_reason: reason,
+        p_correlation_id: correlationId ?? null,
+      }
+    );
 
-    if (error) {
-      log.error('Failed to deactivate field definition', { error });
-      throw new Error(`Failed to deactivate field: ${error.message}`);
-    }
-
-    const result = typeof data === 'string' ? JSON.parse(data) : data;
-    return result as FieldDefinitionResult;
+    throwIfPostgrestError(env, 'deactivate field');
+    return env as FieldDefinitionResult;
   }
 
   async reactivateFieldDefinition(
@@ -145,19 +156,17 @@ export class SupabaseClientFieldService implements IClientFieldService {
   ): Promise<FieldDefinitionResult> {
     log.debug('Reactivating field definition', { fieldId, reason });
 
-    const { data, error } = await supabase.schema('api').rpc('reactivate_field_definition', {
-      p_field_id: fieldId,
-      p_reason: reason,
-      p_correlation_id: correlationId ?? null,
-    });
+    const env = await supabaseService.apiRpcEnvelope<Omit<FieldDefinitionResult, 'success'>>(
+      'reactivate_field_definition',
+      {
+        p_field_id: fieldId,
+        p_reason: reason,
+        p_correlation_id: correlationId ?? null,
+      }
+    );
 
-    if (error) {
-      log.error('Failed to reactivate field definition', { error });
-      throw new Error(`Failed to reactivate field: ${error.message}`);
-    }
-
-    const result = typeof data === 'string' ? JSON.parse(data) : data;
-    return result as FieldDefinitionResult;
+    throwIfPostgrestError(env, 'reactivate field');
+    return env as FieldDefinitionResult;
   }
 
   async deleteFieldDefinition(
@@ -167,25 +176,23 @@ export class SupabaseClientFieldService implements IClientFieldService {
   ): Promise<DeleteFieldResult> {
     log.debug('Deleting field definition', { fieldId, reason });
 
-    const { data, error } = await supabase.schema('api').rpc('delete_field_definition', {
-      p_field_id: fieldId,
-      p_reason: reason,
-      p_correlation_id: correlationId ?? null,
-    });
+    const env = await supabaseService.apiRpcEnvelope<Omit<DeleteFieldResult, 'success'>>(
+      'delete_field_definition',
+      {
+        p_field_id: fieldId,
+        p_reason: reason,
+        p_correlation_id: correlationId ?? null,
+      }
+    );
 
-    if (error) {
-      log.error('Failed to delete field definition', { error });
-      throw new Error(`Failed to delete field: ${error.message}`);
-    }
-
-    const result = typeof data === 'string' ? JSON.parse(data) : data;
-    return result as DeleteFieldResult;
+    throwIfPostgrestError(env, 'delete field');
+    return env as DeleteFieldResult;
   }
 
   async listFieldCategories(includeInactive = false): Promise<FieldCategory[]> {
     log.debug('Fetching field categories', { includeInactive });
 
-    const { data, error } = await supabase.schema('api').rpc('list_field_categories', {
+    const { data, error } = await supabaseService.apiRpc<FieldCategory[]>('list_field_categories', {
       p_include_inactive: includeInactive,
     });
 
@@ -194,7 +201,7 @@ export class SupabaseClientFieldService implements IClientFieldService {
       throw new Error(`Failed to fetch categories: ${error.message}`);
     }
 
-    return (data ?? []) as FieldCategory[];
+    return data ?? [];
   }
 
   async createFieldCategory(
@@ -205,20 +212,18 @@ export class SupabaseClientFieldService implements IClientFieldService {
   ): Promise<FieldCategoryResult> {
     log.debug('Creating field category', { name, slug, sortOrder });
 
-    const { data, error } = await supabase.schema('api').rpc('create_field_category', {
-      p_name: name,
-      p_slug: slug,
-      p_sort_order: sortOrder ?? 0,
-      p_correlation_id: correlationId ?? null,
-    });
+    const env = await supabaseService.apiRpcEnvelope<Omit<FieldCategoryResult, 'success'>>(
+      'create_field_category',
+      {
+        p_name: name,
+        p_slug: slug,
+        p_sort_order: sortOrder ?? 0,
+        p_correlation_id: correlationId ?? null,
+      }
+    );
 
-    if (error) {
-      log.error('Failed to create field category', { error });
-      throw new Error(`Failed to create category: ${error.message}`);
-    }
-
-    const result = typeof data === 'string' ? JSON.parse(data) : data;
-    return result as FieldCategoryResult;
+    throwIfPostgrestError(env, 'create category');
+    return env as FieldCategoryResult;
   }
 
   async updateFieldCategory(
@@ -229,20 +234,18 @@ export class SupabaseClientFieldService implements IClientFieldService {
   ): Promise<FieldCategoryResult> {
     log.debug('Updating field category', { categoryId, name, reason });
 
-    const { data, error } = await supabase.schema('api').rpc('update_field_category', {
-      p_category_id: categoryId,
-      p_name: name,
-      p_reason: reason,
-      p_correlation_id: correlationId ?? null,
-    });
+    const env = await supabaseService.apiRpcEnvelope<Omit<FieldCategoryResult, 'success'>>(
+      'update_field_category',
+      {
+        p_category_id: categoryId,
+        p_name: name,
+        p_reason: reason,
+        p_correlation_id: correlationId ?? null,
+      }
+    );
 
-    if (error) {
-      log.error('Failed to update field category', { error });
-      throw new Error(`Failed to update category: ${error.message}`);
-    }
-
-    const result = typeof data === 'string' ? JSON.parse(data) : data;
-    return result as FieldCategoryResult;
+    throwIfPostgrestError(env, 'update category');
+    return env as FieldCategoryResult;
   }
 
   async deactivateFieldCategory(
@@ -252,19 +255,17 @@ export class SupabaseClientFieldService implements IClientFieldService {
   ): Promise<FieldCategoryResult> {
     log.debug('Deactivating field category', { categoryId, reason });
 
-    const { data, error } = await supabase.schema('api').rpc('deactivate_field_category', {
-      p_category_id: categoryId,
-      p_reason: reason,
-      p_correlation_id: correlationId ?? null,
-    });
+    const env = await supabaseService.apiRpcEnvelope<Omit<FieldCategoryResult, 'success'>>(
+      'deactivate_field_category',
+      {
+        p_category_id: categoryId,
+        p_reason: reason,
+        p_correlation_id: correlationId ?? null,
+      }
+    );
 
-    if (error) {
-      log.error('Failed to deactivate field category', { error });
-      throw new Error(`Failed to deactivate category: ${error.message}`);
-    }
-
-    const result = typeof data === 'string' ? JSON.parse(data) : data;
-    return result as FieldCategoryResult;
+    throwIfPostgrestError(env, 'deactivate category');
+    return env as FieldCategoryResult;
   }
 
   async reactivateFieldCategory(
@@ -274,19 +275,17 @@ export class SupabaseClientFieldService implements IClientFieldService {
   ): Promise<FieldCategoryResult> {
     log.debug('Reactivating field category', { categoryId, reason });
 
-    const { data, error } = await supabase.schema('api').rpc('reactivate_field_category', {
-      p_category_id: categoryId,
-      p_reason: reason,
-      p_correlation_id: correlationId ?? null,
-    });
+    const env = await supabaseService.apiRpcEnvelope<Omit<FieldCategoryResult, 'success'>>(
+      'reactivate_field_category',
+      {
+        p_category_id: categoryId,
+        p_reason: reason,
+        p_correlation_id: correlationId ?? null,
+      }
+    );
 
-    if (error) {
-      log.error('Failed to reactivate field category', { error });
-      throw new Error(`Failed to reactivate category: ${error.message}`);
-    }
-
-    const result = typeof data === 'string' ? JSON.parse(data) : data;
-    return result as FieldCategoryResult;
+    throwIfPostgrestError(env, 'reactivate category');
+    return env as FieldCategoryResult;
   }
 
   async deleteFieldCategory(
@@ -296,35 +295,32 @@ export class SupabaseClientFieldService implements IClientFieldService {
   ): Promise<DeleteCategoryResult> {
     log.debug('Deleting field category', { categoryId, reason });
 
-    const { data, error } = await supabase.schema('api').rpc('delete_field_category', {
-      p_category_id: categoryId,
-      p_reason: reason,
-      p_correlation_id: correlationId ?? null,
-    });
+    const env = await supabaseService.apiRpcEnvelope<Omit<DeleteCategoryResult, 'success'>>(
+      'delete_field_category',
+      {
+        p_category_id: categoryId,
+        p_reason: reason,
+        p_correlation_id: correlationId ?? null,
+      }
+    );
 
-    if (error) {
-      log.error('Failed to delete field category', { error });
-      throw new Error(`Failed to delete category: ${error.message}`);
-    }
-
-    const result = typeof data === 'string' ? JSON.parse(data) : data;
-    return result as DeleteCategoryResult;
+    throwIfPostgrestError(env, 'delete category');
+    return env as DeleteCategoryResult;
   }
 
   async getFieldUsageCount(fieldKey: string): Promise<{ success: boolean; count: number }> {
     log.debug('Getting field usage count', { fieldKey });
 
-    const { data, error } = await supabase.schema('api').rpc('get_field_usage_count', {
+    const env = await supabaseService.apiRpcEnvelope<{ count?: number }>('get_field_usage_count', {
       p_field_key: fieldKey,
     });
 
-    if (error) {
-      log.error('Failed to get field usage count', { error });
+    if (!env.success) {
+      log.error('Failed to get field usage count', { error: env.error });
       return { success: false, count: 0 };
     }
 
-    const result = typeof data === 'string' ? JSON.parse(data) : data;
-    return { success: true, count: result?.count ?? 0 };
+    return { success: true, count: env.count ?? 0 };
   }
 
   async getCategoryFieldCount(
@@ -333,17 +329,19 @@ export class SupabaseClientFieldService implements IClientFieldService {
   ): Promise<{ success: boolean; count: number; fields: string[] }> {
     log.debug('Getting category field count', { categoryId, includeInactive });
 
-    const { data, error } = await supabase.schema('api').rpc('get_category_field_count', {
-      p_category_id: categoryId,
-      p_include_inactive: includeInactive,
-    });
+    const env = await supabaseService.apiRpcEnvelope<{ count?: number; fields?: string[] }>(
+      'get_category_field_count',
+      {
+        p_category_id: categoryId,
+        p_include_inactive: includeInactive,
+      }
+    );
 
-    if (error) {
-      log.error('Failed to get category field count', { error });
+    if (!env.success) {
+      log.error('Failed to get category field count', { error: env.error });
       return { success: false, count: 0, fields: [] };
     }
 
-    const result = typeof data === 'string' ? JSON.parse(data) : data;
-    return { success: true, count: result?.count ?? 0, fields: result?.fields ?? [] };
+    return { success: true, count: env.count ?? 0, fields: env.fields ?? [] };
   }
 }

--- a/frontend/src/services/client-fields/__tests__/SupabaseClientFieldService.test.ts
+++ b/frontend/src/services/client-fields/__tests__/SupabaseClientFieldService.test.ts
@@ -1,5 +1,20 @@
+/**
+ * SupabaseClientFieldService — helper-mock test pattern (Q2 refactor)
+ *
+ * Pre-refactor: this file mocked `@/lib/supabase` chain directly (`schema().rpc()`).
+ * Post-refactor (PR-B Q2): mocks `supabaseService.apiRpc` / `apiRpcEnvelope` to
+ * match the canonical pattern established in PR #56 (PR-A) by
+ * `SupabaseUserCommandService.mapping.test.ts` and the PR-A pilot test files.
+ *
+ * Behavioral changes covered:
+ *  - Envelope writes return `ApiEnvelope<T>` directly (no `{data, error}` wrapper)
+ *  - PostgREST-level failures throw via `throwIfPostgrestError` (pre-migration
+ *    contract preserved); envelope-driven failures still flow through as the
+ *    typed result with `success: false`
+ *  - JSON-string-data tests are obsoleted — the SDK boundary now parses envelopes
+ */
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { SupabaseClientFieldService } from '../SupabaseClientFieldService';
 import type {
   FieldDefinition,
   FieldCategory,
@@ -9,15 +24,20 @@ import type {
   FieldCategoryResult,
 } from '@/types/client-field-settings.types';
 
-// ── Mock @/lib/supabase ──
+// Hoisted spies — see SupabaseUserCommandService.mapping.test.ts for the pattern.
+const { mockApiRpc, mockApiRpcEnvelope } = vi.hoisted(() => ({
+  mockApiRpc: vi.fn(),
+  mockApiRpcEnvelope: vi.fn(),
+}));
 
-const mockRpc = vi.fn();
-
-vi.mock('@/lib/supabase', () => ({
-  supabase: {
-    schema: () => ({ rpc: mockRpc }),
+vi.mock('@/services/auth/supabase.service', () => ({
+  supabaseService: {
+    apiRpc: mockApiRpc,
+    apiRpcEnvelope: mockApiRpcEnvelope,
   },
 }));
+
+import { SupabaseClientFieldService } from '../SupabaseClientFieldService';
 
 // ── Test fixtures ──
 
@@ -58,50 +78,60 @@ const BATCH_UPDATE_RESULT: BatchUpdateResult = {
 
 const RPC_SUCCESS: FieldDefinitionResult = { success: true, field_id: 'field-01' };
 
+/** PostgREST-level failure envelope (e.g., 401, 42501). */
+function postgrestFailure(message: string) {
+  return {
+    success: false as const,
+    error: message,
+    postgrestError: { code: '500', message, details: '', hint: '' },
+  };
+}
+
 // ── Tests ──
 
 describe('SupabaseClientFieldService', () => {
   let service: SupabaseClientFieldService;
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    mockApiRpc.mockReset();
+    mockApiRpcEnvelope.mockReset();
     service = new SupabaseClientFieldService();
   });
 
-  // ── listFieldDefinitions ──
+  // ── listFieldDefinitions ── (read shape via apiRpc)
 
   describe('listFieldDefinitions', () => {
     it('returns field definitions on success (default: includeInactive=false)', async () => {
-      mockRpc.mockResolvedValueOnce({ data: [FIELD_DEFINITION], error: null });
+      mockApiRpc.mockResolvedValueOnce({ data: [FIELD_DEFINITION], error: null });
 
       const result = await service.listFieldDefinitions();
 
-      expect(mockRpc).toHaveBeenCalledWith('list_field_definitions', {
+      expect(mockApiRpc).toHaveBeenCalledWith('list_field_definitions', {
         p_include_inactive: false,
       });
       expect(result).toEqual([FIELD_DEFINITION]);
     });
 
     it('passes p_include_inactive: true when requested', async () => {
-      mockRpc.mockResolvedValueOnce({ data: [FIELD_DEFINITION], error: null });
+      mockApiRpc.mockResolvedValueOnce({ data: [FIELD_DEFINITION], error: null });
 
       await service.listFieldDefinitions(true);
 
-      expect(mockRpc).toHaveBeenCalledWith('list_field_definitions', {
+      expect(mockApiRpc).toHaveBeenCalledWith('list_field_definitions', {
         p_include_inactive: true,
       });
     });
 
     it('returns empty array when data is null', async () => {
-      mockRpc.mockResolvedValueOnce({ data: null, error: null });
+      mockApiRpc.mockResolvedValueOnce({ data: null, error: null });
 
       const result = await service.listFieldDefinitions();
 
       expect(result).toEqual([]);
     });
 
-    it('throws with descriptive message on error', async () => {
-      mockRpc.mockResolvedValueOnce({
+    it('throws with descriptive message on apiRpc error', async () => {
+      mockApiRpc.mockResolvedValueOnce({
         data: null,
         error: { message: 'permission denied for schema api' },
       });
@@ -112,7 +142,7 @@ describe('SupabaseClientFieldService', () => {
     });
   });
 
-  // ── batchUpdateFieldDefinitions ──
+  // ── batchUpdateFieldDefinitions ── (envelope shape via apiRpcEnvelope)
 
   describe('batchUpdateFieldDefinitions', () => {
     const changes = [
@@ -121,12 +151,12 @@ describe('SupabaseClientFieldService', () => {
     ];
     const reason = 'Updating visibility for audit compliance';
 
-    it('returns BatchUpdateResult on success with object data', async () => {
-      mockRpc.mockResolvedValueOnce({ data: BATCH_UPDATE_RESULT, error: null });
+    it('returns BatchUpdateResult on success', async () => {
+      mockApiRpcEnvelope.mockResolvedValueOnce(BATCH_UPDATE_RESULT);
 
       const result = await service.batchUpdateFieldDefinitions(changes, reason);
 
-      expect(mockRpc).toHaveBeenCalledWith('batch_update_field_definitions', {
+      expect(mockApiRpcEnvelope).toHaveBeenCalledWith('batch_update_field_definitions', {
         p_changes: changes,
         p_reason: reason,
         p_correlation_id: null,
@@ -134,36 +164,21 @@ describe('SupabaseClientFieldService', () => {
       expect(result).toEqual(BATCH_UPDATE_RESULT);
     });
 
-    it('parses JSON string data response', async () => {
-      mockRpc.mockResolvedValueOnce({
-        data: JSON.stringify(BATCH_UPDATE_RESULT),
-        error: null,
-      });
-
-      const result = await service.batchUpdateFieldDefinitions(changes, reason);
-
-      expect(result).toEqual(BATCH_UPDATE_RESULT);
-    });
-
     it('passes changes as array (no double stringification)', async () => {
-      // Regression protection: commit 4849122b removed double JSON
-      // serialization — p_changes must be the array itself, not a stringified
-      // JSON blob. The Supabase JS client serializes JSONB params on transport.
-      mockRpc.mockResolvedValueOnce({ data: BATCH_UPDATE_RESULT, error: null });
+      mockApiRpcEnvelope.mockResolvedValueOnce(BATCH_UPDATE_RESULT);
 
       await service.batchUpdateFieldDefinitions(changes, reason);
 
-      const callArgs = mockRpc.mock.calls[0][1];
+      const callArgs = mockApiRpcEnvelope.mock.calls[0][1] as { p_changes: unknown };
       expect(callArgs.p_changes).toEqual(changes);
       expect(Array.isArray(callArgs.p_changes)).toBe(true);
       expect(typeof callArgs.p_changes).not.toBe('string');
     });
 
-    it('throws with descriptive message on error', async () => {
-      mockRpc.mockResolvedValueOnce({
-        data: null,
-        error: { message: 'batch update failed: field not found' },
-      });
+    it('throws with descriptive message on PostgREST error', async () => {
+      mockApiRpcEnvelope.mockResolvedValueOnce(
+        postgrestFailure('batch update failed: field not found')
+      );
 
       await expect(service.batchUpdateFieldDefinitions(changes, reason)).rejects.toThrow(
         'Failed to batch update: batch update failed: field not found'
@@ -171,11 +186,11 @@ describe('SupabaseClientFieldService', () => {
     });
   });
 
-  // ── createFieldDefinition ──
+  // ── createFieldDefinition ── (envelope shape)
 
   describe('createFieldDefinition', () => {
     it('returns RpcResult on success with all params provided', async () => {
-      mockRpc.mockResolvedValueOnce({ data: RPC_SUCCESS, error: null });
+      mockApiRpcEnvelope.mockResolvedValueOnce(RPC_SUCCESS);
 
       const params: CreateFieldDefinitionParams = {
         field_key: 'custom_notes',
@@ -191,7 +206,7 @@ describe('SupabaseClientFieldService', () => {
 
       const result = await service.createFieldDefinition(params);
 
-      expect(mockRpc).toHaveBeenCalledWith('create_field_definition', {
+      expect(mockApiRpcEnvelope).toHaveBeenCalledWith('create_field_definition', {
         p_field_key: 'custom_notes',
         p_display_name: 'Custom Notes',
         p_category_id: 'cat-01',
@@ -207,7 +222,7 @@ describe('SupabaseClientFieldService', () => {
     });
 
     it('applies defaults when optional params are omitted', async () => {
-      mockRpc.mockResolvedValueOnce({ data: RPC_SUCCESS, error: null });
+      mockApiRpcEnvelope.mockResolvedValueOnce(RPC_SUCCESS);
 
       const params: CreateFieldDefinitionParams = {
         field_key: 'custom_field',
@@ -217,7 +232,7 @@ describe('SupabaseClientFieldService', () => {
 
       await service.createFieldDefinition(params);
 
-      expect(mockRpc).toHaveBeenCalledWith('create_field_definition', {
+      expect(mockApiRpcEnvelope).toHaveBeenCalledWith('create_field_definition', {
         p_field_key: 'custom_field',
         p_display_name: 'Custom Field',
         p_category_id: 'cat-01',
@@ -232,7 +247,7 @@ describe('SupabaseClientFieldService', () => {
     });
 
     it('sets p_validation_rules to null when not provided', async () => {
-      mockRpc.mockResolvedValueOnce({ data: RPC_SUCCESS, error: null });
+      mockApiRpcEnvelope.mockResolvedValueOnce(RPC_SUCCESS);
 
       await service.createFieldDefinition({
         field_key: 'f',
@@ -240,27 +255,12 @@ describe('SupabaseClientFieldService', () => {
         category_id: 'cat-01',
       });
 
-      const callArgs = mockRpc.mock.calls[0][1];
+      const callArgs = mockApiRpcEnvelope.mock.calls[0][1] as { p_validation_rules: unknown };
       expect(callArgs.p_validation_rules).toBeNull();
     });
 
-    it('parses JSON string data response', async () => {
-      mockRpc.mockResolvedValueOnce({ data: JSON.stringify(RPC_SUCCESS), error: null });
-
-      const result = await service.createFieldDefinition({
-        field_key: 'f',
-        display_name: 'F',
-        category_id: 'cat-01',
-      });
-
-      expect(result).toEqual(RPC_SUCCESS);
-    });
-
-    it('throws with descriptive message on error', async () => {
-      mockRpc.mockResolvedValueOnce({
-        data: null,
-        error: { message: 'duplicate field key' },
-      });
+    it('throws with descriptive message on PostgREST error', async () => {
+      mockApiRpcEnvelope.mockResolvedValueOnce(postgrestFailure('duplicate field key'));
 
       await expect(
         service.createFieldDefinition({
@@ -270,6 +270,25 @@ describe('SupabaseClientFieldService', () => {
         })
       ).rejects.toThrow('Failed to create field: duplicate field key');
     });
+
+    it('returns envelope-failure shape without throwing on handler-driven failure', async () => {
+      // Pre-migration: handler-returned `{success: false}` was passed through as the typed
+      // result. Post-migration: same behavior — envelope failures (no postgrestError) do
+      // NOT throw; the caller pattern-matches on `result.success`.
+      mockApiRpcEnvelope.mockResolvedValueOnce({
+        success: false,
+        error: 'Field key conflict',
+        errorDetails: { code: 'DUPLICATE', message: 'm' },
+      });
+
+      const result = await service.createFieldDefinition({
+        field_key: 'first_name',
+        display_name: 'First Name',
+        category_id: 'cat-01',
+      });
+
+      expect(result.success).toBe(false);
+    });
   });
 
   // ── deactivateFieldDefinition ──
@@ -277,11 +296,11 @@ describe('SupabaseClientFieldService', () => {
   describe('deactivateFieldDefinition', () => {
     it('returns RpcResult on success', async () => {
       const rpcResult: FieldDefinitionResult = { success: true, field_id: 'field-01' };
-      mockRpc.mockResolvedValueOnce({ data: rpcResult, error: null });
+      mockApiRpcEnvelope.mockResolvedValueOnce(rpcResult);
 
       const result = await service.deactivateFieldDefinition('field-01', 'No longer needed');
 
-      expect(mockRpc).toHaveBeenCalledWith('deactivate_field_definition', {
+      expect(mockApiRpcEnvelope).toHaveBeenCalledWith('deactivate_field_definition', {
         p_field_id: 'field-01',
         p_reason: 'No longer needed',
         p_correlation_id: null,
@@ -289,20 +308,10 @@ describe('SupabaseClientFieldService', () => {
       expect(result).toEqual(rpcResult);
     });
 
-    it('parses JSON string data response', async () => {
-      const rpcResult: FieldDefinitionResult = { success: true, field_id: 'field-01' };
-      mockRpc.mockResolvedValueOnce({ data: JSON.stringify(rpcResult), error: null });
-
-      const result = await service.deactivateFieldDefinition('field-01', 'reason');
-
-      expect(result).toEqual(rpcResult);
-    });
-
-    it('throws with descriptive message on error', async () => {
-      mockRpc.mockResolvedValueOnce({
-        data: null,
-        error: { message: 'field is locked and cannot be deactivated' },
-      });
+    it('throws with descriptive message on PostgREST error', async () => {
+      mockApiRpcEnvelope.mockResolvedValueOnce(
+        postgrestFailure('field is locked and cannot be deactivated')
+      );
 
       await expect(service.deactivateFieldDefinition('field-01', 'reason')).rejects.toThrow(
         'Failed to deactivate field: field is locked and cannot be deactivated'
@@ -314,26 +323,26 @@ describe('SupabaseClientFieldService', () => {
 
   describe('listFieldCategories', () => {
     it('returns field categories on success', async () => {
-      mockRpc.mockResolvedValueOnce({ data: [FIELD_CATEGORY], error: null });
+      mockApiRpc.mockResolvedValueOnce({ data: [FIELD_CATEGORY], error: null });
 
       const result = await service.listFieldCategories();
 
-      expect(mockRpc).toHaveBeenCalledWith('list_field_categories', {
+      expect(mockApiRpc).toHaveBeenCalledWith('list_field_categories', {
         p_include_inactive: false,
       });
       expect(result).toEqual([FIELD_CATEGORY]);
     });
 
     it('returns empty array when data is null', async () => {
-      mockRpc.mockResolvedValueOnce({ data: null, error: null });
+      mockApiRpc.mockResolvedValueOnce({ data: null, error: null });
 
       const result = await service.listFieldCategories();
 
       expect(result).toEqual([]);
     });
 
-    it('throws with descriptive message on error', async () => {
-      mockRpc.mockResolvedValueOnce({
+    it('throws with descriptive message on apiRpc error', async () => {
+      mockApiRpc.mockResolvedValueOnce({
         data: null,
         error: { message: 'relation does not exist' },
       });
@@ -349,11 +358,11 @@ describe('SupabaseClientFieldService', () => {
   describe('createFieldCategory', () => {
     it('returns RpcResult on success', async () => {
       const rpcResult: FieldCategoryResult = { success: true, category_id: 'cat-new' };
-      mockRpc.mockResolvedValueOnce({ data: rpcResult, error: null });
+      mockApiRpcEnvelope.mockResolvedValueOnce(rpcResult);
 
       const result = await service.createFieldCategory('Housing', 'housing', 3);
 
-      expect(mockRpc).toHaveBeenCalledWith('create_field_category', {
+      expect(mockApiRpcEnvelope).toHaveBeenCalledWith('create_field_category', {
         p_name: 'Housing',
         p_slug: 'housing',
         p_sort_order: 3,
@@ -363,11 +372,11 @@ describe('SupabaseClientFieldService', () => {
     });
 
     it('defaults sortOrder to 0 when not provided', async () => {
-      mockRpc.mockResolvedValueOnce({ data: { success: true }, error: null });
+      mockApiRpcEnvelope.mockResolvedValueOnce({ success: true });
 
       await service.createFieldCategory('Housing', 'housing');
 
-      expect(mockRpc).toHaveBeenCalledWith('create_field_category', {
+      expect(mockApiRpcEnvelope).toHaveBeenCalledWith('create_field_category', {
         p_name: 'Housing',
         p_slug: 'housing',
         p_sort_order: 0,
@@ -375,20 +384,8 @@ describe('SupabaseClientFieldService', () => {
       });
     });
 
-    it('parses JSON string data response', async () => {
-      const rpcResult: FieldCategoryResult = { success: true, category_id: 'cat-new' };
-      mockRpc.mockResolvedValueOnce({ data: JSON.stringify(rpcResult), error: null });
-
-      const result = await service.createFieldCategory('Housing', 'housing');
-
-      expect(result).toEqual(rpcResult);
-    });
-
-    it('throws with descriptive message on error', async () => {
-      mockRpc.mockResolvedValueOnce({
-        data: null,
-        error: { message: 'slug already exists' },
-      });
+    it('throws with descriptive message on PostgREST error', async () => {
+      mockApiRpcEnvelope.mockResolvedValueOnce(postgrestFailure('slug already exists'));
 
       await expect(service.createFieldCategory('Demographics', 'demographics')).rejects.toThrow(
         'Failed to create category: slug already exists'
@@ -401,11 +398,11 @@ describe('SupabaseClientFieldService', () => {
   describe('deactivateFieldCategory', () => {
     it('returns RpcResult on success', async () => {
       const rpcResult: FieldCategoryResult = { success: true, category_id: 'cat-01' };
-      mockRpc.mockResolvedValueOnce({ data: rpcResult, error: null });
+      mockApiRpcEnvelope.mockResolvedValueOnce(rpcResult);
 
       const result = await service.deactivateFieldCategory('cat-01', 'Category merged into other');
 
-      expect(mockRpc).toHaveBeenCalledWith('deactivate_field_category', {
+      expect(mockApiRpcEnvelope).toHaveBeenCalledWith('deactivate_field_category', {
         p_category_id: 'cat-01',
         p_reason: 'Category merged into other',
         p_correlation_id: null,
@@ -413,24 +410,36 @@ describe('SupabaseClientFieldService', () => {
       expect(result).toEqual(rpcResult);
     });
 
-    it('parses JSON string data response', async () => {
-      const rpcResult: FieldCategoryResult = { success: true, category_id: 'cat-01' };
-      mockRpc.mockResolvedValueOnce({ data: JSON.stringify(rpcResult), error: null });
-
-      const result = await service.deactivateFieldCategory('cat-01', 'reason');
-
-      expect(result).toEqual(rpcResult);
-    });
-
-    it('throws with descriptive message on error', async () => {
-      mockRpc.mockResolvedValueOnce({
-        data: null,
-        error: { message: 'system categories cannot be deactivated' },
-      });
+    it('throws with descriptive message on PostgREST error', async () => {
+      mockApiRpcEnvelope.mockResolvedValueOnce(
+        postgrestFailure('system categories cannot be deactivated')
+      );
 
       await expect(service.deactivateFieldCategory('cat-01', 'reason')).rejects.toThrow(
         'Failed to deactivate category: system categories cannot be deactivated'
       );
+    });
+  });
+
+  // ── getFieldUsageCount ── (envelope shape but returns {success, count} contract)
+
+  describe('getFieldUsageCount', () => {
+    it('returns success + count on envelope success', async () => {
+      mockApiRpcEnvelope.mockResolvedValueOnce({ success: true, count: 7 });
+
+      const result = await service.getFieldUsageCount('first_name');
+
+      expect(result).toEqual({ success: true, count: 7 });
+    });
+
+    it('returns {success: false, count: 0} on envelope failure (does NOT throw)', async () => {
+      // Unlike other envelope methods, get_field_usage_count returns a soft-failure
+      // contract for use in UI dialogs (count widgets cannot disrupt the page).
+      mockApiRpcEnvelope.mockResolvedValueOnce(postgrestFailure('relation missing'));
+
+      const result = await service.getFieldUsageCount('first_name');
+
+      expect(result).toEqual({ success: false, count: 0 });
     });
   });
 });

--- a/frontend/src/services/direct-care/SupabaseDirectCareSettingsService.ts
+++ b/frontend/src/services/direct-care/SupabaseDirectCareSettingsService.ts
@@ -8,7 +8,7 @@
  * @see api.update_organization_direct_care_settings()
  */
 
-import { supabase } from '@/lib/supabase';
+import { supabaseService } from '@/services/auth/supabase.service';
 import { Logger } from '@/utils/logger';
 import type { DirectCareSettings } from '@/types/direct-care-settings.types';
 import type { IDirectCareSettingsService } from './IDirectCareSettingsService';
@@ -24,11 +24,10 @@ export class SupabaseDirectCareSettingsService implements IDirectCareSettingsSer
   async getSettings(orgId: string): Promise<DirectCareSettings> {
     log.debug('Fetching direct care settings', { orgId });
 
-    const { data, error } = await supabase
-      .schema('api')
-      .rpc('get_organization_direct_care_settings', {
-        p_org_id: orgId,
-      });
+    const { data, error } = await supabaseService.apiRpc<DirectCareSettings | null>(
+      'get_organization_direct_care_settings',
+      { p_org_id: orgId }
+    );
 
     if (error) {
       log.error('Failed to fetch direct care settings', { error, orgId });
@@ -40,14 +39,27 @@ export class SupabaseDirectCareSettingsService implements IDirectCareSettingsSer
       return { ...DEFAULT_SETTINGS };
     }
 
-    const settings = typeof data === 'string' ? JSON.parse(data) : data;
-
     return {
-      enable_staff_client_mapping: settings.enable_staff_client_mapping ?? false,
-      enable_schedule_enforcement: settings.enable_schedule_enforcement ?? false,
+      enable_staff_client_mapping: data.enable_staff_client_mapping ?? false,
+      enable_schedule_enforcement: data.enable_schedule_enforcement ?? false,
     };
   }
 
+  /**
+   * Migrated to envelope-only consumption (PR-B 2026-05-11).
+   *
+   * Legacy/v2 dual-shape parse removed per architect targeted-review:
+   *  - Migration `20260423060052` deployed the envelope shape ~3 weeks ago.
+   *  - PR #44's M3 RPC-shape registry tags `update_organization_direct_care_settings`
+   *    as `EnvelopeRpcs` (frontend/src/services/api/rpc-registry.generated.ts:95).
+   *    Wrong shape from the RPC is now a TypeScript compile error.
+   *  - All callers of this method went through dev rollout post-migration.
+   *
+   * If the v1 raw shape ever surfaces again, `unwrapApiEnvelope` will treat it
+   * as success (no `success: false`) and spread it onto the envelope; the
+   * `env.settings` read below would be undefined and we'd fall back to defaults.
+   * That's a soft failure rather than the previous explicit dual-parse.
+   */
   async updateSettings(
     orgId: string,
     enableStaffClientMapping: boolean | null,
@@ -61,44 +73,26 @@ export class SupabaseDirectCareSettingsService implements IDirectCareSettingsSer
       reason,
     });
 
-    const { data, error } = await supabase
-      .schema('api')
-      .rpc('update_organization_direct_care_settings', {
+    const env = await supabaseService.apiRpcEnvelope<{ settings?: Partial<DirectCareSettings> }>(
+      'update_organization_direct_care_settings',
+      {
         p_org_id: orgId,
         p_enable_staff_client_mapping: enableStaffClientMapping,
         p_enable_schedule_enforcement: enableScheduleEnforcement,
         p_reason: reason,
-      });
-
-    if (error) {
-      log.error('Failed to update direct care settings', { error, orgId });
-      throw new Error(`Failed to update settings: ${error.message}`);
-    }
-
-    const parsed = typeof data === 'string' ? JSON.parse(data) : data;
-
-    // Pattern A envelope (post-migration 20260423060052):
-    //   Success: { success: true, settings: { enable_staff_client_mapping, enable_schedule_enforcement } }
-    //   Failure: { success: false, error: 'Event processing failed: <processing_error>' }
-    // Backward-compat fallback: pre-migration shape was raw { enable_staff_client_mapping, enable_schedule_enforcement }.
-    if (parsed && typeof parsed === 'object' && 'success' in parsed) {
-      if (parsed.success === false) {
-        log.error('Direct care settings update failed', { orgId, error: parsed.error });
-        throw new Error(parsed.error ?? 'Failed to update direct care settings');
       }
-      const settings = parsed.settings ?? {};
-      log.info('Direct care settings updated', { orgId, settings });
-      return {
-        enable_staff_client_mapping: settings.enable_staff_client_mapping ?? false,
-        enable_schedule_enforcement: settings.enable_schedule_enforcement ?? false,
-      };
+    );
+
+    if (!env.success) {
+      log.error('Direct care settings update failed', { orgId, error: env.error });
+      throw new Error(env.error ?? 'Failed to update direct care settings');
     }
 
-    // Legacy shape (pre-migration): raw settings object at top level
-    log.info('Direct care settings updated (legacy shape)', { orgId, settings: parsed });
+    const settings = env.settings ?? {};
+    log.info('Direct care settings updated', { orgId, settings });
     return {
-      enable_staff_client_mapping: parsed?.enable_staff_client_mapping ?? false,
-      enable_schedule_enforcement: parsed?.enable_schedule_enforcement ?? false,
+      enable_staff_client_mapping: settings.enable_staff_client_mapping ?? false,
+      enable_schedule_enforcement: settings.enable_schedule_enforcement ?? false,
     };
   }
 }

--- a/frontend/src/services/organization/SupabaseOrganizationCommandService.ts
+++ b/frontend/src/services/organization/SupabaseOrganizationCommandService.ts
@@ -9,9 +9,10 @@
  * Contract: infrastructure/supabase/contracts/asyncapi/domains/organization.yaml
  */
 
-import { supabase } from '@/lib/supabase';
+import { supabaseService } from '@/services/auth/supabase.service';
 import { Logger } from '@/utils/logger';
 import type {
+  OrganizationDetailRecord,
   OrganizationUpdateData,
   OrganizationOperationResult,
 } from '@/types/organization.types';
@@ -29,24 +30,17 @@ export class SupabaseOrganizationCommandService implements IOrganizationCommandS
     try {
       log.debug('Updating organization via RPC', { orgId, data, reason });
 
-      const { data: result, error } = await supabase.schema('api').rpc('update_organization', {
-        p_org_id: orgId,
-        p_data: data,
-        p_reason: reason ?? null,
-      });
+      const env = await supabaseService.apiRpcEnvelope<{
+        organization?: Partial<OrganizationDetailRecord>;
+      }>('update_organization', { p_org_id: orgId, p_data: data, p_reason: reason ?? null });
 
-      if (error) {
-        log.error('Failed to call update_organization RPC', { error, orgId });
-        return { success: false, error: error.message };
+      if (!env.success) {
+        log.warn('update_organization returned failure', { error: env.error, orgId });
+        return { success: false, error: env.error };
       }
 
-      if (!result?.success) {
-        log.warn('update_organization returned failure', { result, orgId });
-        return { success: false, error: result?.error ?? 'Update failed' };
-      }
-
-      log.info('Organization updated', { orgId, organization: result.organization });
-      return { success: true, organization: result.organization };
+      log.info('Organization updated', { orgId, organization: env.organization });
+      return { success: true, organization: env.organization };
     } catch (error) {
       log.error('Error in updateOrganization', { error, orgId });
       return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
@@ -60,23 +54,17 @@ export class SupabaseOrganizationCommandService implements IOrganizationCommandS
     try {
       log.debug('Deactivating organization', { orgId, reason });
 
-      const { data: result, error } = await supabase.schema('api').rpc('deactivate_organization', {
-        p_org_id: orgId,
-        p_reason: reason ?? null,
-      });
+      const env = await supabaseService.apiRpcEnvelope<{
+        organization?: Partial<OrganizationDetailRecord>;
+      }>('deactivate_organization', { p_org_id: orgId, p_reason: reason ?? null });
 
-      if (error) {
-        log.error('Failed to call deactivate_organization RPC', { error, orgId });
-        return { success: false, error: error.message };
+      if (!env.success) {
+        log.warn('deactivate_organization returned failure', { error: env.error, orgId });
+        return { success: false, error: env.error };
       }
 
-      if (!result?.success) {
-        log.warn('deactivate_organization returned failure', { result, orgId });
-        return { success: false, error: result?.error ?? 'Deactivation failed' };
-      }
-
-      log.info('Organization deactivated', { orgId, organization: result.organization });
-      return { success: true, organization: result.organization };
+      log.info('Organization deactivated', { orgId, organization: env.organization });
+      return { success: true, organization: env.organization };
     } catch (error) {
       log.error('Error in deactivateOrganization', { error, orgId });
       return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
@@ -87,22 +75,17 @@ export class SupabaseOrganizationCommandService implements IOrganizationCommandS
     try {
       log.debug('Reactivating organization', { orgId });
 
-      const { data: result, error } = await supabase.schema('api').rpc('reactivate_organization', {
-        p_org_id: orgId,
-      });
+      const env = await supabaseService.apiRpcEnvelope<{
+        organization?: Partial<OrganizationDetailRecord>;
+      }>('reactivate_organization', { p_org_id: orgId });
 
-      if (error) {
-        log.error('Failed to call reactivate_organization RPC', { error, orgId });
-        return { success: false, error: error.message };
+      if (!env.success) {
+        log.warn('reactivate_organization returned failure', { error: env.error, orgId });
+        return { success: false, error: env.error };
       }
 
-      if (!result?.success) {
-        log.warn('reactivate_organization returned failure', { result, orgId });
-        return { success: false, error: result?.error ?? 'Reactivation failed' };
-      }
-
-      log.info('Organization reactivated', { orgId, organization: result.organization });
-      return { success: true, organization: result.organization };
+      log.info('Organization reactivated', { orgId, organization: env.organization });
+      return { success: true, organization: env.organization };
     } catch (error) {
       log.error('Error in reactivateOrganization', { error, orgId });
       return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
@@ -113,22 +96,16 @@ export class SupabaseOrganizationCommandService implements IOrganizationCommandS
     try {
       log.debug('Deleting organization', { orgId, reason });
 
-      const { data: result, error } = await supabase.schema('api').rpc('delete_organization', {
-        p_org_id: orgId,
-        p_reason: reason ?? null,
-      });
+      const env = await supabaseService.apiRpcEnvelope<{
+        organization?: Partial<OrganizationDetailRecord>;
+      }>('delete_organization', { p_org_id: orgId, p_reason: reason ?? null });
 
-      if (error) {
-        log.error('Failed to call delete_organization RPC', { error, orgId });
-        return { success: false, error: error.message };
+      if (!env.success) {
+        log.warn('delete_organization returned failure', { error: env.error, orgId });
+        return { success: false, error: env.error };
       }
 
-      if (!result?.success) {
-        log.warn('delete_organization returned failure', { result, orgId });
-        return { success: false, error: result?.error ?? 'Deletion failed' };
-      }
-
-      log.info('Organization deleted', { orgId, organization: result.organization });
+      log.info('Organization deleted', { orgId, organization: env.organization });
 
       // Fire-and-forget: trigger async cleanup workflow (DNS removal, user banning, etc.)
       try {
@@ -142,7 +119,7 @@ export class SupabaseOrganizationCommandService implements IOrganizationCommandS
         });
       }
 
-      return { success: true, organization: result.organization };
+      return { success: true, organization: env.organization };
     } catch (error) {
       log.error('Error in deleteOrganization', { error, orgId });
       return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };

--- a/frontend/src/services/organization/SupabaseOrganizationUnitService.ts
+++ b/frontend/src/services/organization/SupabaseOrganizationUnitService.ts
@@ -23,7 +23,8 @@
  * @see documentation/architecture/data/multi-tenancy-architecture.md
  */
 
-import { supabase } from '@/lib/supabase';
+import { supabaseService } from '@/services/auth/supabase.service';
+import type { EnvelopeErrorDetails } from '@/services/api/envelope';
 import { Logger } from '@/utils/logger';
 import type { IOrganizationUnitService } from './IOrganizationUnitService';
 import type {
@@ -37,8 +38,7 @@ import type {
 const log = Logger.getLogger('supabase-ou-service');
 
 /**
- * Database row type for organization unit RPC results
- * MUST match: infrastructure/supabase/sql/03-functions/api/005-organization-unit-crud.sql
+ * Database row type for organization unit RPC results (read-shape).
  */
 interface OrganizationUnitRow {
   id: string;
@@ -56,31 +56,22 @@ interface OrganizationUnitRow {
 }
 
 /**
- * JSONB response type for mutation operations
+ * Success-path unit shape from envelope-shape mutation RPCs (camelCase per
+ * jsonb_build_object in the RPC body).
  */
-interface MutationResponse {
-  success: boolean;
-  unit?: {
-    id: string;
-    name: string;
-    displayName: string;
-    path: string;
-    parentPath: string | null;
-    parentId: string | null;
-    timeZone: string;
-    isActive: boolean;
-    childCount: number;
-    isRootOrganization: boolean;
-    createdAt: string;
-    updatedAt: string;
-  };
-  deletedUnit?: MutationResponse['unit']; // backward-compat: old RPC key before migration fix
-  error?: string;
-  errorDetails?: {
-    code: string;
-    count?: number;
-    message: string;
-  };
+interface UnitRpcShape {
+  id: string;
+  name: string;
+  displayName: string;
+  path: string;
+  parentPath: string | null;
+  parentId: string | null;
+  timeZone: string;
+  isActive: boolean;
+  childCount: number;
+  isRootOrganization: boolean;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export class SupabaseOrganizationUnitService implements IOrganizationUnitService {
@@ -111,7 +102,7 @@ export class SupabaseOrganizationUnitService implements IOrganizationUnitService
   /**
    * Converts mutation response unit to OrganizationUnit type
    */
-  private mapResponseToUnit(unit: MutationResponse['unit']): OrganizationUnit {
+  private mapResponseToUnit(unit: UnitRpcShape | undefined): OrganizationUnit {
     if (!unit) {
       throw new Error('Unit data missing from response');
     }
@@ -135,7 +126,7 @@ export class SupabaseOrganizationUnitService implements IOrganizationUnitService
    * Maps error details from RPC response to operation result format
    */
   private mapErrorDetails(
-    errorDetails?: MutationResponse['errorDetails']
+    errorDetails?: EnvelopeErrorDetails
   ): OrganizationUnitOperationResult['errorDetails'] {
     if (!errorDetails) return undefined;
 
@@ -187,17 +178,20 @@ export class SupabaseOrganizationUnitService implements IOrganizationUnitService
     log.debug('getUnits called', { filters });
 
     try {
-      const { data, error } = await supabase.schema('api').rpc('get_organization_units', {
-        p_status: filters?.status || 'all',
-        p_search_term: filters?.searchTerm || null,
-      });
+      const { data, error } = await supabaseService.apiRpc<OrganizationUnitRow[]>(
+        'get_organization_units',
+        {
+          p_status: filters?.status || 'all',
+          p_search_term: filters?.searchTerm || null,
+        }
+      );
 
       if (error) {
         log.error('Error fetching organization units', error);
         throw new Error(`Failed to fetch organization units: ${error.message}`);
       }
 
-      const rows = (data as OrganizationUnitRow[]) || [];
+      const rows = data || [];
       log.debug(`Fetched ${rows.length} organization units`);
 
       return rows.map((row) => this.mapRowToUnit(row));
@@ -214,16 +208,17 @@ export class SupabaseOrganizationUnitService implements IOrganizationUnitService
     log.debug('getUnitById called', { unitId });
 
     try {
-      const { data, error } = await supabase.schema('api').rpc('get_organization_unit_by_id', {
-        p_unit_id: unitId,
-      });
+      const { data, error } = await supabaseService.apiRpc<OrganizationUnitRow[]>(
+        'get_organization_unit_by_id',
+        { p_unit_id: unitId }
+      );
 
       if (error) {
         log.error('Error fetching organization unit by ID', error);
         throw new Error(`Failed to fetch organization unit: ${error.message}`);
       }
 
-      const rows = (data as OrganizationUnitRow[]) || [];
+      const rows = data || [];
 
       if (rows.length === 0) {
         log.debug('Organization unit not found', { unitId });
@@ -244,18 +239,17 @@ export class SupabaseOrganizationUnitService implements IOrganizationUnitService
     log.debug('getDescendants called', { unitId });
 
     try {
-      const { data, error } = await supabase
-        .schema('api')
-        .rpc('get_organization_unit_descendants', {
-          p_unit_id: unitId,
-        });
+      const { data, error } = await supabaseService.apiRpc<OrganizationUnitRow[]>(
+        'get_organization_unit_descendants',
+        { p_unit_id: unitId }
+      );
 
       if (error) {
         log.error('Error fetching unit descendants', error);
         throw new Error(`Failed to fetch descendants: ${error.message}`);
       }
 
-      const rows = (data as OrganizationUnitRow[]) || [];
+      const rows = data || [];
       log.debug(`Fetched ${rows.length} descendants`);
 
       return rows.map((row) => this.mapRowToUnit(row));
@@ -274,42 +268,31 @@ export class SupabaseOrganizationUnitService implements IOrganizationUnitService
     log.debug('createUnit called', { request });
 
     try {
-      const { data, error } = await supabase.schema('api').rpc('create_organization_unit', {
-        p_parent_id: request.parentId,
-        p_name: request.name,
-        p_display_name: request.displayName,
-        p_timezone: request.timeZone || null,
-      });
+      const env = await supabaseService.apiRpcEnvelope<{ unit?: UnitRpcShape }>(
+        'create_organization_unit',
+        {
+          p_parent_id: request.parentId,
+          p_name: request.name,
+          p_display_name: request.displayName,
+          p_timezone: request.timeZone || null,
+        }
+      );
 
-      if (error) {
-        log.error('Error creating organization unit', error);
+      if (!env.success) {
+        log.warn('Create unit failed', { error: env.error, errorDetails: env.errorDetails });
         return {
           success: false,
-          error: error.message,
-          errorDetails: {
-            code: 'UNKNOWN',
-            message: error.message,
-          },
-        };
-      }
-
-      const response = data as MutationResponse;
-
-      if (!response.success) {
-        log.warn('Create unit failed', { response });
-        return {
-          success: false,
-          error: response.error,
-          errorDetails: this.mapErrorDetails(response.errorDetails),
+          error: env.error,
+          errorDetails: this.mapErrorDetails(env.errorDetails),
         };
       }
 
       // Defense-in-depth: if handler failed, RPC may return success with empty unit
-      if (!response.unit?.id) {
-        log.error('Create returned success but no unit data', { response });
+      if (!env.unit?.id) {
+        log.error('Create returned success but no unit data');
         return {
           success: false,
-          error: response.error || 'Organization unit creation failed — no data returned',
+          error: 'Organization unit creation failed — no data returned',
           errorDetails: {
             code: 'UNKNOWN',
             message: 'Server returned success but no unit data',
@@ -317,10 +300,10 @@ export class SupabaseOrganizationUnitService implements IOrganizationUnitService
         };
       }
 
-      log.info('Organization unit created', { unitId: response.unit.id });
+      log.info('Organization unit created', { unitId: env.unit.id });
       return {
         success: true,
-        unit: this.mapResponseToUnit(response.unit),
+        unit: this.mapResponseToUnit(env.unit),
       };
     } catch (err) {
       log.error('Exception in createUnit', err);
@@ -347,42 +330,31 @@ export class SupabaseOrganizationUnitService implements IOrganizationUnitService
     log.debug('updateUnit called', { request });
 
     try {
-      const { data, error } = await supabase.schema('api').rpc('update_organization_unit', {
-        p_unit_id: request.id,
-        p_name: request.name || null,
-        p_display_name: request.displayName || null,
-        p_timezone: request.timeZone || null,
-      });
+      const env = await supabaseService.apiRpcEnvelope<{ unit?: UnitRpcShape }>(
+        'update_organization_unit',
+        {
+          p_unit_id: request.id,
+          p_name: request.name || null,
+          p_display_name: request.displayName || null,
+          p_timezone: request.timeZone || null,
+        }
+      );
 
-      if (error) {
-        log.error('Error updating organization unit', error);
+      if (!env.success) {
+        log.warn('Update unit failed', { error: env.error, errorDetails: env.errorDetails });
         return {
           success: false,
-          error: error.message,
-          errorDetails: {
-            code: 'UNKNOWN',
-            message: error.message,
-          },
-        };
-      }
-
-      const response = data as MutationResponse;
-
-      if (!response.success) {
-        log.warn('Update unit failed', { response });
-        return {
-          success: false,
-          error: response.error,
-          errorDetails: this.mapErrorDetails(response.errorDetails),
+          error: env.error,
+          errorDetails: this.mapErrorDetails(env.errorDetails),
         };
       }
 
       // Defense-in-depth: if handler failed, RPC may return success with empty unit
-      if (!response.unit?.id) {
-        log.error('Update returned success but no unit data', { response });
+      if (!env.unit?.id) {
+        log.error('Update returned success but no unit data');
         return {
           success: false,
-          error: response.error || 'Organization unit update failed — no data returned',
+          error: 'Organization unit update failed — no data returned',
           errorDetails: {
             code: 'UNKNOWN',
             message: 'Server returned success but no unit data',
@@ -393,7 +365,7 @@ export class SupabaseOrganizationUnitService implements IOrganizationUnitService
       log.info('Organization unit updated', { unitId: request.id });
       return {
         success: true,
-        unit: this.mapResponseToUnit(response.unit),
+        unit: this.mapResponseToUnit(env.unit),
       };
     } catch (err) {
       log.error('Exception in updateUnit', err);
@@ -418,39 +390,26 @@ export class SupabaseOrganizationUnitService implements IOrganizationUnitService
     log.debug('deactivateUnit called', { unitId });
 
     try {
-      const { data, error } = await supabase.schema('api').rpc('deactivate_organization_unit', {
-        p_unit_id: unitId,
-      });
+      const env = await supabaseService.apiRpcEnvelope<{ unit?: UnitRpcShape }>(
+        'deactivate_organization_unit',
+        { p_unit_id: unitId }
+      );
 
-      if (error) {
-        log.error('Error deactivating organization unit', error);
+      if (!env.success) {
+        log.warn('Deactivate unit failed', { error: env.error, errorDetails: env.errorDetails });
         return {
           success: false,
-          error: error.message,
-          errorDetails: {
-            code: 'UNKNOWN',
-            message: error.message,
-          },
-        };
-      }
-
-      const response = data as MutationResponse;
-
-      if (!response.success) {
-        log.warn('Deactivate unit failed', { response });
-        return {
-          success: false,
-          error: response.error,
-          errorDetails: this.mapErrorDetails(response.errorDetails),
+          error: env.error,
+          errorDetails: this.mapErrorDetails(env.errorDetails),
         };
       }
 
       // Defense-in-depth: if handler failed, RPC may return success with empty unit
-      if (!response.unit?.id) {
-        log.error('Deactivate returned success but no unit data', { response });
+      if (!env.unit?.id) {
+        log.error('Deactivate returned success but no unit data');
         return {
           success: false,
-          error: response.error || 'Organization unit deactivation failed — no data returned',
+          error: 'Organization unit deactivation failed — no data returned',
           errorDetails: {
             code: 'UNKNOWN',
             message: 'Server returned success but no unit data',
@@ -461,7 +420,7 @@ export class SupabaseOrganizationUnitService implements IOrganizationUnitService
       log.info('Organization unit deactivated', { unitId });
       return {
         success: true,
-        unit: this.mapResponseToUnit(response.unit),
+        unit: this.mapResponseToUnit(env.unit),
       };
     } catch (err) {
       log.error('Exception in deactivateUnit', err);
@@ -485,39 +444,26 @@ export class SupabaseOrganizationUnitService implements IOrganizationUnitService
     log.debug('reactivateUnit called', { unitId });
 
     try {
-      const { data, error } = await supabase.schema('api').rpc('reactivate_organization_unit', {
-        p_unit_id: unitId,
-      });
+      const env = await supabaseService.apiRpcEnvelope<{ unit?: UnitRpcShape }>(
+        'reactivate_organization_unit',
+        { p_unit_id: unitId }
+      );
 
-      if (error) {
-        log.error('Error reactivating organization unit', error);
+      if (!env.success) {
+        log.warn('Reactivate unit failed', { error: env.error, errorDetails: env.errorDetails });
         return {
           success: false,
-          error: error.message,
-          errorDetails: {
-            code: 'UNKNOWN',
-            message: error.message,
-          },
-        };
-      }
-
-      const response = data as MutationResponse;
-
-      if (!response.success) {
-        log.warn('Reactivate unit failed', { response });
-        return {
-          success: false,
-          error: response.error,
-          errorDetails: this.mapErrorDetails(response.errorDetails),
+          error: env.error,
+          errorDetails: this.mapErrorDetails(env.errorDetails),
         };
       }
 
       // Defense-in-depth: if handler failed, RPC may return success with empty unit
-      if (!response.unit?.id) {
-        log.error('Reactivate returned success but no unit data', { response });
+      if (!env.unit?.id) {
+        log.error('Reactivate returned success but no unit data');
         return {
           success: false,
-          error: response.error || 'Organization unit reactivation failed — no data returned',
+          error: 'Organization unit reactivation failed — no data returned',
           errorDetails: {
             code: 'UNKNOWN',
             message: 'Server returned success but no unit data',
@@ -528,7 +474,7 @@ export class SupabaseOrganizationUnitService implements IOrganizationUnitService
       log.info('Organization unit reactivated', { unitId });
       return {
         success: true,
-        unit: this.mapResponseToUnit(response.unit),
+        unit: this.mapResponseToUnit(env.unit),
       };
     } catch (err) {
       log.error('Exception in reactivateUnit', err);
@@ -553,41 +499,29 @@ export class SupabaseOrganizationUnitService implements IOrganizationUnitService
     log.debug('deleteUnit called', { unitId });
 
     try {
-      const { data, error } = await supabase.schema('api').rpc('delete_organization_unit', {
-        p_unit_id: unitId,
-      });
+      // Backward-compat: old RPC returned 'deletedUnit', new RPC returns 'unit'.
+      // Both shapes are typed on the envelope so the dual-read below stays type-safe.
+      const env = await supabaseService.apiRpcEnvelope<{
+        unit?: UnitRpcShape;
+        deletedUnit?: UnitRpcShape;
+      }>('delete_organization_unit', { p_unit_id: unitId });
 
-      if (error) {
-        log.error('Error deleting organization unit', error);
+      if (!env.success) {
+        log.warn('Delete unit failed', { error: env.error, errorDetails: env.errorDetails });
         return {
           success: false,
-          error: error.message,
-          errorDetails: {
-            code: 'UNKNOWN',
-            message: error.message,
-          },
-        };
-      }
-
-      const response = data as MutationResponse;
-
-      if (!response.success) {
-        log.warn('Delete unit failed', { response });
-        return {
-          success: false,
-          error: response.error,
-          errorDetails: this.mapErrorDetails(response.errorDetails),
+          error: env.error,
+          errorDetails: this.mapErrorDetails(env.errorDetails),
         };
       }
 
       // Defense-in-depth: if handler failed, RPC may return success with empty unit
-      // Backward-compat: old RPC returned 'deletedUnit', new RPC returns 'unit'
-      const unitData = response.unit || response.deletedUnit;
+      const unitData = env.unit || env.deletedUnit;
       if (!unitData?.id) {
-        log.error('Delete returned success but no unit data', { response });
+        log.error('Delete returned success but no unit data');
         return {
           success: false,
-          error: response.error || 'Organization unit deletion failed — no data returned',
+          error: 'Organization unit deletion failed — no data returned',
           errorDetails: {
             code: 'UNKNOWN',
             message: 'Server returned success but no unit data',

--- a/frontend/src/services/schedule/SupabaseScheduleService.ts
+++ b/frontend/src/services/schedule/SupabaseScheduleService.ts
@@ -15,7 +15,7 @@
  * @see api.unassign_user_from_schedule()
  */
 
-import { supabase } from '@/lib/supabase';
+import { supabaseService } from '@/services/auth/supabase.service';
 import { Logger } from '@/utils/logger';
 import type {
   ScheduleTemplate,
@@ -32,28 +32,14 @@ import type { IScheduleService, ScheduleDeleteResult } from './IScheduleService'
 
 const log = Logger.getLogger('api');
 
-/** Parse RPC response envelope: { success, error?, data?, errorDetails? } */
-function parseRpcResult(data: unknown): {
-  success: boolean;
-  error?: string;
-  data?: unknown;
-  template_id?: string;
-  errorDetails?: { code: string; count?: number };
-} {
-  const result = typeof data === 'string' ? JSON.parse(data) : data;
-  return result;
-}
-
-/** Parse and throw on failure */
-function parseOrThrow(data: unknown): ReturnType<typeof parseRpcResult> {
-  const result = parseRpcResult(data);
-  if (!result?.success) {
-    throw new Error(result?.error ?? 'RPC call failed');
-  }
-  return result;
-}
-
 export class SupabaseScheduleService implements IScheduleService {
+  // -------------------------------------------------------------------------
+  // Q6 — most envelope methods THROW on `!env.success` (pre-migration
+  // `parseOrThrow` contract). Only `deleteTemplate` RETURNS the typed envelope
+  // because consumers need `errorDetails.code` for the cannot-delete dialog
+  // (HAS_USERS / STILL_ACTIVE).
+  // -------------------------------------------------------------------------
+
   async listTemplates(params: {
     orgId?: string;
     status?: 'all' | 'active' | 'inactive';
@@ -61,46 +47,42 @@ export class SupabaseScheduleService implements IScheduleService {
   }): Promise<ScheduleTemplate[]> {
     log.debug('Listing schedule templates', params);
 
-    const { data, error } = await supabase.schema('api').rpc('list_schedule_templates', {
-      p_org_id: params.orgId ?? null,
-      p_status: params.status ?? 'all',
-      p_search: params.search ?? null,
-    });
+    const env = await supabaseService.apiRpcEnvelope<{ data?: ScheduleTemplate[] }>(
+      'list_schedule_templates',
+      {
+        p_org_id: params.orgId ?? null,
+        p_status: params.status ?? 'all',
+        p_search: params.search ?? null,
+      }
+    );
 
-    if (error) {
-      log.error('Failed to list schedule templates', { error });
-      throw new Error(`Failed to list schedule templates: ${error.message}`);
+    if (!env.success) {
+      log.error('Failed to list schedule templates', { error: env.error });
+      throw new Error(`Failed to list schedule templates: ${env.error}`);
     }
 
-    const result = parseOrThrow(data);
-    return (result.data as ScheduleTemplate[]) ?? [];
+    return env.data ?? [];
   }
 
   async getTemplate(templateId: string): Promise<ScheduleTemplateDetail | null> {
     log.debug('Getting schedule template', { templateId });
 
-    const { data, error } = await supabase.schema('api').rpc('get_schedule_template', {
-      p_template_id: templateId,
-    });
+    const env = await supabaseService.apiRpcEnvelope<{
+      template?: Omit<ScheduleTemplateDetail, 'assigned_users' | 'assigned_user_count'>;
+      assigned_users?: ScheduleTemplateDetail['assigned_users'];
+    }>('get_schedule_template', { p_template_id: templateId });
 
-    if (error) {
-      log.error('Failed to get schedule template', { error });
-      throw new Error(`Failed to get schedule template: ${error.message}`);
+    if (!env.success) {
+      log.error('Failed to get schedule template', { error: env.error });
+      throw new Error(`Failed to get schedule template: ${env.error}`);
     }
 
-    const result = parseOrThrow(data);
-
-    // get_schedule_template returns { success, template, assigned_users }
-    const parsed = result as unknown as {
-      template: Omit<ScheduleTemplateDetail, 'assigned_users' | 'assigned_user_count'>;
-      assigned_users: ScheduleTemplateDetail['assigned_users'];
-    };
-    if (!parsed.template) return null;
+    if (!env.template) return null;
 
     return {
-      ...parsed.template,
-      assigned_users: parsed.assigned_users ?? [],
-      assigned_user_count: parsed.assigned_users?.length ?? 0,
+      ...env.template,
+      assigned_users: env.assigned_users ?? [],
+      assigned_user_count: env.assigned_users?.length ?? 0,
     } as ScheduleTemplateDetail;
   }
 
@@ -115,21 +97,23 @@ export class SupabaseScheduleService implements IScheduleService {
       userCount: params.userIds.length,
     });
 
-    const { data, error } = await supabase.schema('api').rpc('create_schedule_template', {
-      p_name: params.name,
-      p_schedule: params.schedule,
-      p_org_unit_id: params.orgUnitId ?? null,
-      p_user_ids: params.userIds,
-    });
+    const env = await supabaseService.apiRpcEnvelope<{ template_id?: string }>(
+      'create_schedule_template',
+      {
+        p_name: params.name,
+        p_schedule: params.schedule,
+        p_org_unit_id: params.orgUnitId ?? null,
+        p_user_ids: params.userIds,
+      }
+    );
 
-    if (error) {
-      log.error('Failed to create schedule template', { error });
-      throw new Error(`Failed to create schedule template: ${error.message}`);
+    if (!env.success) {
+      log.error('Failed to create schedule template', { error: env.error });
+      throw new Error(`Failed to create schedule template: ${env.error}`);
     }
 
-    const result = parseOrThrow(data);
-    log.info('Schedule template created', { templateId: result.template_id });
-    return { templateId: result.template_id as string };
+    log.info('Schedule template created', { templateId: env.template_id });
+    return { templateId: env.template_id as string };
   }
 
   async updateTemplate(params: {
@@ -140,83 +124,79 @@ export class SupabaseScheduleService implements IScheduleService {
   }): Promise<void> {
     log.debug('Updating schedule template', { templateId: params.templateId });
 
-    const { data, error } = await supabase.schema('api').rpc('update_schedule_template', {
+    const env = await supabaseService.apiRpcEnvelope('update_schedule_template', {
       p_template_id: params.templateId,
       p_name: params.name ?? null,
       p_schedule: params.schedule ?? null,
       p_org_unit_id: params.orgUnitId ?? null,
     });
 
-    if (error) {
-      log.error('Failed to update schedule template', { error });
-      throw new Error(`Failed to update schedule template: ${error.message}`);
+    if (!env.success) {
+      log.error('Failed to update schedule template', { error: env.error });
+      throw new Error(`Failed to update schedule template: ${env.error}`);
     }
 
-    parseOrThrow(data);
     log.info('Schedule template updated', { templateId: params.templateId });
   }
 
   async deactivateTemplate(params: { templateId: string; reason?: string }): Promise<void> {
     log.debug('Deactivating schedule template', { templateId: params.templateId });
 
-    const { data, error } = await supabase.schema('api').rpc('deactivate_schedule_template', {
+    const env = await supabaseService.apiRpcEnvelope('deactivate_schedule_template', {
       p_template_id: params.templateId,
       p_reason: params.reason ?? null,
     });
 
-    if (error) {
-      log.error('Failed to deactivate schedule template', { error });
-      throw new Error(`Failed to deactivate schedule template: ${error.message}`);
+    if (!env.success) {
+      log.error('Failed to deactivate schedule template', { error: env.error });
+      throw new Error(`Failed to deactivate schedule template: ${env.error}`);
     }
 
-    parseOrThrow(data);
     log.info('Schedule template deactivated', { templateId: params.templateId });
   }
 
   async reactivateTemplate(params: { templateId: string }): Promise<void> {
     log.debug('Reactivating schedule template', { templateId: params.templateId });
 
-    const { data, error } = await supabase.schema('api').rpc('reactivate_schedule_template', {
+    const env = await supabaseService.apiRpcEnvelope('reactivate_schedule_template', {
       p_template_id: params.templateId,
     });
 
-    if (error) {
-      log.error('Failed to reactivate schedule template', { error });
-      throw new Error(`Failed to reactivate schedule template: ${error.message}`);
+    if (!env.success) {
+      log.error('Failed to reactivate schedule template', { error: env.error });
+      throw new Error(`Failed to reactivate schedule template: ${env.error}`);
     }
 
-    parseOrThrow(data);
     log.info('Schedule template reactivated', { templateId: params.templateId });
   }
 
+  /**
+   * Q6 exception: this method RETURNS on `!env.success` (pre-migration
+   * `parseRpcResult` contract). Consumers branch on `result.success` to render
+   * the cannot-delete dialog with `errorDetails.code` (HAS_USERS / STILL_ACTIVE)
+   * and `errorDetails.count`.
+   */
   async deleteTemplate(params: {
     templateId: string;
     reason?: string;
   }): Promise<ScheduleDeleteResult> {
     log.debug('Deleting schedule template', { templateId: params.templateId });
 
-    const { data, error } = await supabase.schema('api').rpc('delete_schedule_template', {
+    const env = await supabaseService.apiRpcEnvelope('delete_schedule_template', {
       p_template_id: params.templateId,
       p_reason: params.reason ?? null,
     });
 
-    if (error) {
-      log.error('Failed to delete schedule template', { error });
-      throw new Error(`Failed to delete schedule template: ${error.message}`);
-    }
-
-    const result = parseRpcResult(data);
-
-    if (!result.success) {
+    if (!env.success) {
       log.warn('Delete schedule template returned error', {
         templateId: params.templateId,
-        error: result.error,
-        errorDetails: result.errorDetails,
+        error: env.error,
+        errorDetails: env.errorDetails,
       });
       return {
         success: false,
-        error: result.error ?? 'Failed to delete schedule template',
-        errorDetails: result.errorDetails as ScheduleDeleteResult['errorDetails'],
+        error: env.error,
+        errorDetails: env.errorDetails as ScheduleDeleteResult['errorDetails'],
       };
     }
 
@@ -235,19 +215,18 @@ export class SupabaseScheduleService implements IScheduleService {
       userId: params.userId,
     });
 
-    const { data, error } = await supabase.schema('api').rpc('assign_user_to_schedule', {
+    const env = await supabaseService.apiRpcEnvelope('assign_user_to_schedule', {
       p_template_id: params.templateId,
       p_user_id: params.userId,
       p_effective_from: params.effectiveFrom ?? null,
       p_effective_until: params.effectiveUntil ?? null,
     });
 
-    if (error) {
-      log.error('Failed to assign user to schedule', { error });
-      throw new Error(`Failed to assign user to schedule: ${error.message}`);
+    if (!env.success) {
+      log.error('Failed to assign user to schedule', { error: env.error });
+      throw new Error(`Failed to assign user to schedule: ${env.error}`);
     }
 
-    parseOrThrow(data);
     log.info('User assigned to schedule', {
       templateId: params.templateId,
       userId: params.userId,
@@ -264,18 +243,17 @@ export class SupabaseScheduleService implements IScheduleService {
       userId: params.userId,
     });
 
-    const { data, error } = await supabase.schema('api').rpc('unassign_user_from_schedule', {
+    const env = await supabaseService.apiRpcEnvelope('unassign_user_from_schedule', {
       p_template_id: params.templateId,
       p_user_id: params.userId,
       p_reason: params.reason ?? null,
     });
 
-    if (error) {
-      log.error('Failed to unassign user from schedule', { error });
-      throw new Error(`Failed to unassign user from schedule: ${error.message}`);
+    if (!env.success) {
+      log.error('Failed to unassign user from schedule', { error: env.error });
+      throw new Error(`Failed to unassign user from schedule: ${env.error}`);
     }
 
-    parseOrThrow(data);
     log.info('User unassigned from schedule', {
       templateId: params.templateId,
       userId: params.userId,
@@ -287,12 +265,15 @@ export class SupabaseScheduleService implements IScheduleService {
   ): Promise<ScheduleManageableUser[]> {
     log.debug('Listing users for schedule management', params);
 
-    const { data, error } = await supabase.schema('api').rpc('list_users_for_schedule_management', {
-      p_template_id: params.templateId,
-      p_search_term: params.searchTerm ?? null,
-      p_limit: params.limit ?? 100,
-      p_offset: params.offset ?? 0,
-    });
+    const { data, error } = await supabaseService.apiRpc<Record<string, unknown>[]>(
+      'list_users_for_schedule_management',
+      {
+        p_template_id: params.templateId,
+        p_search_term: params.searchTerm ?? null,
+        p_limit: params.limit ?? 100,
+        p_offset: params.offset ?? 0,
+      }
+    );
 
     if (error) {
       log.error('Failed to list users for schedule management', { error });
@@ -300,8 +281,8 @@ export class SupabaseScheduleService implements IScheduleService {
     }
 
     // This RPC returns TABLE rows directly (not wrapped in envelope)
-    const rows = Array.isArray(data) ? data : [];
-    return rows.map((row: Record<string, unknown>) => ({
+    const rows = data ?? [];
+    return rows.map((row) => ({
       id: row.id as string,
       displayName: (row.display_name as string) || (row.email as string),
       email: row.email as string,
@@ -323,7 +304,18 @@ export class SupabaseScheduleService implements IScheduleService {
 
     const correlationId = params.correlationId || globalThis.crypto.randomUUID();
 
-    const { data, error } = await supabase.schema('api').rpc('sync_schedule_assignments', {
+    const { data, error } = await supabaseService.apiRpc<{
+      added?: {
+        successful: string[];
+        failed: Array<{ userId: string; reason: string; sqlstate?: string }>;
+      };
+      removed?: {
+        successful: string[];
+        failed: Array<{ userId: string; reason: string; sqlstate?: string }>;
+      };
+      transferred?: unknown[];
+      correlationId?: string;
+    }>('sync_schedule_assignments', {
       p_template_id: params.templateId,
       p_user_ids_to_add: params.userIdsToAdd,
       p_user_ids_to_remove: params.userIdsToRemove,
@@ -336,25 +328,24 @@ export class SupabaseScheduleService implements IScheduleService {
       throw new Error(`Failed to sync schedule assignments: ${error.message}`);
     }
 
-    const result = typeof data === 'string' ? JSON.parse(data) : data;
     log.info('Schedule assignments synced', {
-      addedSuccessful: result.added?.successful?.length ?? 0,
-      removedSuccessful: result.removed?.successful?.length ?? 0,
-      transferred: result.transferred?.length ?? 0,
-      correlationId: result.correlationId,
+      addedSuccessful: data?.added?.successful?.length ?? 0,
+      removedSuccessful: data?.removed?.successful?.length ?? 0,
+      transferred: data?.transferred?.length ?? 0,
+      correlationId: data?.correlationId,
     });
 
     return {
       added: {
-        successful: result.added?.successful ?? [],
-        failed: result.added?.failed ?? [],
+        successful: data?.added?.successful ?? [],
+        failed: data?.added?.failed ?? [],
       },
       removed: {
-        successful: result.removed?.successful ?? [],
-        failed: result.removed?.failed ?? [],
+        successful: data?.removed?.successful ?? [],
+        failed: data?.removed?.failed ?? [],
       },
-      transferred: result.transferred ?? [],
-      correlationId: result.correlationId ?? correlationId,
+      transferred: (data?.transferred ?? []) as SyncScheduleAssignmentsResult['transferred'],
+      correlationId: data?.correlationId ?? correlationId,
     };
   }
 }


### PR DESCRIPTION
## Summary

PR-B of 3 (defense-in-depth migration of frontend services to `apiRpc<T>` / `apiRpcEnvelope<T>` helpers). Migrates the bulk envelope wave across 6 services and refactors one test file to the new helper-mock pattern.

**Card**: `dev/active/migrate-services-to-api-rpc-envelope/`
**Plan**: `~/.claude/plans/ddoes-it-make-sense-lucky-dongarra.md` (v2)
**Inventory artifact**: `dev/active/migrate-services-to-api-rpc-envelope/inventory.md` (updated)

## Migrations in this PR

| Service | Envelope | Read | Total |
|---|---:|---:|---:|
| `SupabaseOrganizationCommandService.ts` | 4 | 0 | 4 |
| `SupabaseOrganizationUnitService.ts` | 5 | 3 | 8 |
| `SupabaseClientFieldService.ts` | 13 | 2 | 15 |
| `SupabaseScheduleService.ts` | 9 | 2 | 11 |
| `SupabaseDirectCareSettingsService.ts` | 1 | 1 | 2 |
| `SupabaseAssignmentService.ts` | 2 | 1 | 3 |
| **TOTAL** | **34** | **9** | **43** |

**+2 sites vs. plan estimate of 41** — discovered during implementation: `getDescendants` in OrgUnit (multi-line chain my Phase 0 grep missed) and `listFieldDefinitions` in ClientFields (agent inventory miss).

## Architect-targeted-review items (from PR #56 post-merge evaluation)

### 1. DirectCareSettingsService dual-shape parse (FILE: `direct-care/SupabaseDirectCareSettingsService.ts`)

**Action taken**: REMOVED the legacy/v2 fallback at L84-95 of the pre-migration code. Evidence the v1 path is dead:
- Migration `20260423060052` deployed the envelope shape ~3 weeks ago (2026-04-23).
- PR #44's M3 RPC-shape registry tags `update_organization_direct_care_settings` as `EnvelopeRpcs` (`rpc-registry.generated.ts:95`). Wrong shape is now a TypeScript compile error at the DB schema layer.
- All dev/prod callers went through deploy post-migration.

The decision and reasoning is documented inline at the `updateSettings` method docblock so a future audit can trace it.

### 2. Schedule throw-vs-return contract (FILE: `schedule/SupabaseScheduleService.ts`)

**Action taken**: per-method audit and migration preserving each method's prior contract:
- `parseOrThrow` methods (`listTemplates`, `getTemplate`, `createTemplate`, `updateTemplate`, `deactivateTemplate`, `reactivateTemplate`, `assignUser`, `unassignUser`) — **THROW** on `!env.success`
- `parseRpcResult` method (`deleteTemplate`) — **RETURNS** the typed `ScheduleDeleteResult` so consumers can render the cannot-delete dialog with `errorDetails.code` (HAS_USERS / STILL_ACTIVE) and `errorDetails.count`

The `parseOrThrow` / `parseRpcResult` helpers are deleted post-migration; `apiRpcEnvelope<T>` provides the parsed envelope directly.

### 3. ClientFieldService test-mock refactor (FILE: `client-fields/__tests__/SupabaseClientFieldService.test.ts`)

**Action taken**: migrated from `@/lib/supabase` chain mock to the helper-mock template established by PR-A's three new test files (`mockApiRpc` / `mockApiRpcEnvelope` via `vi.hoisted`). No third pattern invented.

Net test count: 24 cases pass (was 26). Removed 2 obsoleted `parses JSON string data response` tests (envelope helper now parses upstream); added 3 new tests: PostgREST-shape failure throw, `getFieldUsageCount` soft-failure, handler-driven envelope-failure return path.

## Q6 throw-vs-return preservation across services

A new module-level helper `throwIfPostgrestError(env, verb)` in `SupabaseClientFieldService.ts` preserves the pre-migration `throw new Error('Failed to <verb>: <message>')` contract for 11 envelope methods. The helper is justified inline at the function docblock; if this pattern is adopted elsewhere in PR-C it can be promoted to a shared utility.

## Test plan

- [x] `npm run typecheck` green
- [x] `npm run test -- --run` — 540 pass / 56 fail (pre-existing baseline unchanged; -2 net from ClientField refactor). **Zero regressions.**
- [x] `npm run build` green
- [ ] Manual smoke (post-deploy): create/edit/delete a role-related field definition; toggle a direct-care setting; create+delete a schedule template. Confirm rich error display where applicable.

## What's NOT in this PR (deferred to PR-C)

- `SupabaseClientService.ts` (25 envelope sites — largest file)
- `SupabaseOrganizationQueryService.ts` (4 read)
- `getOrganizationSubdomainInfo.ts` (1 read with `.single<T>()` — Q5 refactor)
- ESLint rule activation at `frontend/eslint.config.js:124-131`
- Pre-merge inventory refresh (per Q4 — accept the window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)