### PR TITLE
refactor(services): PR-C closeout — migrate Clients/OrgQuery/Subdomain + activate ESLint rule

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -121,14 +121,40 @@ export default [
       'no-var': 'error',
       'no-undef': 'error', // This should be handled by globals now
 
-      // FUTURE — deferred to follow-up card:
-      //   dev/active/migrate-services-to-api-rpc-envelope/
-      // A no-restricted-syntax rule will forbid direct .schema('api').rpc(...) outside
-      // src/services/auth/supabase.service.ts and src/services/api/envelope.ts. Lands
-      // together with the codemod that migrates the 8 legacy services to
-      // apiRpcEnvelope<T>. Repo-wide --max-warnings 0 means the rule can't ship until
-      // existing call sites are migrated. See also the PII handling section in
-      // documentation/architecture/decisions/adr-rpc-readback-pattern.md.
+      // Bans direct .schema(*).rpc(...) calls outside the SDK helpers. The selector
+      // matches any schema argument, not just 'api' — there are no .schema('public').rpc(...)
+      // calls in the repo today; if that changes, broaden the override list below.
+      //
+      // Activated 2026-05-11 (PR-C closeout) after migrating all 11 services to
+      // supabaseService.apiRpc<T> / apiRpcEnvelope<T>. The repo-wide --max-warnings 0
+      // policy means new direct callers will fail the lint gate.
+      // See documentation/architecture/decisions/adr-rpc-readback-pattern.md
+      // §"PII handling" + dev/active/migrate-services-to-api-rpc-envelope/.
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "CallExpression[callee.type='MemberExpression'][callee.property.name='rpc']" +
+            "[callee.object.type='CallExpression'][callee.object.callee.type='MemberExpression']" +
+            "[callee.object.callee.property.name='schema']",
+          message:
+            "Direct .schema('api').rpc(...) calls bypass PII masking. Use " +
+            "supabaseService.apiRpcEnvelope<T>(...) for envelope-shape writes or " +
+            "supabaseService.apiRpc<T>(...) for read-shape RPCs. The two SDK-boundary " +
+            'helpers are allow-listed at src/services/auth/supabase.service.ts and ' +
+            'src/services/api/envelope.ts.',
+        },
+      ],
+    },
+  },
+
+  // SDK boundary — these are the two files that legitimately call .schema('api').rpc(...).
+  // The helpers exposed here are the only sanctioned way for the rest of the codebase
+  // to invoke api.* RPCs (no-restricted-syntax above forbids the pattern elsewhere).
+  {
+    files: ['src/services/auth/supabase.service.ts', 'src/services/api/envelope.ts'],
+    rules: {
+      'no-restricted-syntax': 'off',
     },
   },
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -148,11 +148,14 @@ export default [
     },
   },
 
-  // SDK boundary — these are the two files that legitimately call .schema('api').rpc(...).
-  // The helpers exposed here are the only sanctioned way for the rest of the codebase
-  // to invoke api.* RPCs (no-restricted-syntax above forbids the pattern elsewhere).
+  // SDK boundary — this is the only file that legitimately calls .schema('api').rpc(...).
+  // The helpers exposed here (apiRpc, apiRpcEnvelope) are the only sanctioned way for
+  // the rest of the codebase to invoke api.* RPCs; no-restricted-syntax above forbids
+  // the pattern everywhere else. `envelope.ts` was previously listed defensively but
+  // operates only on PostgrestSingleResponse objects (does not call .schema().rpc()
+  // itself), so it doesn't trigger the rule — F5 PR #58 review removed the dead entry.
   {
-    files: ['src/services/auth/supabase.service.ts', 'src/services/api/envelope.ts'],
+    files: ['src/services/auth/supabase.service.ts'],
     rules: {
       'no-restricted-syntax': 'off',
     },

--- a/frontend/src/services/CLAUDE.md
+++ b/frontend/src/services/CLAUDE.md
@@ -191,9 +191,61 @@ return data ?? [];
 
 `apiRpc<T>` only masks the wrapper error (`PostgrestError`), NOT the `data` payload. Mutating `data.error` inside a generic `apiRpc<T>` would silently change the caller's typed `T` — a contract break. `apiRpcEnvelope<T>` exists specifically to mask the envelope's `data.error` field via `unwrapApiEnvelope<T>` and return a typed `ApiEnvelope<T>`.
 
-### Direct `.schema('api').rpc(...)` (legacy)
+### Companion helpers — `throwIfPostgrestError` and `logIfPostgrestError`
 
-Some services still call `supabase.schema('api').rpc(...)` directly. These bypass masking and are slated for migration to `apiRpcEnvelope<T>` in a follow-up card. New code MUST use one of the two helpers above; an ESLint rule will land alongside the bulk migration to enforce this.
+PII masking happens at the SDK boundary; **observability does too**. Two named exports from `@/services/api/envelope.ts` close the observability surface so services don't reinvent the per-method `if (env.postgrestError) log.error(...)` boilerplate:
+
+| Helper | When to use | Behavior on `env.postgrestError` |
+|---|---|---|
+| `throwIfPostgrestError(env, verb)` | Service method's pre-migration contract was to **throw** on PostgREST 4xx/5xx (e.g. `listClients`, `getClient`, Schedule's `parseOrThrow` methods) | Logs `Failed to <verb>` at error level **AND** throws `Error('Failed to <verb>: <env.error>')` |
+| `logIfPostgrestError(env, verb)` | Service method's pre-migration contract was to **return** `{success: false, error}` on PostgREST 4xx/5xx (e.g. ClientService lifecycle methods register/update/admit/discharge) | Logs `Failed to <verb>` at error level; does NOT throw — caller continues with `return { success: false, error: env.error }` |
+
+Both helpers no-op on success envelopes and on handler-driven envelope failures (where `env.postgrestError` is undefined). Handler-driven failures are expected business-logic outcomes; surfacing them as error-level logs would generate noise.
+
+```typescript
+// Throw contract (queries that historically threw on RPC failure)
+const env = await supabaseService.apiRpcEnvelope<{ data?: Client[] }>('list_clients', { ... });
+throwIfPostgrestError(env, 'list clients');
+if (!env.success) throw new Error(env.error ?? 'Failed to list clients');
+return env.data ?? [];
+
+// Return contract (mutations that historically returned the failure envelope)
+const env = await supabaseService.apiRpcEnvelope<Omit<ClientUpdateResult, 'success'>>(
+  'register_client', { ... }
+);
+if (!env.success) {
+  logIfPostgrestError(env, 'register client');
+  return { success: false, error: env.error };
+}
+return env as ClientUpdateResult;
+```
+
+### Inline generic idiom — `Omit<NamedResult, 'success'>`
+
+Always prefer the named result type from the relevant `*.types.ts` file over an inline anonymous generic. Use the `Omit<NamedResult, 'success'>` shape so the success-path intersection produces a value structurally compatible with the named type:
+
+```typescript
+// ❌ DON'T: inline anonymous mirror of the named type
+const env = await supabaseService.apiRpcEnvelope<{ phone_id?: string; phone?: ClientPhone }>(
+  'add_client_phone', { ... }
+);
+return { success: true, phone_id: env.phone_id, phone: env.phone };
+
+// ✅ DO: named type via Omit, uniform return
+const env = await supabaseService.apiRpcEnvelope<Omit<ClientPhoneResult, 'success'>>(
+  'add_client_phone', { ... }
+);
+if (!env.success) return { success: false, error: env.error };
+return env as ClientPhoneResult;
+```
+
+Benefits: single source of truth for what the RPC returns; catches accidental shape drift via `tsc`; satisfies the "No Anonymous Types" architecture-checklist item. The `as NamedResult` cast on the success path is safe because `ApiEnvelopeSuccess<Omit<NamedResult, 'success'>>` = `{success: true} & Omit<NamedResult, 'success'>` ≡ `NamedResult` (with `success: true` strictly narrower than `success: boolean`).
+
+For void results (`ClientVoidResult` and friends — only `{success, error?}`), no generic argument is needed — `apiRpcEnvelope(...)` defaults to `Record<string, never>` and the success-path return is just `{ success: true }`.
+
+### Direct `.schema('api').rpc(...)` is blocked
+
+The ESLint `no-restricted-syntax` rule at `frontend/eslint.config.js` blocks direct `.schema(*).rpc(...)` calls outside the SDK boundary. The only allow-listed file is `src/services/auth/supabase.service.ts` (which implements the two helpers). New direct callers fail the lint gate under `--max-warnings 0`. PR-A/B/C of the `migrate-services-to-api-rpc-envelope` card (2026-05-11) completed the bulk migration that made activation possible.
 
 ### Type-narrowed helper signatures (M3 registry)
 

--- a/frontend/src/services/api/__tests__/envelope.test.ts
+++ b/frontend/src/services/api/__tests__/envelope.test.ts
@@ -11,7 +11,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { PostgrestSingleResponse } from '@supabase/supabase-js';
 import type { ApiEnvelope } from '../envelope';
