### PR TITLE
fix(accept-invitation): remove unused deno-lint-ignore (unblocks PR #61 deploy)

### DIFF
--- a/infrastructure/supabase/supabase/functions/accept-invitation/index.ts
+++ b/infrastructure/supabase/supabase/functions/accept-invitation/index.ts
@@ -171,7 +171,6 @@ export interface ExistingUserPathResult {
  * re-emit `user.created`. See `_shared/rpc-readback.ts` for the canonical
  * schema-pinning pattern.
  */
-// deno-lint-ignore no-explicit-any
 export async function checkExistingUserPath(
   // deno-lint-ignore no-explicit-any
   client: any,


### PR DESCRIPTION
## Summary

Tiny lint fix. PR #61's `edge-functions-deploy` workflow failed at the `deno lint` step:

\`\`\`
[ban-unused-ignore]: Ignore for code \"no-explicit-any\" was not used.
 --> accept-invitation/index.ts:174
\`\`\`

The outer `// deno-lint-ignore no-explicit-any` (above the `export async function checkExistingUserPath` line) wasn't applying to anything — the function signature itself has no `any`. Only the `client: any` parameter does, and that has its own inner ignore comment that's still needed.

**Net effect**: removing one redundant ignore comment; no behavioral change. Unblocks the deploy workflow so PR #61's accept-invitation schema-mismatch fix actually reaches dev.

## Verification

- `deno lint accept-invitation/index.ts` → clean (no errors)
- `deno test --allow-net accept-invitation/__tests__/` → 6/6 pass

## Why direct merge is appropriate

This is a 1-line lint fix to unblock a failed deploy workflow on main. The accept-invitation schema fix from PR #61 is currently NOT deployed to dev because of this lint error; UAT can't proceed until it lands. No architectural decisions; no test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)