-import { unwrapApiEnvelope, throwIfPostgrestError } from '../envelope';
+import { unwrapApiEnvelope, throwIfPostgrestError, logIfPostgrestError } from '../envelope';
 
 // Stub maskPii to be identity so tests assert on shape, not masking behavior.
 vi.mock('@/utils/maskPii', () => ({
@@ -250,5 +250,46 @@ describe('throwIfPostgrestError', () => {
         error: 'permission denied',
       });
     });
+  });
+});
+
+describe('logIfPostgrestError (F1 — return-contract companion)', () => {
+  beforeEach(() => {
+    mockLogError.mockReset();
+  });
+
+  it('emits log.error on PostgREST-shape failure and does NOT throw', () => {
+    const env: ApiEnvelope<Record<string, unknown>> = {
+      success: false,
+      error: 'permission denied',
+      postgrestError: { code: '42501', message: 'permission denied', details: '', hint: '' },
+    };
+
+    expect(() => logIfPostgrestError(env, 'register client')).not.toThrow();
+    expect(mockLogError).toHaveBeenCalledTimes(1);
+    expect(mockLogError).toHaveBeenCalledWith('Failed to register client', {
+      error: 'permission denied',
+    });
+  });
+
+  it('does NOT log on handler-driven envelope failure', () => {
+    const env: ApiEnvelope<Record<string, unknown>> = {
+      success: false,
+      error: 'Duplicate client',
+      errorDetails: { code: 'DUPLICATE', message: 'm' },
+    };
+
+    expect(() => logIfPostgrestError(env, 'register client')).not.toThrow();
+    expect(mockLogError).not.toHaveBeenCalled();
+  });
+
+  it('does NOT log on success envelope', () => {
+    const env: ApiEnvelope<{ client_id: string }> = {
+      success: true,
+      client_id: 'c1',
+    };
+
+    expect(() => logIfPostgrestError(env, 'register client')).not.toThrow();
+    expect(mockLogError).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/services/api/envelope.ts
+++ b/frontend/src/services/api/envelope.ts
@@ -126,6 +126,27 @@ export function throwIfPostgrestError(
 }
 
 /**
+ * Return-contract companion to `throwIfPostgrestError`. Emits the same
+ * service-boundary `log.error('Failed to <verb>', { error })` on PostgREST
+ * 4xx/5xx failures but does NOT throw — for services whose pre-migration
+ * contract was to log + return `{success: false, error}` (e.g. the lifecycle
+ * methods on `SupabaseClientService`: register, update, admit, discharge).
+ *
+ * Use this immediately before `return { success: false, error: env.error }`
+ * when the calling service is on the return-contract path. Does nothing on
+ * success envelopes or handler-driven envelope failures.
+ *
+ * Promoted to the SDK boundary per PR #58 architect review F1 — closes the
+ * observability regression where 4 lifecycle methods lost their PostgREST-
+ * error log emission post-migration.
+ */
+export function logIfPostgrestError(env: ApiEnvelope<Record<string, unknown>>, verb: string): void {
+  if (!env.success && env.postgrestError) {
+    log.error(`Failed to ${verb}`, { error: env.error });
+  }
+}
+
+/**
  * Mask all PII-bearing string fields on a PostgrestError.
  * Returns a NEW object (does not mutate the input).
  */

--- a/frontend/src/services/clients/SupabaseClientService.ts
+++ b/frontend/src/services/clients/SupabaseClientService.ts
@@ -5,11 +5,18 @@
  * Follows CQRS pattern: all queries via api schema RPCs.
  */
 
-import { supabase } from '@/lib/supabase';
+import { supabaseService } from '@/services/auth/supabase.service';
+import { throwIfPostgrestError } from '@/services/api/envelope';
 import { Logger } from '@/utils/logger';
 import type {
   Client,
   ClientListItem,
+  ClientPhone,
+  ClientEmail,
+  ClientAddress,
+  ClientInsurancePolicy,
+  ClientFundingSource,
+  ClientProjectionRow,
   ClientUpdateResult,
   ClientPhoneResult,
   ClientEmailResult,
@@ -39,121 +46,108 @@ import type { IClientService } from './IClientService';
 
 const log = Logger.getLogger('api');
 
-function parseResponse(data: unknown): unknown {
-  return typeof data === 'string' ? JSON.parse(data) : data;
-}
-
 export class SupabaseClientService implements IClientService {
   // ---------------------------------------------------------------------------
-  // Queries
+  // Queries (throw on failure — pre-migration listClients/getClient contract)
   // ---------------------------------------------------------------------------
 
   async listClients(status?: string, searchTerm?: string): Promise<ClientListItem[]> {
     log.debug('Listing clients', { status, searchTerm });
 
-    const { data, error } = await supabase.schema('api').rpc('list_clients', {
+    const env = await supabaseService.apiRpcEnvelope<{ data?: ClientListItem[] }>('list_clients', {
       p_status: status ?? null,
       p_search_term: searchTerm ?? null,
     });
 
-    if (error) {
-      log.error('Failed to list clients', { error });
-      throw new Error(`Failed to list clients: ${error.message}`);
-    }
-
-    const result = parseResponse(data) as {
-      success: boolean;
-      data?: ClientListItem[];
-      error?: string;
-    };
-    if (!result.success) throw new Error(result.error ?? 'Failed to list clients');
-    return result.data ?? [];
+    throwIfPostgrestError(env, 'list clients');
+    if (!env.success) throw new Error(env.error ?? 'Failed to list clients');
+    return env.data ?? [];
   }
 
   async getClient(clientId: string): Promise<Client> {
     log.debug('Getting client', { clientId });
 
-    const { data, error } = await supabase.schema('api').rpc('get_client', {
+    const env = await supabaseService.apiRpcEnvelope<{ data?: Client }>('get_client', {
       p_client_id: clientId,
     });
 
-    if (error) {
-      log.error('Failed to get client', { error });
-      throw new Error(`Failed to get client: ${error.message}`);
-    }
-
-    const result = parseResponse(data) as { success: boolean; data?: Client; error?: string };
-    if (!result.success) throw new Error(result.error ?? 'Failed to get client');
-    if (!result.data) throw new Error('Client not found');
-    return result.data;
+    throwIfPostgrestError(env, 'get client');
+    if (!env.success) throw new Error(env.error ?? 'Failed to get client');
+    if (!env.data) throw new Error('Client not found');
+    return env.data;
   }
 
   // ---------------------------------------------------------------------------
-  // Lifecycle
+  // Lifecycle (return on failure)
   // ---------------------------------------------------------------------------
 
   async registerClient(params: RegisterClientParams): Promise<ClientUpdateResult> {
     log.debug('Registering client');
 
-    const { data, error } = await supabase.schema('api').rpc('register_client', {
+    const env = await supabaseService.apiRpcEnvelope<{
+      client_id?: string;
+      client?: ClientProjectionRow;
+    }>('register_client', {
       p_client_data: JSON.stringify(params.client_data),
       p_reason: params.reason ?? 'Client registered',
       p_correlation_id: params.correlation_id ?? null,
     });
 
-    if (error) {
-      log.error('Failed to register client', { error });
-      return { success: false, error: error.message };
-    }
-
-    return parseResponse(data) as ClientUpdateResult;
+    if (!env.success) return { success: false, error: env.error };
+    return { success: true, client_id: env.client_id, client: env.client };
   }
 
   async updateClient(clientId: string, params: UpdateClientParams): Promise<ClientUpdateResult> {
     log.debug('Updating client', { clientId });
 
-    const { data, error } = await supabase.schema('api').rpc('update_client', {
+    const env = await supabaseService.apiRpcEnvelope<{
+      client_id?: string;
+      client?: ClientProjectionRow;
+    }>('update_client', {
       p_client_id: clientId,
       p_changes: JSON.stringify(params.changes),
       p_reason: params.reason ?? 'Client information updated',
     });
 
-    if (error) {
-      log.error('Failed to update client', { error });
-      return { success: false, error: error.message };
-    }
+    if (!env.success) return { success: false, error: env.error };
 
-    const result = parseResponse(data) as ClientUpdateResult;
-
-    if (result.success && !result.client) {
+    // Fallback: if RPC returned success without the projection row, refetch via getClient
+    // to keep the consumer's optimistic-update path populated.
+    let client = env.client;
+    if (!client) {
       try {
-        result.client = await this.getClient(clientId);
+        // getClient returns the read-model `Client` type; assign through unknown
+        // because ClientUpdateResult.client is typed against ClientProjectionRow.
+        // Preserves pre-migration behavior verbatim.
+        client = (await this.getClient(clientId)) as unknown as ClientProjectionRow;
       } catch (err) {
         log.warn('Failed to refetch client after update fallback', { err });
       }
     }
 
-    return result;
+    return { success: true, client_id: env.client_id, client };
   }
 
   async admitClient(clientId: string, params?: AdmitClientParams): Promise<ClientUpdateResult> {
     log.debug('Admitting client', { clientId });
 
-    const { data, error } = await supabase.schema('api').rpc('admit_client', {
+    const env = await supabaseService.apiRpcEnvelope<{
+      client_id?: string;
+      client?: ClientProjectionRow;
+    }>('admit_client', {
       p_client_id: clientId,
       p_admission_data: JSON.stringify(params?.admission_data ?? {}),
       p_reason: params?.reason ?? 'Client admitted',
     });
 
-    if (error) {
-      log.error('Failed to admit client', { error });
-      return { success: false, error: error.message };
-    }
-
-    return parseResponse(data) as ClientUpdateResult;
+    if (!env.success) return { success: false, error: env.error };
+    return { success: true, client_id: env.client_id, client: env.client };
   }
 
-  async dischargeClient(clientId: string, params: DischargeClientParams): Promise<ClientUpdateResult> {
+  async dischargeClient(
+    clientId: string,
+    params: DischargeClientParams
+  ): Promise<ClientUpdateResult> {
     log.debug('Discharging client', { clientId });
 
     const dischargeData: Record<string, unknown> = {
@@ -164,18 +158,17 @@ export class SupabaseClientService implements IClientService {
     if (params.discharge_diagnosis) dischargeData.discharge_diagnosis = params.discharge_diagnosis;
     if (params.discharge_placement) dischargeData.discharge_placement = params.discharge_placement;
 
-    const { data, error } = await supabase.schema('api').rpc('discharge_client', {
+    const env = await supabaseService.apiRpcEnvelope<{
+      client_id?: string;
+      client?: ClientProjectionRow;
+    }>('discharge_client', {
       p_client_id: clientId,
       p_discharge_data: JSON.stringify(dischargeData),
       p_reason: params.reason ?? 'Client discharged',
     });
 
-    if (error) {
-      log.error('Failed to discharge client', { error });
-      return { success: false, error: error.message };
-    }
-
-    return parseResponse(data) as ClientUpdateResult;
+    if (!env.success) return { success: false, error: env.error };
+    return { success: true, client_id: env.client_id, client: env.client };
   }
 
   // ---------------------------------------------------------------------------
@@ -183,17 +176,20 @@ export class SupabaseClientService implements IClientService {
   // ---------------------------------------------------------------------------
 
   async addClientPhone(clientId: string, params: AddPhoneParams): Promise<ClientPhoneResult> {
-    const { data, error } = await supabase.schema('api').rpc('add_client_phone', {
-      p_client_id: clientId,
-      p_phone_number: params.phone_number,
-      p_phone_type: params.phone_type ?? 'mobile',
-      p_is_primary: params.is_primary ?? false,
-      p_reason: params.reason ?? 'Phone added',
-      p_correlation_id: params.correlation_id ?? null,
-    });
+    const env = await supabaseService.apiRpcEnvelope<{ phone_id?: string; phone?: ClientPhone }>(
+      'add_client_phone',
+      {
+        p_client_id: clientId,
+        p_phone_number: params.phone_number,
+        p_phone_type: params.phone_type ?? 'mobile',
+        p_is_primary: params.is_primary ?? false,
+        p_reason: params.reason ?? 'Phone added',
+        p_correlation_id: params.correlation_id ?? null,
+      }
+    );
 
-    if (error) return { success: false, error: error.message };
-    return parseResponse(data) as ClientPhoneResult;
+    if (!env.success) return { success: false, error: env.error };
+    return { success: true, phone_id: env.phone_id, phone: env.phone };
   }
 
   async updateClientPhone(
@@ -201,17 +197,20 @@ export class SupabaseClientService implements IClientService {
     phoneId: string,
     params: UpdatePhoneParams
   ): Promise<ClientPhoneResult> {
-    const { data, error } = await supabase.schema('api').rpc('update_client_phone', {
-      p_client_id: clientId,
-      p_phone_id: phoneId,
-      p_phone_number: params.phone_number ?? null,
-      p_phone_type: params.phone_type ?? null,
-      p_is_primary: params.is_primary ?? null,
-      p_reason: params.reason ?? 'Phone updated',
-    });
+    const env = await supabaseService.apiRpcEnvelope<{ phone_id?: string; phone?: ClientPhone }>(
+      'update_client_phone',
+      {
+        p_client_id: clientId,
+        p_phone_id: phoneId,
+        p_phone_number: params.phone_number ?? null,
+        p_phone_type: params.phone_type ?? null,
+        p_is_primary: params.is_primary ?? null,
+        p_reason: params.reason ?? 'Phone updated',
+      }
+    );
 
-    if (error) return { success: false, error: error.message };
-    return parseResponse(data) as ClientPhoneResult;
+    if (!env.success) return { success: false, error: env.error };
+    return { success: true, phone_id: env.phone_id, phone: env.phone };
   }
 
   async removeClientPhone(
@@ -219,14 +218,14 @@ export class SupabaseClientService implements IClientService {
     phoneId: string,
     reason?: string
   ): Promise<ClientVoidResult> {
-    const { data, error } = await supabase.schema('api').rpc('remove_client_phone', {
+    const env = await supabaseService.apiRpcEnvelope('remove_client_phone', {
       p_client_id: clientId,
       p_phone_id: phoneId,
       p_reason: reason ?? 'Phone removed',
     });
 
-    if (error) return { success: false, error: error.message };
-    return parseResponse(data) as ClientVoidResult;
+    if (!env.success) return { success: false, error: env.error };
+    return { success: true };
   }
 
   // ---------------------------------------------------------------------------
@@ -234,17 +233,20 @@ export class SupabaseClientService implements IClientService {
   // ---------------------------------------------------------------------------
 
   async addClientEmail(clientId: string, params: AddEmailParams): Promise<ClientEmailResult> {
-    const { data, error } = await supabase.schema('api').rpc('add_client_email', {
-      p_client_id: clientId,
-      p_email: params.email,
-      p_email_type: params.email_type ?? 'personal',
-      p_is_primary: params.is_primary ?? false,
-      p_reason: params.reason ?? 'Email added',
-      p_correlation_id: params.correlation_id ?? null,
-    });
+    const env = await supabaseService.apiRpcEnvelope<{ email_id?: string; email?: ClientEmail }>(
+      'add_client_email',
+      {
+        p_client_id: clientId,
+        p_email: params.email,
+        p_email_type: params.email_type ?? 'personal',
+        p_is_primary: params.is_primary ?? false,
+        p_reason: params.reason ?? 'Email added',
+        p_correlation_id: params.correlation_id ?? null,
+      }
+    );
 
-    if (error) return { success: false, error: error.message };
-    return parseResponse(data) as ClientEmailResult;
+    if (!env.success) return { success: false, error: env.error };
+    return { success: true, email_id: env.email_id, email: env.email };
   }
 
   async updateClientEmail(
@@ -252,17 +254,20 @@ export class SupabaseClientService implements IClientService {
     emailId: string,
     params: UpdateEmailParams
   ): Promise<ClientEmailResult> {
-    const { data, error } = await supabase.schema('api').rpc('update_client_email', {
-      p_client_id: clientId,
-      p_email_id: emailId,
-      p_email: params.email ?? null,
-      p_email_type: params.email_type ?? null,
-      p_is_primary: params.is_primary ?? null,
-      p_reason: params.reason ?? 'Email updated',
-    });
+    const env = await supabaseService.apiRpcEnvelope<{ email_id?: string; email?: ClientEmail }>(
+      'update_client_email',
+      {
+        p_client_id: clientId,
+        p_email_id: emailId,
+        p_email: params.email ?? null,
+        p_email_type: params.email_type ?? null,
+        p_is_primary: params.is_primary ?? null,
+        p_reason: params.reason ?? 'Email updated',
+      }
+    );
 
-    if (error) return { success: false, error: error.message };
-    return parseResponse(data) as ClientEmailResult;
+    if (!env.success) return { success: false, error: env.error };
+    return { success: true, email_id: env.email_id, email: env.email };
   }
 
   async removeClientEmail(
@@ -270,14 +275,14 @@ export class SupabaseClientService implements IClientService {
     emailId: string,
     reason?: string
   ): Promise<ClientVoidResult> {
-    const { data, error } = await supabase.schema('api').rpc('remove_client_email', {
+    const env = await supabaseService.apiRpcEnvelope('remove_client_email', {
       p_client_id: clientId,
       p_email_id: emailId,
       p_reason: reason ?? 'Email removed',
     });
 
-    if (error) return { success: false, error: error.message };
-    return parseResponse(data) as ClientVoidResult;
+    if (!env.success) return { success: false, error: env.error };
+    return { success: true };
   }
 
   // ---------------------------------------------------------------------------
@@ -285,7 +290,10 @@ export class SupabaseClientService implements IClientService {
   // ---------------------------------------------------------------------------
 
   async addClientAddress(clientId: string, params: AddAddressParams): Promise<ClientAddressResult> {
-    const { data, error } = await supabase.schema('api').rpc('add_client_address', {
+    const env = await supabaseService.apiRpcEnvelope<{
+      address_id?: string;
+      address?: ClientAddress;
+    }>('add_client_address', {
       p_client_id: clientId,
       p_street1: params.street1,
       p_city: params.city,
@@ -299,8 +307,8 @@ export class SupabaseClientService implements IClientService {
       p_correlation_id: params.correlation_id ?? null,
     });
 
-    if (error) return { success: false, error: error.message };
-    return parseResponse(data) as ClientAddressResult;
+    if (!env.success) return { success: false, error: env.error };
+    return { success: true, address_id: env.address_id, address: env.address };
   }
 
   async updateClientAddress(
@@ -308,7 +316,10 @@ export class SupabaseClientService implements IClientService {
     addressId: string,
     params: UpdateAddressParams
   ): Promise<ClientAddressResult> {
-    const { data, error } = await supabase.schema('api').rpc('update_client_address', {
+    const env = await supabaseService.apiRpcEnvelope<{
+      address_id?: string;
+      address?: ClientAddress;
+    }>('update_client_address', {
       p_client_id: clientId,
       p_address_id: addressId,
       p_address_type: params.address_type ?? null,
@@ -322,8 +333,8 @@ export class SupabaseClientService implements IClientService {
       p_reason: params.reason ?? 'Address updated',
     });
 
-    if (error) return { success: false, error: error.message };
-    return parseResponse(data) as ClientAddressResult;
+    if (!env.success) return { success: false, error: env.error };
+    return { success: true, address_id: env.address_id, address: env.address };
   }
 
   async removeClientAddress(
@@ -331,22 +342,28 @@ export class SupabaseClientService implements IClientService {
     addressId: string,
     reason?: string
   ): Promise<ClientVoidResult> {
-    const { data, error } = await supabase.schema('api').rpc('remove_client_address', {
+    const env = await supabaseService.apiRpcEnvelope('remove_client_address', {
       p_client_id: clientId,
       p_address_id: addressId,
       p_reason: reason ?? 'Address removed',
     });
 
-    if (error) return { success: false, error: error.message };
-    return parseResponse(data) as ClientVoidResult;
+    if (!env.success) return { success: false, error: env.error };
+    return { success: true };
   }
 
   // ---------------------------------------------------------------------------
   // Insurance
   // ---------------------------------------------------------------------------
 
-  async addClientInsurance(clientId: string, params: AddInsuranceParams): Promise<ClientInsuranceResult> {
-    const { data, error } = await supabase.schema('api').rpc('add_client_insurance', {
+  async addClientInsurance(
+    clientId: string,
+    params: AddInsuranceParams
+  ): Promise<ClientInsuranceResult> {
+    const env = await supabaseService.apiRpcEnvelope<{
+      policy_id?: string;
+      policy?: ClientInsurancePolicy;
+    }>('add_client_insurance', {
       p_client_id: clientId,
       p_policy_type: params.policy_type,
       p_payer_name: params.payer_name,
@@ -360,8 +377,8 @@ export class SupabaseClientService implements IClientService {
       p_correlation_id: params.correlation_id ?? null,
     });
 
-    if (error) return { success: false, error: error.message };
-    return parseResponse(data) as ClientInsuranceResult;
+    if (!env.success) return { success: false, error: env.error };
+    return { success: true, policy_id: env.policy_id, policy: env.policy };
   }
 
   async updateClientInsurance(
@@ -369,7 +386,10 @@ export class SupabaseClientService implements IClientService {
     policyId: string,
     params: UpdateInsuranceParams
   ): Promise<ClientInsuranceResult> {
-    const { data, error } = await supabase.schema('api').rpc('update_client_insurance', {
+    const env = await supabaseService.apiRpcEnvelope<{
+      policy_id?: string;
+      policy?: ClientInsurancePolicy;
+    }>('update_client_insurance', {
       p_client_id: clientId,
       p_policy_id: policyId,
       p_payer_name: params.payer_name ?? null,
@@ -382,8 +402,8 @@ export class SupabaseClientService implements IClientService {
       p_reason: params.reason ?? 'Insurance updated',
     });
 
-    if (error) return { success: false, error: error.message };
-    return parseResponse(data) as ClientInsuranceResult;
+    if (!env.success) return { success: false, error: env.error };
+    return { success: true, policy_id: env.policy_id, policy: env.policy };
   }
 
   async removeClientInsurance(
@@ -391,14 +411,14 @@ export class SupabaseClientService implements IClientService {
     policyId: string,
     reason?: string
   ): Promise<ClientVoidResult> {
-    const { data, error } = await supabase.schema('api').rpc('remove_client_insurance', {
+    const env = await supabaseService.apiRpcEnvelope('remove_client_insurance', {
       p_client_id: clientId,
       p_policy_id: policyId,
       p_reason: reason ?? 'Insurance removed',
     });
 
-    if (error) return { success: false, error: error.message };
-    return parseResponse(data) as ClientVoidResult;
+    if (!env.success) return { success: false, error: env.error };
+    return { success: true };
   }
 
   // ---------------------------------------------------------------------------
@@ -409,17 +429,20 @@ export class SupabaseClientService implements IClientService {
     clientId: string,
     params: ChangePlacementParams
   ): Promise<ClientPlacementResult> {
-    const { data, error } = await supabase.schema('api').rpc('change_client_placement', {
-      p_client_id: clientId,
-      p_placement_arrangement: params.placement_arrangement,
-      p_start_date: params.start_date,
-      p_reason: params.reason ?? 'Placement changed',
-      p_correlation_id: params.correlation_id ?? null,
-      p_organization_unit_id: params.organization_unit_id ?? null,
-    });
+    const env = await supabaseService.apiRpcEnvelope<{ placement_id?: string }>(
+      'change_client_placement',
+      {
+        p_client_id: clientId,
+        p_placement_arrangement: params.placement_arrangement,
+        p_start_date: params.start_date,
+        p_reason: params.reason ?? 'Placement changed',
+        p_correlation_id: params.correlation_id ?? null,
+        p_organization_unit_id: params.organization_unit_id ?? null,
+      }
+    );
 
-    if (error) return { success: false, error: error.message };
-    return parseResponse(data) as ClientPlacementResult;
+    if (!env.success) return { success: false, error: env.error };
+    return { success: true, placement_id: env.placement_id };
   }
 
   async endClientPlacement(
@@ -427,15 +450,18 @@ export class SupabaseClientService implements IClientService {
     endDate?: string,
     reasonText?: string
   ): Promise<ClientPlacementResult> {
-    const { data, error } = await supabase.schema('api').rpc('end_client_placement', {
-      p_client_id: clientId,
-      p_end_date: endDate ?? null,
-      p_reason_text: reasonText ?? null,
-      p_reason: 'Placement ended',
-    });
+    const env = await supabaseService.apiRpcEnvelope<{ placement_id?: string }>(
+      'end_client_placement',
+      {
+        p_client_id: clientId,
+        p_end_date: endDate ?? null,
+        p_reason_text: reasonText ?? null,
+        p_reason: 'Placement ended',
+      }
+    );
 
-    if (error) return { success: false, error: error.message };
-    return parseResponse(data) as ClientPlacementResult;
+    if (!env.success) return { success: false, error: env.error };
+    return { success: true, placement_id: env.placement_id };
   }
 
   // ---------------------------------------------------------------------------
@@ -446,7 +472,10 @@ export class SupabaseClientService implements IClientService {
     clientId: string,
     params: AddFundingSourceParams
   ): Promise<ClientFundingResult> {
-    const { data, error } = await supabase.schema('api').rpc('add_client_funding_source', {
+    const env = await supabaseService.apiRpcEnvelope<{
+      funding_source_id?: string;
+      funding_source?: ClientFundingSource;
+    }>('add_client_funding_source', {
       p_client_id: clientId,
       p_source_type: params.source_type,
       p_source_name: params.source_name,
@@ -458,8 +487,12 @@ export class SupabaseClientService implements IClientService {
       p_correlation_id: params.correlation_id ?? null,
     });
 
-    if (error) return { success: false, error: error.message };
-    return parseResponse(data) as ClientFundingResult;
+    if (!env.success) return { success: false, error: env.error };
+    return {
+      success: true,
+      funding_source_id: env.funding_source_id,
+      funding_source: env.funding_source,
+    };
   }
 
   async updateClientFundingSource(
@@ -467,7 +500,10 @@ export class SupabaseClientService implements IClientService {
     sourceId: string,
     params: UpdateFundingSourceParams
   ): Promise<ClientFundingResult> {
-    const { data, error } = await supabase.schema('api').rpc('update_client_funding_source', {
+    const env = await supabaseService.apiRpcEnvelope<{
+      funding_source_id?: string;
+      funding_source?: ClientFundingSource;
+    }>('update_client_funding_source', {
       p_client_id: clientId,
       p_funding_source_id: sourceId,
       p_source_type: params.source_type ?? null,
@@ -479,8 +515,12 @@ export class SupabaseClientService implements IClientService {
       p_reason: params.reason ?? 'Funding source updated',
     });
 
-    if (error) return { success: false, error: error.message };
-    return parseResponse(data) as ClientFundingResult;
+    if (!env.success) return { success: false, error: env.error };
+    return {
+      success: true,
+      funding_source_id: env.funding_source_id,
+      funding_source: env.funding_source,
+    };
   }
 
   async removeClientFundingSource(
@@ -488,14 +528,14 @@ export class SupabaseClientService implements IClientService {
     sourceId: string,
     reason?: string
   ): Promise<ClientVoidResult> {
-    const { data, error } = await supabase.schema('api').rpc('remove_client_funding_source', {
+    const env = await supabaseService.apiRpcEnvelope('remove_client_funding_source', {
       p_client_id: clientId,
       p_funding_source_id: sourceId,
       p_reason: reason ?? 'Funding source removed',
     });
 
-    if (error) return { success: false, error: error.message };
-    return parseResponse(data) as ClientVoidResult;
+    if (!env.success) return { success: false, error: env.error };
+    return { success: true };
   }
 
   // ---------------------------------------------------------------------------
@@ -508,15 +548,18 @@ export class SupabaseClientService implements IClientService {
     designation: string,
     reason?: string
   ): Promise<ClientAssignmentResult> {
-    const { data, error } = await supabase.schema('api').rpc('assign_client_contact', {
-      p_client_id: clientId,
-      p_contact_id: contactId,
-      p_designation: designation,
-      p_reason: reason ?? 'Contact assigned',
-    });
+    const env = await supabaseService.apiRpcEnvelope<{ assignment_id?: string }>(
+      'assign_client_contact',
+      {
+        p_client_id: clientId,
+        p_contact_id: contactId,
+        p_designation: designation,
+        p_reason: reason ?? 'Contact assigned',
+      }
+    );
 
-    if (error) return { success: false, error: error.message };
-    return parseResponse(data) as ClientAssignmentResult;
+    if (!env.success) return { success: false, error: env.error };
+    return { success: true, assignment_id: env.assignment_id };
   }
 
   async unassignClientContact(
@@ -525,14 +568,17 @@ export class SupabaseClientService implements IClientService {
     designation: string,
     reason?: string
   ): Promise<ClientAssignmentResult> {
-    const { data, error } = await supabase.schema('api').rpc('unassign_client_contact', {
-      p_client_id: clientId,
-      p_contact_id: contactId,
-      p_designation: designation,
-      p_reason: reason ?? 'Contact unassigned',
-    });
+    const env = await supabaseService.apiRpcEnvelope<{ assignment_id?: string }>(
+      'unassign_client_contact',
+      {
+        p_client_id: clientId,
+        p_contact_id: contactId,
+        p_designation: designation,
+        p_reason: reason ?? 'Contact unassigned',
+      }
+    );
 
-    if (error) return { success: false, error: error.message };
-    return parseResponse(data) as ClientAssignmentResult;
+    if (!env.success) return { success: false, error: env.error };
+    return { success: true, assignment_id: env.assignment_id };
   }
 }

--- a/frontend/src/services/clients/SupabaseClientService.ts
+++ b/frontend/src/services/clients/SupabaseClientService.ts
@@ -3,19 +3,20 @@
  *
  * Production implementation using api.* schema RPC functions.
  * Follows CQRS pattern: all queries via api schema RPCs.
+ *
+ * Envelope-shape RPCs route through `supabaseService.apiRpcEnvelope<T>` where
+ * `T = Omit<ResultType, 'success'>` so the success-path intersection produces
+ * a value structurally compatible with the named result type. The 4 lifecycle
+ * methods (register/update/admit/discharge) emit `log.error` on PostgREST 4xx/5xx
+ * via `logIfPostgrestError` to preserve the pre-migration observability contract.
  */
 
 import { supabaseService } from '@/services/auth/supabase.service';
-import { throwIfPostgrestError } from '@/services/api/envelope';
+import { throwIfPostgrestError, logIfPostgrestError } from '@/services/api/envelope';
 import { Logger } from '@/utils/logger';
 import type {
   Client,
   ClientListItem,
-  ClientPhone,
-  ClientEmail,
-  ClientAddress,
-  ClientInsurancePolicy,
-  ClientFundingSource,
   ClientProjectionRow,
   ClientUpdateResult,
   ClientPhoneResult,
@@ -78,47 +79,53 @@ export class SupabaseClientService implements IClientService {
   }
 
   // ---------------------------------------------------------------------------
-  // Lifecycle (return on failure)
+  // Lifecycle (return on failure; logIfPostgrestError preserves the pre-
+  // migration log.error emission for PostgREST 4xx/5xx — F1 closure)
   // ---------------------------------------------------------------------------
 
   async registerClient(params: RegisterClientParams): Promise<ClientUpdateResult> {
     log.debug('Registering client');
 
-    const env = await supabaseService.apiRpcEnvelope<{
-      client_id?: string;
-      client?: ClientProjectionRow;
-    }>('register_client', {
-      p_client_data: JSON.stringify(params.client_data),
-      p_reason: params.reason ?? 'Client registered',
-      p_correlation_id: params.correlation_id ?? null,
-    });
+    const env = await supabaseService.apiRpcEnvelope<Omit<ClientUpdateResult, 'success'>>(
+      'register_client',
+      {
+        p_client_data: JSON.stringify(params.client_data),
+        p_reason: params.reason ?? 'Client registered',
+        p_correlation_id: params.correlation_id ?? null,
+      }
+    );
 
-    if (!env.success) return { success: false, error: env.error };
-    return { success: true, client_id: env.client_id, client: env.client };
+    if (!env.success) {
+      logIfPostgrestError(env, 'register client');
+      return { success: false, error: env.error };
+    }
+    return env as ClientUpdateResult;
   }
 
   async updateClient(clientId: string, params: UpdateClientParams): Promise<ClientUpdateResult> {
     log.debug('Updating client', { clientId });
 
-    const env = await supabaseService.apiRpcEnvelope<{
-      client_id?: string;
-      client?: ClientProjectionRow;
-    }>('update_client', {
-      p_client_id: clientId,
-      p_changes: JSON.stringify(params.changes),
-      p_reason: params.reason ?? 'Client information updated',
-    });
+    const env = await supabaseService.apiRpcEnvelope<Omit<ClientUpdateResult, 'success'>>(
+      'update_client',
+      {
+        p_client_id: clientId,
+        p_changes: JSON.stringify(params.changes),
+        p_reason: params.reason ?? 'Client information updated',
+      }
+    );
 
-    if (!env.success) return { success: false, error: env.error };
+    if (!env.success) {
+      logIfPostgrestError(env, 'update client');
+      return { success: false, error: env.error };
+    }
 
     // Fallback: if RPC returned success without the projection row, refetch via getClient
-    // to keep the consumer's optimistic-update path populated.
+    // to keep the consumer's optimistic-update path populated. Preserves pre-migration
+    // behavior verbatim — `getClient` returns the read-model `Client` type, cast through
+    // `unknown` because `ClientUpdateResult.client` is typed against `ClientProjectionRow`.
     let client = env.client;
     if (!client) {
       try {
-        // getClient returns the read-model `Client` type; assign through unknown
-        // because ClientUpdateResult.client is typed against ClientProjectionRow.
-        // Preserves pre-migration behavior verbatim.
         client = (await this.getClient(clientId)) as unknown as ClientProjectionRow;
       } catch (err) {
         log.warn('Failed to refetch client after update fallback', { err });
@@ -131,17 +138,20 @@ export class SupabaseClientService implements IClientService {
   async admitClient(clientId: string, params?: AdmitClientParams): Promise<ClientUpdateResult> {
     log.debug('Admitting client', { clientId });
 
-    const env = await supabaseService.apiRpcEnvelope<{
-      client_id?: string;
-      client?: ClientProjectionRow;
-    }>('admit_client', {
-      p_client_id: clientId,
-      p_admission_data: JSON.stringify(params?.admission_data ?? {}),
-      p_reason: params?.reason ?? 'Client admitted',
-    });
+    const env = await supabaseService.apiRpcEnvelope<Omit<ClientUpdateResult, 'success'>>(
+      'admit_client',
+      {
+        p_client_id: clientId,
+        p_admission_data: JSON.stringify(params?.admission_data ?? {}),
+        p_reason: params?.reason ?? 'Client admitted',
+      }
+    );
 
-    if (!env.success) return { success: false, error: env.error };
-    return { success: true, client_id: env.client_id, client: env.client };
+    if (!env.success) {
+      logIfPostgrestError(env, 'admit client');
+      return { success: false, error: env.error };
+    }
+    return env as ClientUpdateResult;
   }
 
   async dischargeClient(
@@ -158,17 +168,20 @@ export class SupabaseClientService implements IClientService {
     if (params.discharge_diagnosis) dischargeData.discharge_diagnosis = params.discharge_diagnosis;
     if (params.discharge_placement) dischargeData.discharge_placement = params.discharge_placement;
 
-    const env = await supabaseService.apiRpcEnvelope<{
-      client_id?: string;
-      client?: ClientProjectionRow;
-    }>('discharge_client', {
-      p_client_id: clientId,
-      p_discharge_data: JSON.stringify(dischargeData),
-      p_reason: params.reason ?? 'Client discharged',
-    });
+    const env = await supabaseService.apiRpcEnvelope<Omit<ClientUpdateResult, 'success'>>(
+      'discharge_client',
+      {
+        p_client_id: clientId,
+        p_discharge_data: JSON.stringify(dischargeData),
+        p_reason: params.reason ?? 'Client discharged',
+      }
+    );
 
-    if (!env.success) return { success: false, error: env.error };
-    return { success: true, client_id: env.client_id, client: env.client };
+    if (!env.success) {
+      logIfPostgrestError(env, 'discharge client');
+      return { success: false, error: env.error };
+    }
+    return env as ClientUpdateResult;
   }
 
   // ---------------------------------------------------------------------------
@@ -176,7 +189,7 @@ export class SupabaseClientService implements IClientService {
   // ---------------------------------------------------------------------------
 
   async addClientPhone(clientId: string, params: AddPhoneParams): Promise<ClientPhoneResult> {
-    const env = await supabaseService.apiRpcEnvelope<{ phone_id?: string; phone?: ClientPhone }>(
+    const env = await supabaseService.apiRpcEnvelope<Omit<ClientPhoneResult, 'success'>>(
       'add_client_phone',
       {
         p_client_id: clientId,
@@ -189,7 +202,7 @@ export class SupabaseClientService implements IClientService {
     );
 
     if (!env.success) return { success: false, error: env.error };
-    return { success: true, phone_id: env.phone_id, phone: env.phone };
+    return env as ClientPhoneResult;
   }
 
   async updateClientPhone(
@@ -197,7 +210,7 @@ export class SupabaseClientService implements IClientService {
     phoneId: string,
     params: UpdatePhoneParams
   ): Promise<ClientPhoneResult> {
-    const env = await supabaseService.apiRpcEnvelope<{ phone_id?: string; phone?: ClientPhone }>(
+    const env = await supabaseService.apiRpcEnvelope<Omit<ClientPhoneResult, 'success'>>(
       'update_client_phone',
       {
         p_client_id: clientId,
@@ -210,7 +223,7 @@ export class SupabaseClientService implements IClientService {
     );
 
     if (!env.success) return { success: false, error: env.error };
-    return { success: true, phone_id: env.phone_id, phone: env.phone };
+    return env as ClientPhoneResult;
   }
 
   async removeClientPhone(
@@ -233,7 +246,7 @@ export class SupabaseClientService implements IClientService {
   // ---------------------------------------------------------------------------
 
   async addClientEmail(clientId: string, params: AddEmailParams): Promise<ClientEmailResult> {
-    const env = await supabaseService.apiRpcEnvelope<{ email_id?: string; email?: ClientEmail }>(
+    const env = await supabaseService.apiRpcEnvelope<Omit<ClientEmailResult, 'success'>>(
       'add_client_email',
       {
         p_client_id: clientId,
@@ -246,7 +259,7 @@ export class SupabaseClientService implements IClientService {
     );
 
     if (!env.success) return { success: false, error: env.error };
-    return { success: true, email_id: env.email_id, email: env.email };
+    return env as ClientEmailResult;
   }
 
   async updateClientEmail(
@@ -254,7 +267,7 @@ export class SupabaseClientService implements IClientService {
     emailId: string,
     params: UpdateEmailParams
   ): Promise<ClientEmailResult> {
-    const env = await supabaseService.apiRpcEnvelope<{ email_id?: string; email?: ClientEmail }>(
+    const env = await supabaseService.apiRpcEnvelope<Omit<ClientEmailResult, 'success'>>(
       'update_client_email',
       {
         p_client_id: clientId,
@@ -267,7 +280,7 @@ export class SupabaseClientService implements IClientService {
     );
 
     if (!env.success) return { success: false, error: env.error };
-    return { success: true, email_id: env.email_id, email: env.email };
+    return env as ClientEmailResult;
   }
 
   async removeClientEmail(
@@ -290,25 +303,25 @@ export class SupabaseClientService implements IClientService {
   // ---------------------------------------------------------------------------
 
   async addClientAddress(clientId: string, params: AddAddressParams): Promise<ClientAddressResult> {
-    const env = await supabaseService.apiRpcEnvelope<{
-      address_id?: string;
-      address?: ClientAddress;
-    }>('add_client_address', {
-      p_client_id: clientId,
-      p_street1: params.street1,
-      p_city: params.city,
-      p_state: params.state,
-      p_zip: params.zip,
-      p_address_type: params.address_type ?? 'home',
-      p_street2: params.street2 ?? null,
-      p_country: params.country ?? 'US',
-      p_is_primary: params.is_primary ?? false,
-      p_reason: params.reason ?? 'Address added',
-      p_correlation_id: params.correlation_id ?? null,
-    });
+    const env = await supabaseService.apiRpcEnvelope<Omit<ClientAddressResult, 'success'>>(
+      'add_client_address',
+      {
+        p_client_id: clientId,
+        p_street1: params.street1,
+        p_city: params.city,
+        p_state: params.state,
+        p_zip: params.zip,
+        p_address_type: params.address_type ?? 'home',
+        p_street2: params.street2 ?? null,
+        p_country: params.country ?? 'US',
+        p_is_primary: params.is_primary ?? false,
+        p_reason: params.reason ?? 'Address added',
+        p_correlation_id: params.correlation_id ?? null,
+      }
+    );
 
     if (!env.success) return { success: false, error: env.error };
-    return { success: true, address_id: env.address_id, address: env.address };
+    return env as ClientAddressResult;
   }
 
   async updateClientAddress(
@@ -316,25 +329,25 @@ export class SupabaseClientService implements IClientService {
     addressId: string,
     params: UpdateAddressParams
   ): Promise<ClientAddressResult> {
-    const env = await supabaseService.apiRpcEnvelope<{
-      address_id?: string;
-      address?: ClientAddress;
-    }>('update_client_address', {
-      p_client_id: clientId,
-      p_address_id: addressId,
-      p_address_type: params.address_type ?? null,
-      p_street1: params.street1 ?? null,
-      p_street2: params.street2 ?? null,
-      p_city: params.city ?? null,
-      p_state: params.state ?? null,
-      p_zip: params.zip ?? null,
-      p_country: params.country ?? null,
-      p_is_primary: params.is_primary ?? null,
-      p_reason: params.reason ?? 'Address updated',
-    });
+    const env = await supabaseService.apiRpcEnvelope<Omit<ClientAddressResult, 'success'>>(
+      'update_client_address',
+      {
+        p_client_id: clientId,
+        p_address_id: addressId,
+        p_address_type: params.address_type ?? null,
+        p_street1: params.street1 ?? null,
+        p_street2: params.street2 ?? null,
+        p_city: params.city ?? null,
+        p_state: params.state ?? null,
+        p_zip: params.zip ?? null,
+        p_country: params.country ?? null,
+        p_is_primary: params.is_primary ?? null,
+        p_reason: params.reason ?? 'Address updated',
+      }
+    );
 
     if (!env.success) return { success: false, error: env.error };
-    return { success: true, address_id: env.address_id, address: env.address };
+    return env as ClientAddressResult;
   }
 
   async removeClientAddress(
@@ -360,25 +373,25 @@ export class SupabaseClientService implements IClientService {
     clientId: string,
     params: AddInsuranceParams
   ): Promise<ClientInsuranceResult> {
-    const env = await supabaseService.apiRpcEnvelope<{
-      policy_id?: string;
-      policy?: ClientInsurancePolicy;
-    }>('add_client_insurance', {
-      p_client_id: clientId,
-      p_policy_type: params.policy_type,
-      p_payer_name: params.payer_name,
-      p_policy_number: params.policy_number ?? null,
-      p_group_number: params.group_number ?? null,
-      p_subscriber_name: params.subscriber_name ?? null,
-      p_subscriber_relation: params.subscriber_relation ?? null,
-      p_coverage_start_date: params.coverage_start_date ?? null,
-      p_coverage_end_date: params.coverage_end_date ?? null,
-      p_reason: params.reason ?? 'Insurance added',
-      p_correlation_id: params.correlation_id ?? null,
-    });
+    const env = await supabaseService.apiRpcEnvelope<Omit<ClientInsuranceResult, 'success'>>(
+      'add_client_insurance',
+      {
+        p_client_id: clientId,
+        p_policy_type: params.policy_type,
+        p_payer_name: params.payer_name,
+        p_policy_number: params.policy_number ?? null,
+        p_group_number: params.group_number ?? null,
+        p_subscriber_name: params.subscriber_name ?? null,
+        p_subscriber_relation: params.subscriber_relation ?? null,
+        p_coverage_start_date: params.coverage_start_date ?? null,
+        p_coverage_end_date: params.coverage_end_date ?? null,
+        p_reason: params.reason ?? 'Insurance added',
+        p_correlation_id: params.correlation_id ?? null,
+      }
+    );
 
     if (!env.success) return { success: false, error: env.error };
-    return { success: true, policy_id: env.policy_id, policy: env.policy };
+    return env as ClientInsuranceResult;
   }
 
   async updateClientInsurance(
@@ -386,24 +399,24 @@ export class SupabaseClientService implements IClientService {
     policyId: string,
     params: UpdateInsuranceParams
   ): Promise<ClientInsuranceResult> {
-    const env = await supabaseService.apiRpcEnvelope<{
-      policy_id?: string;
-      policy?: ClientInsurancePolicy;
-    }>('update_client_insurance', {
-      p_client_id: clientId,
-      p_policy_id: policyId,
-      p_payer_name: params.payer_name ?? null,
-      p_policy_number: params.policy_number ?? null,
-      p_group_number: params.group_number ?? null,
-      p_subscriber_name: params.subscriber_name ?? null,
-      p_subscriber_relation: params.subscriber_relation ?? null,
-      p_coverage_start_date: params.coverage_start_date ?? null,
-      p_coverage_end_date: params.coverage_end_date ?? null,
-      p_reason: params.reason ?? 'Insurance updated',
-    });
+    const env = await supabaseService.apiRpcEnvelope<Omit<ClientInsuranceResult, 'success'>>(
+      'update_client_insurance',
+      {
+        p_client_id: clientId,
+        p_policy_id: policyId,
+        p_payer_name: params.payer_name ?? null,
+        p_policy_number: params.policy_number ?? null,
+        p_group_number: params.group_number ?? null,
+        p_subscriber_name: params.subscriber_name ?? null,
+        p_subscriber_relation: params.subscriber_relation ?? null,
+        p_coverage_start_date: params.coverage_start_date ?? null,
+        p_coverage_end_date: params.coverage_end_date ?? null,
+        p_reason: params.reason ?? 'Insurance updated',
+      }
+    );
 
     if (!env.success) return { success: false, error: env.error };
-    return { success: true, policy_id: env.policy_id, policy: env.policy };
+    return env as ClientInsuranceResult;
   }
 
   async removeClientInsurance(
@@ -429,7 +442,7 @@ export class SupabaseClientService implements IClientService {
     clientId: string,
     params: ChangePlacementParams
   ): Promise<ClientPlacementResult> {
-    const env = await supabaseService.apiRpcEnvelope<{ placement_id?: string }>(
+    const env = await supabaseService.apiRpcEnvelope<Omit<ClientPlacementResult, 'success'>>(
       'change_client_placement',
       {
         p_client_id: clientId,
@@ -442,7 +455,7 @@ export class SupabaseClientService implements IClientService {
     );
 
     if (!env.success) return { success: false, error: env.error };
-    return { success: true, placement_id: env.placement_id };
+    return env as ClientPlacementResult;
   }
 
   async endClientPlacement(
@@ -450,7 +463,7 @@ export class SupabaseClientService implements IClientService {
     endDate?: string,
     reasonText?: string
   ): Promise<ClientPlacementResult> {
-    const env = await supabaseService.apiRpcEnvelope<{ placement_id?: string }>(
+    const env = await supabaseService.apiRpcEnvelope<Omit<ClientPlacementResult, 'success'>>(
       'end_client_placement',
       {
         p_client_id: clientId,
@@ -461,7 +474,7 @@ export class SupabaseClientService implements IClientService {
     );
 
     if (!env.success) return { success: false, error: env.error };
-    return { success: true, placement_id: env.placement_id };
+    return env as ClientPlacementResult;
   }
 
   // ---------------------------------------------------------------------------
@@ -472,27 +485,23 @@ export class SupabaseClientService implements IClientService {
     clientId: string,
     params: AddFundingSourceParams
   ): Promise<ClientFundingResult> {
-    const env = await supabaseService.apiRpcEnvelope<{
-      funding_source_id?: string;
-      funding_source?: ClientFundingSource;
-    }>('add_client_funding_source', {
-      p_client_id: clientId,
-      p_source_type: params.source_type,
-      p_source_name: params.source_name,
-      p_reference_number: params.reference_number ?? null,
-      p_start_date: params.start_date ?? null,
-      p_end_date: params.end_date ?? null,
-      p_custom_fields: JSON.stringify(params.custom_fields ?? {}),
-      p_reason: params.reason ?? 'Funding source added',
-      p_correlation_id: params.correlation_id ?? null,
-    });
+    const env = await supabaseService.apiRpcEnvelope<Omit<ClientFundingResult, 'success'>>(
+      'add_client_funding_source',
+      {
+        p_client_id: clientId,
+        p_source_type: params.source_type,
+        p_source_name: params.source_name,
+        p_reference_number: params.reference_number ?? null,
+        p_start_date: params.start_date ?? null,
+        p_end_date: params.end_date ?? null,
+        p_custom_fields: JSON.stringify(params.custom_fields ?? {}),
+        p_reason: params.reason ?? 'Funding source added',
+        p_correlation_id: params.correlation_id ?? null,
+      }
+    );
 
     if (!env.success) return { success: false, error: env.error };
-    return {
-      success: true,
-      funding_source_id: env.funding_source_id,
-      funding_source: env.funding_source,
-    };
+    return env as ClientFundingResult;
   }
 
   async updateClientFundingSource(
@@ -500,27 +509,23 @@ export class SupabaseClientService implements IClientService {
     sourceId: string,
     params: UpdateFundingSourceParams
   ): Promise<ClientFundingResult> {
-    const env = await supabaseService.apiRpcEnvelope<{
-      funding_source_id?: string;
-      funding_source?: ClientFundingSource;
-    }>('update_client_funding_source', {
-      p_client_id: clientId,
-      p_funding_source_id: sourceId,
-      p_source_type: params.source_type ?? null,
-      p_source_name: params.source_name ?? null,
-      p_reference_number: params.reference_number ?? null,
-      p_start_date: params.start_date ?? null,
-      p_end_date: params.end_date ?? null,
-      p_custom_fields: params.custom_fields ? JSON.stringify(params.custom_fields) : null,
-      p_reason: params.reason ?? 'Funding source updated',
-    });
+    const env = await supabaseService.apiRpcEnvelope<Omit<ClientFundingResult, 'success'>>(
+      'update_client_funding_source',
+      {
+        p_client_id: clientId,
+        p_funding_source_id: sourceId,
+        p_source_type: params.source_type ?? null,
+        p_source_name: params.source_name ?? null,
+        p_reference_number: params.reference_number ?? null,
+        p_start_date: params.start_date ?? null,
+        p_end_date: params.end_date ?? null,
+        p_custom_fields: params.custom_fields ? JSON.stringify(params.custom_fields) : null,
+        p_reason: params.reason ?? 'Funding source updated',
+      }
+    );
 
     if (!env.success) return { success: false, error: env.error };
-    return {
-      success: true,
-      funding_source_id: env.funding_source_id,
-      funding_source: env.funding_source,
-    };
+    return env as ClientFundingResult;
   }
 
   async removeClientFundingSource(
@@ -548,7 +553,7 @@ export class SupabaseClientService implements IClientService {
     designation: string,
     reason?: string
   ): Promise<ClientAssignmentResult> {
-    const env = await supabaseService.apiRpcEnvelope<{ assignment_id?: string }>(
+    const env = await supabaseService.apiRpcEnvelope<Omit<ClientAssignmentResult, 'success'>>(
       'assign_client_contact',
       {
         p_client_id: clientId,
@@ -559,7 +564,7 @@ export class SupabaseClientService implements IClientService {
     );
 
     if (!env.success) return { success: false, error: env.error };
-    return { success: true, assignment_id: env.assignment_id };
+    return env as ClientAssignmentResult;
   }
 
   async unassignClientContact(
@@ -568,7 +573,7 @@ export class SupabaseClientService implements IClientService {
     designation: string,
     reason?: string
   ): Promise<ClientAssignmentResult> {
-    const env = await supabaseService.apiRpcEnvelope<{ assignment_id?: string }>(
+    const env = await supabaseService.apiRpcEnvelope<Omit<ClientAssignmentResult, 'success'>>(
       'unassign_client_contact',
       {
         p_client_id: clientId,
@@ -579,6 +584,6 @@ export class SupabaseClientService implements IClientService {
     );
 
     if (!env.success) return { success: false, error: env.error };
-    return { success: true, assignment_id: env.assignment_id };
+    return env as ClientAssignmentResult;
   }
 }

--- a/frontend/src/services/clients/__tests__/SupabaseClientService.test.ts
+++ b/frontend/src/services/clients/__tests__/SupabaseClientService.test.ts
@@ -1,0 +1,251 @@
+/**
+ * SupabaseClientService — envelope-contract tests (F4 closure)
+ *
+ * Addresses PR #58 architect review F4: PR-C migrated 30 sites with zero
+ * coverage. This file pins the load-bearing contracts that are at risk of
+ * silent regression in PR-D and future migrations:
+ *
+ *  - Query throw contract (listClients / getClient) — PostgREST + envelope failure
+ *  - Lifecycle return contract — log.error fires on PostgREST failure (F1 helper)
+ *  - updateClient refetch fallback — when RPC returns success without projection row
+ *  - Representative mutation (addClientPhone) — success-path envelope spread + return
+ *
+ * Test-mock pattern matches the helper-mock template from PR-A
+ * (SupabaseUserCommandService.mapping.test.ts) and PR-B
+ * (SupabaseClientFieldService.test.ts).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockApiRpcEnvelope, mockLogError } = vi.hoisted(() => ({
+  mockApiRpcEnvelope: vi.fn(),
+  mockLogError: vi.fn(),
+}));
+
+vi.mock('@/services/auth/supabase.service', () => ({
+  supabaseService: { apiRpcEnvelope: mockApiRpcEnvelope },
+}));
+
+vi.mock('@/utils/logger', () => ({
+  Logger: {
+    getLogger: () => ({
+      error: mockLogError,
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+    }),
+  },
+}));
+
+import { SupabaseClientService } from '../SupabaseClientService';
+
+function pgFailure(msg: string) {
+  return {
+    success: false as const,
+    error: msg,
+    postgrestError: { code: '500', message: msg, details: '', hint: '' },
+  };
+}
+
+describe('SupabaseClientService', () => {
+  let service: SupabaseClientService;
+
+  beforeEach(() => {
+    mockApiRpcEnvelope.mockReset();
+    mockLogError.mockReset();
+    service = new SupabaseClientService();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Query throw contract (listClients / getClient)
+  // ---------------------------------------------------------------------------
+
+  describe('listClients — throw contract', () => {
+    it('returns data array on success', async () => {
+      const clients = [{ id: 'c1' }, { id: 'c2' }];
+      mockApiRpcEnvelope.mockResolvedValueOnce({ success: true, data: clients });
+
+      const result = await service.listClients();
+
+      expect(mockApiRpcEnvelope).toHaveBeenCalledWith('list_clients', {
+        p_status: null,
+        p_search_term: null,
+      });
+      expect(result).toEqual(clients);
+    });
+
+    it('throws with verb-prefixed message on PostgREST failure (via throwIfPostgrestError)', async () => {
+      mockApiRpcEnvelope.mockResolvedValueOnce(pgFailure('permission denied'));
+
+      await expect(service.listClients()).rejects.toThrow(
+        'Failed to list clients: permission denied'
+      );
+    });
+
+    it('throws on envelope-driven failure (no postgrestError)', async () => {
+      mockApiRpcEnvelope.mockResolvedValueOnce({
+        success: false,
+        error: 'Invalid status filter',
+      });
+
+      await expect(service.listClients()).rejects.toThrow('Invalid status filter');
+    });
+  });
+
+  describe('getClient — throw contract', () => {
+    it('returns client on success', async () => {
+      const client = { id: 'c1', first_name: 'Alex' };
+      mockApiRpcEnvelope.mockResolvedValueOnce({ success: true, data: client });
+
+      const result = await service.getClient('c1');
+
+      expect(result).toEqual(client);
+    });
+
+    it('throws "Client not found" on envelope success with null data', async () => {
+      mockApiRpcEnvelope.mockResolvedValueOnce({ success: true });
+
+      await expect(service.getClient('c1')).rejects.toThrow('Client not found');
+    });
+
+    it('throws verb-prefixed message on PostgREST failure', async () => {
+      mockApiRpcEnvelope.mockResolvedValueOnce(pgFailure('row not visible'));
+
+      await expect(service.getClient('c1')).rejects.toThrow(
+        'Failed to get client: row not visible'
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle return contract (F1 — logIfPostgrestError observability)
+  // ---------------------------------------------------------------------------
+
+  describe('registerClient — return contract + F1 observability', () => {
+    it('returns success envelope on success', async () => {
+      mockApiRpcEnvelope.mockResolvedValueOnce({
+        success: true,
+        client_id: 'c1',
+        client: { id: 'c1' },
+      });
+
+      const result = await service.registerClient({
+        client_data: { first_name: 'Alex' },
+      } as never);
+
+      expect(result.success).toBe(true);
+      expect(result.client_id).toBe('c1');
+    });
+
+    it('logs error AND returns {success: false} on PostgREST failure (F1)', async () => {
+      mockApiRpcEnvelope.mockResolvedValueOnce(pgFailure('database timeout'));
+
+      const result = await service.registerClient({ client_data: {} } as never);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('database timeout');
+      expect(mockLogError).toHaveBeenCalledWith('Failed to register client', {
+        error: 'database timeout',
+      });
+    });
+
+    it('does NOT log on handler-driven envelope failure (F1 — only fires on PostgREST)', async () => {
+      mockApiRpcEnvelope.mockResolvedValueOnce({
+        success: false,
+        error: 'Duplicate client_data hash',
+      });
+
+      const result = await service.registerClient({ client_data: {} } as never);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Duplicate client_data hash');
+      expect(mockLogError).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // updateClient — refetch fallback
+  // ---------------------------------------------------------------------------
+
+  describe('updateClient — refetch fallback', () => {
+    it('returns the RPC-provided client when present (no refetch)', async () => {
+      const client = { id: 'c1', first_name: 'Alex (updated)' };
+      mockApiRpcEnvelope.mockResolvedValueOnce({
+        success: true,
+        client_id: 'c1',
+        client,
+      });
+
+      const result = await service.updateClient('c1', { changes: { first_name: 'Alex' } } as never);
+
+      expect(result.success).toBe(true);
+      expect(result.client).toEqual(client);
+      // No refetch: only the original RPC call
+      expect(mockApiRpcEnvelope).toHaveBeenCalledTimes(1);
+    });
+
+    it('refetches via getClient when RPC succeeds without client', async () => {
+      // First call: update returns success but no client
+      mockApiRpcEnvelope.mockResolvedValueOnce({ success: true, client_id: 'c1' });
+      // Second call: getClient refetch returns the client
+      const refetched = { id: 'c1', first_name: 'Alex' };
+      mockApiRpcEnvelope.mockResolvedValueOnce({ success: true, data: refetched });
+
+      const result = await service.updateClient('c1', { changes: { first_name: 'Alex' } } as never);
+
+      expect(result.success).toBe(true);
+      expect(result.client).toEqual(refetched);
+      expect(mockApiRpcEnvelope).toHaveBeenCalledTimes(2);
+      expect(mockApiRpcEnvelope.mock.calls[1][0]).toBe('get_client');
+    });
+
+    it('logs warning and continues if refetch fails', async () => {
+      mockApiRpcEnvelope.mockResolvedValueOnce({ success: true, client_id: 'c1' });
+      mockApiRpcEnvelope.mockResolvedValueOnce(pgFailure('refetch failed'));
+
+      const result = await service.updateClient('c1', { changes: {} } as never);
+
+      expect(result.success).toBe(true);
+      expect(result.client_id).toBe('c1');
+      expect(result.client).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Representative mutation — addClientPhone (envelope spread → typed result)
+  // ---------------------------------------------------------------------------
+
+  describe('addClientPhone — mutation envelope contract', () => {
+    it('returns envelope spread on success (Omit<ResultType, success> pattern — F2)', async () => {
+      const phone = { id: 'p1', phone_number: '+15551234567' };
+      mockApiRpcEnvelope.mockResolvedValueOnce({
+        success: true,
+        phone_id: 'p1',
+        phone,
+      });
+
+      const result = await service.addClientPhone('c1', {
+        phone_number: '+15551234567',
+      } as never);
+
+      expect(result.success).toBe(true);
+      expect(result.phone_id).toBe('p1');
+      expect(result.phone).toEqual(phone);
+    });
+
+    it('returns {success: false, error} on envelope failure without throwing', async () => {
+      mockApiRpcEnvelope.mockResolvedValueOnce({
+        success: false,
+        error: 'Phone number invalid',
+      });
+
+      const result = await service.addClientPhone('c1', { phone_number: 'bad' } as never);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Phone number invalid');
+      // Phone mutations do NOT call logIfPostgrestError (only lifecycle methods do per
+      // pre-migration contract — F1 scope was the 4 lifecycle methods).
+      expect(mockLogError).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/services/organization/SupabaseOrganizationQueryService.ts
+++ b/frontend/src/services/organization/SupabaseOrganizationQueryService.ts
@@ -8,7 +8,7 @@
  * - Regular users: See only their own organization
  */
 
-import { supabase } from '@/lib/supabase';
+import { supabaseService } from '@/services/auth/supabase.service';
 import { Logger } from '@/utils/logger';
 import type {
   Organization,
@@ -82,9 +82,7 @@ export class SupabaseOrganizationQueryService implements IOrganizationQueryServi
     try {
       log.debug('Fetching organizations with filters', { filters });
 
-      // Use API schema RPC function instead of direct table query
-      // This matches the established pattern for Temporal workflow activities
-      const { data, error } = await supabase.schema('api').rpc('get_organizations', {
+      const { data, error } = await supabaseService.apiRpc<OrganizationRow[]>('get_organizations', {
         p_type: filters?.type && filters.type !== 'all' ? filters.type : null,
         p_is_active:
           filters?.status && filters.status !== 'all' ? filters.status === 'active' : null,
@@ -102,7 +100,7 @@ export class SupabaseOrganizationQueryService implements IOrganizationQueryServi
       }
 
       log.info(`Fetched ${data.length} organizations`, { filters });
-      return data.map((row: OrganizationRow) => this.mapRowToOrganization(row));
+      return data.map((row) => this.mapRowToOrganization(row));
     } catch (error) {
       log.error('Error in getOrganizations', { error, filters });
       throw error;
@@ -113,10 +111,10 @@ export class SupabaseOrganizationQueryService implements IOrganizationQueryServi
     try {
       log.debug('Fetching organization by ID', { orgId });
 
-      // Use API schema RPC function instead of direct table query
-      const { data, error } = await supabase.schema('api').rpc('get_organization_by_id', {
-        p_org_id: orgId,
-      });
+      const { data, error } = await supabaseService.apiRpc<OrganizationRow[]>(
+        'get_organization_by_id',
+        { p_org_id: orgId }
+      );
 
       if (error) {
         log.error('Failed to fetch organization by ID', { error, orgId });
@@ -141,10 +139,10 @@ export class SupabaseOrganizationQueryService implements IOrganizationQueryServi
     try {
       log.debug('Fetching child organizations', { parentOrgId });
 
-      // Use API schema RPC function instead of direct table query
-      const { data, error } = await supabase.schema('api').rpc('get_child_organizations', {
-        p_parent_org_id: parentOrgId,
-      });
+      const { data, error } = await supabaseService.apiRpc<OrganizationRow[]>(
+        'get_child_organizations',
+        { p_parent_org_id: parentOrgId }
+      );
 
       if (error) {
         log.error('Failed to fetch child organizations', { error, parentOrgId });
@@ -157,7 +155,7 @@ export class SupabaseOrganizationQueryService implements IOrganizationQueryServi
       }
 
       log.info(`Fetched ${data.length} child organizations`, { parentOrgId });
-      return data.map((row: OrganizationRow) => this.mapRowToOrganization(row));
+      return data.map((row) => this.mapRowToOrganization(row));
     } catch (error) {
       log.error('Error in getChildOrganizations', { error, parentOrgId });
       throw error;
@@ -173,17 +171,19 @@ export class SupabaseOrganizationQueryService implements IOrganizationQueryServi
 
       log.debug('Fetching paginated organizations', { options });
 
-      // Use API schema RPC function for paginated query
-      const { data, error } = await supabase.schema('api').rpc('get_organizations_paginated', {
-        p_type: options?.type && options.type !== 'all' ? options.type : null,
-        p_is_active:
-          options?.status && options.status !== 'all' ? options.status === 'active' : null,
-        p_search_term: options?.searchTerm || null,
-        p_page: page,
-        p_page_size: pageSize,
-        p_sort_by: options?.sortBy || 'name',
-        p_sort_order: options?.sortOrder || 'asc',
-      });
+      const { data, error } = await supabaseService.apiRpc<OrganizationPaginatedRow[]>(
+        'get_organizations_paginated',
+        {
+          p_type: options?.type && options.type !== 'all' ? options.type : null,
+          p_is_active:
+            options?.status && options.status !== 'all' ? options.status === 'active' : null,
+          p_search_term: options?.searchTerm || null,
+          p_page: page,
+          p_page_size: pageSize,
+          p_sort_by: options?.sortBy || 'name',
+          p_sort_order: options?.sortOrder || 'asc',
+        }
+      );
 
       if (error) {
         log.error('Failed to fetch paginated organizations', { error, options });
@@ -202,13 +202,13 @@ export class SupabaseOrganizationQueryService implements IOrganizationQueryServi
       }
 
       // Extract total_count from first row (all rows have same value via window function)
-      const totalCount = (data[0] as OrganizationPaginatedRow).total_count;
+      const totalCount = data[0].total_count;
       const totalPages = Math.ceil(totalCount / pageSize);
 
       log.info(`Fetched page ${page} of ${totalPages} (${totalCount} total)`, { options });
 
       return {
-        data: data.map((row: OrganizationPaginatedRow) => this.mapRowToOrganization(row)),
+        data: data.map((row) => this.mapRowToOrganization(row)),
         totalCount,
         page,
         pageSize,
@@ -220,30 +220,34 @@ export class SupabaseOrganizationQueryService implements IOrganizationQueryServi
     }
   }
 
+  /**
+   * `get_organization_details` is envelope-shape per the M3 registry: returns
+   * `{success, organization, contacts, addresses, phones}` on success and
+   * `{success: false, error}` on handler-driven failure. PR-A inventory had this
+   * misclassified as read-shape; corrected during PR-C implementation 2026-05-11.
+   */
   async getOrganizationDetails(orgId: string): Promise<OrganizationDetails | null> {
     try {
       log.debug('Fetching organization details', { orgId });
 
-      const { data: result, error } = await supabase
-        .schema('api')
-        .rpc('get_organization_details', { p_org_id: orgId });
+      const env = await supabaseService.apiRpcEnvelope<{
+        organization?: OrganizationDetails['organization'];
+        contacts?: OrganizationDetails['contacts'];
+        addresses?: OrganizationDetails['addresses'];
+        phones?: OrganizationDetails['phones'];
+      }>('get_organization_details', { p_org_id: orgId });
 
-      if (error) {
-        log.error('Failed to fetch organization details', { error, orgId });
-        throw new Error(`Failed to fetch organization details: ${error.message}`);
-      }
-
-      if (!result?.success) {
-        log.debug('Organization details not found', { orgId, error: result?.error });
+      if (!env.success) {
+        log.debug('Organization details not found', { orgId, error: env.error });
         return null;
       }
 
-      log.info('Fetched organization details', { orgId, name: result.organization?.name });
+      log.info('Fetched organization details', { orgId, name: env.organization?.name });
       return {
-        organization: result.organization,
-        contacts: result.contacts ?? [],
-        addresses: result.addresses ?? [],
-        phones: result.phones ?? [],
+        organization: env.organization as OrganizationDetails['organization'],
+        contacts: env.contacts ?? [],
+        addresses: env.addresses ?? [],
+        phones: env.phones ?? [],
       };
     } catch (error) {
       log.error('Error in getOrganizationDetails', { error, orgId });

--- a/frontend/src/services/organization/SupabaseOrganizationQueryService.ts
+++ b/frontend/src/services/organization/SupabaseOrganizationQueryService.ts
@@ -242,9 +242,19 @@ export class SupabaseOrganizationQueryService implements IOrganizationQueryServi
         return null;
       }
 
-      log.info('Fetched organization details', { orgId, name: env.organization?.name });
+      // Runtime guard for the envelope-contract invariant: api.get_organization_details
+      // returns `organization` on every success (verified against the RPC body). The
+      // inline generic types `organization?` as optional only because the M3 codegen
+      // emits `Partial`-like shapes for envelope success-path fields. If this guard
+      // ever fires, the RPC contract has drifted — fail closed.
+      if (!env.organization) {
+        log.warn('Organization details envelope missing organization field', { orgId });
+        return null;
+      }
+
+      log.info('Fetched organization details', { orgId, name: env.organization.name });
       return {
-        organization: env.organization as OrganizationDetails['organization'],
+        organization: env.organization,
         contacts: env.contacts ?? [],
         addresses: env.addresses ?? [],
         phones: env.phones ?? [],

--- a/frontend/src/services/organization/getOrganizationSubdomainInfo.ts
+++ b/frontend/src/services/organization/getOrganizationSubdomainInfo.ts
@@ -5,7 +5,7 @@
  * needed for post-login redirect logic. The RPC function has SECURITY DEFINER
  * which bypasses RLS, avoiding session timing issues with @supabase/ssr.
  */
-import { supabase } from '@/lib/supabase';
+import { supabaseService } from '@/services/auth/supabase.service';
 import { Logger } from '@/utils/logger';
 
 const log = Logger.getLogger('organization');
@@ -21,6 +21,15 @@ export interface OrganizationSubdomainInfo {
 }
 
 /**
+ * Response type from api.get_organization_by_id RPC function
+ * Only includes the fields we care about for subdomain redirect
+ */
+interface OrganizationRpcResponse {
+  slug: string;
+  subdomain_status: string;
+}
+
+/**
  * Fetches subdomain information for an organization
  *
  * @param orgId - Organization UUID
@@ -33,42 +42,39 @@ export interface OrganizationSubdomainInfo {
  *   window.location.href = `https://${info.slug}.${baseDomain}/dashboard`;
  * }
  * ```
+ *
+ * Refactored 2026-05-11 (PR-C, Q5 Option A): the pre-migration call chained
+ * `.single<OrganizationRpcResponse>()` after `.rpc(...)`. The new SDK helpers
+ * `apiRpc<T>` / `apiRpcEnvelope<T>` do not expose `.single()`. Replaced with
+ * `apiRpc<OrganizationRpcResponse[]>(...)` + `data?.[0] ?? null` because the
+ * RPC looks up by UUID primary key (multi-row case is impossible at the DB
+ * level). Behavioral equivalence: 0-row case folds to `null` (same as
+ * pre-migration); 2+-row case would have errored with PGRST116 but cannot
+ * occur for a PK lookup. See plan v2 §"Read-shape with `.single<T>()`".
  */
-/**
- * Response type from api.get_organization_by_id RPC function
- * Only includes the fields we care about for subdomain redirect
- */
-interface OrganizationRpcResponse {
-  slug: string;
-  subdomain_status: string;
-}
-
 export async function getOrganizationSubdomainInfo(
   orgId: string
 ): Promise<OrganizationSubdomainInfo | null> {
   try {
-    // Use RPC function with SECURITY DEFINER to bypass RLS
-    // This avoids session timing issues where @supabase/ssr may not
-    // have the JWT properly set in the Authorization header yet
-    const { data, error } = await supabase
-      .schema('api')
-      .rpc('get_organization_by_id', { p_org_id: orgId })
-      .single<OrganizationRpcResponse>();
+    const { data, error } = await supabaseService.apiRpc<OrganizationRpcResponse[]>(
+      'get_organization_by_id',
+      { p_org_id: orgId }
+    );
 
     if (error) {
       log.error('RPC error', { orgId, error });
       return null;
     }
 
-    if (!data) {
+    const row = data?.[0] ?? null;
+    if (!row) {
       log.warn('No data for org', { orgId });
       return null;
     }
 
-    // Extract just the fields we need from the full org response
     return {
-      slug: data.slug,
-      subdomain_status: data.subdomain_status as OrganizationSubdomainInfo['subdomain_status'],
+      slug: row.slug,
+      subdomain_status: row.subdomain_status as OrganizationSubdomainInfo['subdomain_status'],
     };
   } catch (err) {
     log.error('Unexpected error', { orgId, error: err });


### PR DESCRIPTION
## Summary

**PR-C of 3** — final wave of the apiRpc/apiRpcEnvelope migration card. Migrates the remaining 3 service files and **activates the `no-restricted-syntax` ESLint rule** that forbids new direct `.schema('api').rpc(...)` callers. Closes out the 3-PR plan.

**Card**: `dev/active/migrate-services-to-api-rpc-envelope/`
**Plan**: `~/.claude/plans/ddoes-it-make-sense-lucky-dongarra.md` (v2)
**Prior PRs**: #56 (PR-A, merged) + #57 (PR-B, merged)

## Migrations in this PR

| File | Sites |
|---|---|
| `clients/SupabaseClientService.ts` | 25 envelope |
| `organization/SupabaseOrganizationQueryService.ts` | 4 read + 1 envelope = 5 sites |
| `organization/getOrganizationSubdomainInfo.ts` | 1 read (Q5 refactor) |
| `eslint.config.js:124-131` | placeholder → active `no-restricted-syntax` rule |
| **TOTAL** | **31 sites + rule** |

**+1 site vs. plan estimate of 30** — `getOrganizationDetails` was misclassified as read in the inventory; M3 registry tags it as envelope. Migrated via `apiRpcEnvelope`.

## F3 pre-PR-C inventory refresh (architect-required)

Per architect F3 from PR #57 review, re-ran inventory with multi-line-aware grep before opening this PR:

```bash
grep -lE "\.schema\(['\"]api['\"]\)" frontend/src/services/ -r | grep -v __tests__ | grep -v CLAUDE.md
```

Returns exactly 4 files:
1. `auth/supabase.service.ts` — SDK helper (allow-listed, must not migrate)
2. `organization/SupabaseOrganizationQueryService.ts` — migrated in this PR
3. `organization/getOrganizationSubdomainInfo.ts` — migrated in this PR
4. `clients/SupabaseClientService.ts` — migrated in this PR

**Zero new direct callers landed in the PR-A→PR-C window.** Q4 (accept the window) was sound.

## Q5 — `.single<T>()` refactor in `getOrganizationSubdomainInfo.ts`

The only `.single<T>()` chain in the repo. Refactored to `apiRpc<OrganizationRpcResponse[]>(...)` + `data?.[0] ?? null` per plan v2 Option A. UUID-by-primary-key lookup makes the multi-row case impossible at the DB level; 0-row case folds to `null` (same as pre-migration). The inline docblock documents the equivalence reasoning.

## ESLint rule activation

```javascript
'no-restricted-syntax': ['error', { selector: '...', message: '...' }]
```

Allow-listed files (SDK boundary):
- `src/services/auth/supabase.service.ts`
- `src/services/api/envelope.ts`

Repo-wide `--max-warnings 0` policy active. New direct callers will fail the lint gate.

## Test plan

- [x] `npm run typecheck` green
- [x] `npm run lint -- --max-warnings 0` green (rule active, no warnings, no errors)
- [x] `npm run test -- --run` — 548 pass / 56 fail (pre-existing baseline unchanged from PR-B; +8 from the merged envelope-helper log-emission contract tests in PR-B commit `11c796c0`). **Zero regressions.**
- [x] `npm run build` green
- [ ] Manual smoke (post-deploy): one client lifecycle flow (register → update → discharge), one organization detail load, one post-login redirect via subdomain info

## Card close-out

After this PR merges:
- All 11 production services consume `supabaseService.apiRpc<T>` / `apiRpcEnvelope<T>` exclusively
- New direct callers blocked by ESLint
- Move `dev/active/migrate-services-to-api-rpc-envelope/` to `dev/archived/`
- Inventory artifact (`inventory.md`) preserved as historical baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)