### PR TITLE
feat(invitation): reject direct cross-provider invitations at the EF boundary

### DIFF
--- a/dev/active/fix-handle-user-role-assigned-update-accessible-organizations-seed.md
+++ b/dev/active/fix-handle-user-role-assigned-update-accessible-organizations-seed.md
@@ -1,8 +1,22 @@
 # Fix `handle_user_role_assigned` to maintain `public.users.accessible_organizations`
 
-**Status**: seed (not yet planned)
+**Status**: SUPERSEDED 2026-05-13 — see `dev/active/reject-cross-provider-invitations/plan.md`
 **Priority**: Medium (affects post-invitation routing for multi-org users — frontend lands them on the wrong subdomain)
 **Origin**: PR #63 UAT Test 5 post-test finding (2026-05-13, Sally scenario for `dakaratekid@gmail.com`)
+
+## Supersession note (2026-05-13)
+
+Planning investigation revealed this seed treats a symptom of architectural drift, not a root cause. Per `documentation/architecture/data/provider-partners-architecture.md` (last updated 2026-05-06, still authoritative): cross-tenant access between distinct `provider`-type orgs is reserved for users whose home org is `provider_partner`, and is mediated by `cross_tenant_access_grants_projection` — NOT by native role assignment. dakaratekid's case is a provider→provider Sally invitation that should have been rejected at the boundary. Both `liveforlife` and `testorg-20260329` are confirmed `type='provider'`, `partner_type=NULL`.
+
+The architectural fix is to reject the invitation, not denormalize the data of an accepted-but-unintended invitation. See `dev/active/reject-cross-provider-invitations/` for the boundary-repair plan, including dakaratekid cleanup. The accessible_organizations denormalization gap closes automatically once provider→provider Sally invitations are rejected (no new offending rows).
+
+The full cross-tenant grant pipeline (api.create_access_grant, RLS on provider data, partner UI) remains parked at `dev/active/sub-tenant-admin-design/`.
+
+Routing-to-a4c symptom (dakaratekid landing on `a4c.firstovertheline.com/clients` despite JWT `org_id=liveforlife`) is NOT caused by `accessible_organizations` — routing reads JWT `org_id`, not the array. Seeded separately: `dev/active/investigate-auth-callback-priority-2-fallthrough.md`.
+
+---
+
+## Original framing (preserved for context, do not act on)
 
 ## Problem
 

--- a/dev/active/investigate-auth-callback-priority-2-fallthrough.md
+++ b/dev/active/investigate-auth-callback-priority-2-fallthrough.md
@@ -1,0 +1,59 @@
+# Investigate AuthCallback Priority-2 fall-through to platform subdomain
+
+**Status**: seed (not yet planned)
+**Priority**: Medium
+**Origin**: 2026-05-13 follow-up from `dev/active/reject-cross-provider-invitations/` planning investigation
+**Predecessor**: PR #63 UAT Test 5 (dakaratekid@gmail.com)
+
+## Problem
+
+After dakaratekid logged out and logged back in via Google OAuth, she landed on `https://a4c.firstovertheline.com/clients` (the platform-owner subdomain's `/clients` route) instead of `https://liveforlife.firstovertheline.com/dashboard` (her home org's subdomain). The data state at the time of the landing:
+
+- `users.current_organization_id` = liveforlife UUID (correct)
+- liveforlife `organizations_projection.subdomain_status` = `'verified'` (correct)
+- JWT `org_id` claim = liveforlife UUID (correct, computed by `custom_access_token_hook`)
+- AuthCallback routing logic at `frontend/src/pages/auth/AuthCallback.tsx:204-255` SHOULD have:
+  1. Decoded JWT → got `orgId = liveforlife`
+  2. Called `getOrganizationSubdomainInfo(orgId)`
+  3. Received `{slug: 'liveforlife', subdomain_status: 'verified'}` back
+  4. Built `https://liveforlife.firstovertheline.com/dashboard`
+  5. `window.location.href = subdomainUrl`
+- Instead, control fell through to **Priority 3** (`return '/clients'`) and the browser stayed on the host it came from (`a4c.firstovertheline.com`).
+
+## What the gate-repair work confirmed
+
+This symptom is NOT caused by `users.accessible_organizations` drift. The frontend routing reads `org_id` from the JWT claim, NOT the `accessible_organizations` array. The seed `fix-handle-user-role-assigned-update-accessible-organizations-seed.md` was misframed; the denormalization gap is unrelated to this routing bug.
+
+## Hypotheses
+
+1. **`getOrganizationSubdomainInfo` RPC failure** — `api.get_organization_by_id` may have denied her access to read liveforlife's row. Check RLS on `organizations_projection`: do `provider_admin` callers have a SELECT policy that covers their own org?
+2. **`subdomain_status !== 'verified'`** at the moment of the lookup — could have been a transient state during testing. (Currently verified per DB query 2026-05-13; check the historic state at the time of the bug.)
+3. **Thrown exception inside `getOrganizationSubdomainInfo`** — caught by the outer try/catch which logs but falls through to Priority 3.
+4. **`sanitizeRedirectUrl` rejected the Priority-1 invitation flow's `auth_return_to`** — but that branch shouldn't fire on a normal logout/login (only on invitation acceptance).
+5. **Stale closure / fresh-session race** — the AuthCallback comments mention this class of bug. Possibly the JWT was not yet decoded correctly when the redirect fired.
+
+## Suggested investigation order
+
+1. Read `frontend/src/services/organization/getOrganizationSubdomainInfo.ts` and the underlying RPC's RLS policies.
+2. Read `frontend/src/pages/auth/AuthCallback.tsx:204-255` (`determineRedirectUrl`) end-to-end.
+3. Query the deployed dev project's PostgREST logs (Supabase Dashboard → Logs → API) for the time window of dakaratekid's OAuth callback. Look for `get_organization_by_id` calls returning errors or empty results.
+4. Reproduce: log in as a clean `provider_admin` user in liveforlife with no extra roles. Verify routing lands them on `liveforlife.firstovertheline.com/dashboard`.
+5. If reproducible, add structured logging on the AuthCallback Priority-2 path to surface which step failed.
+
+## Out of scope
+
+- Rewriting the AuthCallback routing logic itself. The fix should be the smallest possible change that closes the Priority-2 fall-through.
+- The cross-provider invitation gate (closed by `reject-cross-provider-invitations`).
+
+## Why this matters
+
+- Multi-org users (post `reject-cross-provider-invitations` shipping, this means partner-org users with future cross-tenant grants OR single-org users with verified subdomains) need reliable redirect-to-home-subdomain on login.
+- If Priority-2 silently fails, users land on the platform-owner subdomain with the wrong tenant context. Beyond the UX bump, this could cause RLS surprises if any code reads JWT `org_id` while the URL host says otherwise.
+
+## Files likely involved
+
+- `frontend/src/pages/auth/AuthCallback.tsx` (routing logic)
+- `frontend/src/pages/auth/LoginPage.tsx` (similar routing logic at the login redirect path)
+- `frontend/src/services/organization/getOrganizationSubdomainInfo.ts`
+- `api.get_organization_by_id` RPC (RLS / permission check)
+- `organizations_projection` RLS policies (`baseline_v4.sql`)

--- a/dev/active/reject-cross-provider-invitations/plan.md
+++ b/dev/active/reject-cross-provider-invitations/plan.md
@@ -1,0 +1,364 @@
+# Plan: Reject cross-provider invitations in accept-invitation
+
+**Status**: planned (architect-reviewed 2026-05-13, see ARCHITECT NOTES inline)
+**Priority**: Medium-High
+**Origin**: PR #63 UAT Test 5 follow-up; investigation 2026-05-13
+**Supersedes**: `dev/active/fix-handle-user-role-assigned-update-accessible-organizations-seed.md`
+
+## ARCHITECT VERDICT 2026-05-13
+
+**Direction is sound.** The card correctly identifies that the missing boundary check at `accept-invitation` is the architectural defect to close, and that the symptomatic-fix path (denormalization rebuild on `handle_user_role_assigned`) treats a leaf, not a root. Decision to scope to Class 1 boundary repair only (no grant pipeline build) is the right tradeoff for the risk/reward of this PR.
+
+**Five contract gaps must be addressed before any code is written.** Each is flagged inline in the relevant section with `**ARCHITECT NOTE 2026-05-13**:` markers. Summary of the must-fix list:
+
+1. **(C1) `auth.uid() IS NULL` precondition is wrong** — accept-invitation calls Edge Function helpers with the **service_role** client (no JWT subject). `auth.uid()` returns NULL in that context, which is *not* an authn failure. Mirror the existing `api.check_user_invitation_existence` precedent (PR #63 baseline at `infrastructure/supabase/supabase/migrations/20260512194836_deactivate_user_rpc_and_check_user_invitation_existence.sql:228-277`): GRANT to BOTH `authenticated` and `service_role`, drop the auth.uid() guard, and document the threat model (this is a read-only eligibility check; SECURITY DEFINER caller is always service_role from EF or the calling user's own session — no PII leak risk).
+2. **(C2) Wrong Edge Function name for the second gate** — the invite-creation operation lives in **`invite-user/`** (`infrastructure/supabase/supabase/functions/invite-user/index.ts`), NOT `manage-user/`. `manage-user` handles update/deactivate/role-modify; it does not emit `user.invited`. The plan's gate placement description has the wrong target. Verified via `grep "user.invited" supabase/functions/`. Update tasks.md accordingly.
+3. **(C3) Organization type enum mismatch with the cited doc** — `documentation/architecture/data/provider-partners-architecture.md` uses `type='partner'` (legacy/incorrect) but the live CHECK constraint at `baseline_v4.sql:13111` allows `('platform_owner', 'provider', 'provider_partner')`. The plan's RPC correctly filters on `type = 'provider'`, but the doc fix scope must expand: not just enum-value renames for `authorization_type`, but also `type='partner'` → `type='provider_partner'` throughout the doc. The plan's doc-fix bullet is too narrow.
+4. **(C4) Eligibility check has three semantic blind spots**:
+   - **(C4a) Global super_admin rows** with `organization_id IS NULL` (per `handle_user_role_assigned`:9544 — sets `v_org_id := NULL` when event_data.org_id is `*` or platform_org). The plan's INNER JOIN `op ON op.id = urp.organization_id` silently drops them. Fix: explicit handling of NULL — either `WHERE urp.organization_id IS NOT NULL AND ...` (correct because super_admin shouldn't gate cross-tenant invites) or document the semantics in the function comment.
+   - **(C4b) `role_valid_from`** is not filtered. A future-dated role assignment (admin pre-provisioning a role starting next month) currently counts as "active in another provider". Add: `AND (urp.role_valid_from IS NULL OR urp.role_valid_from <= CURRENT_DATE)`.
+   - **(C4c) `op.is_active`** is not checked. The existing `validate_cross_tenant_access` function (baseline_v4.sql:12092) joins on `is_active = true`. A deactivated provider org should not block an invite. Add: `AND op.is_active = true`.
+5. **(C5) Idempotency framing on the cleanup DO block is implicit** — `IF FOUND` after a `SELECT … LIMIT 1` is effectively idempotent (rerun: row already revoked → not found → no-op), but the architecturally correct phrasing is "the cleanup is convergent under re-run because `handle_user_role_revoked` deletes the projection row". Add an explicit precondition assertion: `SELECT … FROM user_roles_projection WHERE … AND <not-already-revoked-marker>`. Since revoke deletes the row, this collapses to the existing query — but the docblock should state the invariant.
+
+**Two non-blocking improvements** (apply if cheap, defer otherwise — flagged as `**ARCHITECT NOTE (optional)**:`):
+
+- Read-shape return contract is **fine as `{eligible, error?, message?, details?}`** but slightly less consistent with PR #63's `{isExistingUser, isDeleted}` boolean-pair precedent. Consider whether the Edge Function caller actually needs the `details.existing_provider_org_id` UUID in the response — if it just logs and surfaces a generic 422 message, the UUID adds PII surface for no caller benefit. Keep the details object only if the UI actually displays the existing-org name (which requires a follow-up query anyway).
+- Doc home for the boundary-repair note: prefer the **Edge Function docblock** at top of `accept-invitation/index.ts` and `invite-user/index.ts` (wire-tier concern, lives with the code). Add a short cross-reference in `infrastructure/supabase/CLAUDE.md` rather than a full subsection — the canonical statement should be next to the code that enforces it.
+
+**Proceed with the plan as edited below.** No fundamental redesign needed.
+
+## TL;DR
+
+Provider→provider Sally invitations silently emit `user.role.assigned` and create native multi-tenant role rows. This violates the original architectural intent (`documentation/architecture/data/provider-partners-architecture.md`): cross-tenant access between provider orgs is reserved for users whose home org is `type='provider_partner'`, and is mediated by `cross_tenant_access_grants_projection` — NOT by native role assignment.
+
+This card adds a boundary gate in `accept-invitation` (and `manage-user` invite-creation, defense-in-depth) that rejects provider→provider Sally invitations and cleans up the one known accidental cross-tenant native role (dakaratekid@gmail.com in testorg-20260329).
+
+This card does **NOT**:
+- Build the cross-tenant grant producer pipeline → `dev/active/sub-tenant-admin-design/`
+- Fix the `accessible_organizations` denormalization → symptomatic; if the gate ships, the bad case stops happening
+- Root-cause the routing-to-a4c symptom → seeded as a separate follow-up card
+
+## Investigation findings (verified 2026-05-13 via Management API SQL)
+
+| Item | Result |
+|---|---|
+| Live for Life | `type='provider'`, `partner_type=NULL`, subdomain `liveforlife` (verified) |
+| TestOrg-20260329 | `type='provider'`, `partner_type=NULL`, subdomain `testorg-20260329` (verified) |
+| dakaratekid `current_organization_id` | liveforlife UUID |
+| dakaratekid `accessible_organizations` | `[liveforlife]` only |
+| dakaratekid `user_roles_projection` rows | 2: `Aspen Program Manager @ liveforlife`, `Cypress Admin @ testorg-20260329` |
+| dakaratekid `user_organizations_projection` rows | 1: liveforlife only |
+
+**Both orgs are `provider` type. Neither is `provider_partner`.** Per original intent, this invitation should have been rejected at the boundary.
+
+**Drift**: `accept-invitation`'s Sally path (existing user) emits `user.role.assigned` for any cross-org invitation, with no check on invitee's home-org type or whether the cross-org direction is provider→provider. The grant infrastructure (`cross_tenant_access_grants_projection` + `process_access_grant_event` router) exists in baseline_v4 but no producer flow fires the events and no RLS policy on provider data consults the projection, so the grant pathway is architecturally aspirational today.
+
+**Routing symptom is a separate bug**: dakaratekid's JWT will carry `org_id=liveforlife` (her `current_organization_id`), and liveforlife's subdomain is verified. The `AuthCallback.tsx` Priority-2 redirect should have sent her to `liveforlife.firstovertheline.com/dashboard`. The fact that she landed on `a4c.firstovertheline.com/clients` (Priority-3 default on the platform host) means Priority-2 silently fell through — likely an RPC denial or thrown exception in `getOrganizationSubdomainInfo`. `accessible_organizations` is NOT on the routing read path. Seed a follow-up card to investigate.
+
+## Architecture
+
+### New SQL RPC: `api.check_invitation_acceptance_eligibility`
+
+**Contract (Design-by-Contract)**:
+
+- **Preconditions**:
+  - `p_invitee_user_id` is non-NULL (caller guarantees from invitation row).
+  - `p_target_org_id` is non-NULL (caller guarantees from invitation row).
+  - Caller is `authenticated` OR `service_role` (GRANT-enforced; **no** `auth.uid()` runtime guard — see ARCHITECT NOTE C1 below).
+  - Function is invoked AFTER existence check (`api.check_user_invitation_existence`) confirms `isExistingUser = true`. Brand-new invitees skip the eligibility call entirely.
+- **Postconditions**:
+  - Returns a jsonb object. Two-shape contract:
+    - On eligible: `{"eligible": true}` (no other keys).
+    - On blocked: `{"eligible": false, "error": "<machine_code>", "message": "<human_text>", "details"?: {...}}`.
+  - Function is pure read; no events emitted, no projections modified, no auth.* mutation.
+- **Invariants**:
+  - Does NOT consult `invitations_projection` — the caller has already validated invitation state (not accepted, not revoked, not expired). This function is org-level, not invitation-level.
+  - Does NOT consult `cross_tenant_access_grants_projection` — the existence of a grant does NOT make a direct role assignment eligible; grants are a separate access pathway.
+  - Filtering on the existing-role side considers `role_valid_from <= today`, `role_valid_until IS NULL OR >= today`, AND `op.is_active = true` (so a stale role at a deactivated org doesn't block a legitimate fresh invite). See C4 below.
+- **Error conditions**:
+  - `target_org_not_found` — target org row missing (likely race with org deletion).
+  - `cross_provider_invitation_blocked` — invitee has an active role in a different `type='provider'` org AND target is `type='provider'`.
+- **Performance**: Two indexed reads (`user_roles_projection.user_id` + PK lookup on `organizations_projection.id`). p95 < 10ms expected.
+- **Security**: SECURITY DEFINER. The function only reads org type + existing-role org IDs. Caller cannot pass arbitrary `p_invitee_user_id` to enumerate users in other orgs because the function returns at most ONE `existing_provider_org_id` (and only when the result is "blocked"); it does NOT reveal which role/name/user-detail. See C1 NOTE below for threat-model rationale.
+
+```sql
+CREATE OR REPLACE FUNCTION api.check_invitation_acceptance_eligibility(
+  p_invitee_user_id uuid,
+  p_target_org_id uuid
+) RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER STABLE
+SET search_path = public, extensions, pg_temp
+AS $$
+DECLARE
+  v_target_org_type text;
+  v_target_is_active boolean;
+  v_existing_org_id uuid;
+BEGIN
+  -- **ARCHITECT NOTE C1 2026-05-13 (must-fix)**: Original draft had
+  --   IF auth.uid() IS NULL THEN RAISE EXCEPTION '42501' END IF;
+  -- This is WRONG. accept-invitation calls this RPC via the service-role
+  -- admin client (the Edge Function runs unauthenticated until the user has
+  -- accepted), where auth.uid() legitimately returns NULL. Mirror the existing
+  -- api.check_user_invitation_existence precedent (PR #63):
+  --   - GRANT EXECUTE TO authenticated  ← invite-user path (user-initiated)
+  --   - GRANT EXECUTE TO service_role   ← accept-invitation path (EF admin client)
+  -- and rely on GRANT for authn. Threat model: this is a read-only org-type
+  -- check. Worst case if leaked to an unauthorized caller: they learn whether
+  -- a known user_id has a role in some provider org (booleanish info already
+  -- knowable via the org's user-list APIs). No PII leak — function never
+  -- returns names/emails/role-ids, only org_ids.
+
+  SELECT type, is_active INTO v_target_org_type, v_target_is_active
+  FROM public.organizations_projection
+  WHERE id = p_target_org_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'eligible', false,
+      'error', 'target_org_not_found',
+      'message', 'Target organization does not exist.'
+    );
+  END IF;
+
+  -- Defensive: deactivated target org should not be invitable to anyway,
+  -- but the existing invite-creation flow allows it and a separate concern
+  -- handles deactivation. Don't expand scope here.
+  -- (Surface for follow-up if UAT shows this is an issue.)
+
+  -- **ARCHITECT NOTE C4 2026-05-13 (must-fix)**: original filter missed three things:
+  --   (C4a) `organization_id IS NULL` rows (global super_admin) — silently dropped
+  --         by INNER JOIN. Made explicit: WHERE urp.organization_id IS NOT NULL.
+  --         Semantics: a super_admin has cross-org reach by design; that should
+  --         NOT block a fresh provider invite (they can already see the org).
+  --   (C4b) `role_valid_from` not filtered — future-dated assignments leaked
+  --         through as "active". Added: role_valid_from IS NULL OR <= CURRENT_DATE.
+  --   (C4c) Existing role's org might be deactivated — that role is effectively
+  --         dead and should not block a fresh invite. Added: op.is_active = true.
+  SELECT urp.organization_id INTO v_existing_org_id
+  FROM public.user_roles_projection urp
+  JOIN public.organizations_projection op ON op.id = urp.organization_id
+  WHERE urp.user_id = p_invitee_user_id
+    AND urp.organization_id IS NOT NULL
+    AND urp.organization_id != p_target_org_id
+    AND op.type = 'provider'
+    AND op.is_active = true
+    AND (urp.role_valid_from IS NULL OR urp.role_valid_from <= CURRENT_DATE)
+    AND (urp.role_valid_until IS NULL OR urp.role_valid_until >= CURRENT_DATE)
+  LIMIT 1;
+
+  IF FOUND AND v_target_org_type = 'provider' THEN
+    RETURN jsonb_build_object(
+      'eligible', false,
+      'error', 'cross_provider_invitation_blocked',
+      'message', 'This user is already a member of another provider organization. Cross-tenant access between providers requires a cross-tenant access grant via a partner organization, not a direct invitation.',
+      'details', jsonb_build_object(
+        'existing_provider_org_id', v_existing_org_id,
+        'target_provider_org_id', p_target_org_id
+      )
+    );
+  END IF;
+
+  RETURN jsonb_build_object('eligible', true);
+END;
+$$;
+
+COMMENT ON FUNCTION api.check_invitation_acceptance_eligibility(uuid, uuid) IS
+$comment$Check whether an invitee may accept (or be issued) an invitation to a target org.
+
+Rejects when the invitee already has an active native role in a different
+provider-type org AND the target org is also provider-type. Aligns with
+provider-partners-architecture.md: cross-tenant access between providers is
+reserved for provider_partner-org users via cross_tenant_access_grants_projection.
+
+Active-role filter: organization_id IS NOT NULL (skip global super_admin),
+role_valid_from <= today, role_valid_until IS NULL OR >= today,
+target org is_active = true.
+
+Returns:
+  {eligible: true}                                          -- proceed
+  {eligible: false, error: 'target_org_not_found', ...}     -- 422
+  {eligible: false, error: 'cross_provider_invitation_blocked', ...} -- 403/422
+
+Called from:
+- accept-invitation Edge Function (Sally path, after isExistingUser=true)
+- invite-user Edge Function (pre-issuance, defense in depth)
+
+@a4c-rpc-shape: read$comment$;
+
+-- **ARCHITECT NOTE C1 2026-05-13**: GRANT to BOTH roles — service_role REQUIRED
+-- for accept-invitation (admin client, no JWT subject), authenticated REQUIRED
+-- for invite-user (user-initiated session). Matches api.check_user_invitation_existence.
+GRANT EXECUTE ON FUNCTION api.check_invitation_acceptance_eligibility(uuid, uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION api.check_invitation_acceptance_eligibility(uuid, uuid) TO service_role;
+```
+
+**Shape: `read`** (not envelope) — this is a check function, not a write RPC. The Edge Function inspects `eligible: boolean` and translates to HTTP status.
+
+**ARCHITECT NOTE (optional, on response shape)**: Consider dropping the `details.existing_provider_org_id` field if the UI does NOT display the existing org's name. The blocked path is rare and the EF logs the full context anyway; returning the UUID adds an exfiltration surface for callers who learn the function exists. Keep ONLY if the invite-user UI plans a "this user is in org X" affordance (which requires a separate org-lookup permission). For v1, **recommend removing `details`** and adding it back when UI need is concrete.
+
+**ARCHITECT NOTE (org type values verified 2026-05-13)**: Live CHECK constraint at `baseline_v4.sql:13111` allows `('platform_owner', 'provider', 'provider_partner')` — **not** the legacy `'partner'` shown in `provider-partners-architecture.md`. The RPC's `op.type = 'provider'` filter is correct. `platform_owner` callers/targets are correctly ignored by this check (cross-platform_owner invitations don't exist in practice).
+
+### Edge Function gate: `accept-invitation` Sally path
+
+In the existing-user branch (around `accept-invitation/index.ts:580-660`, after `checkExistingUserPath` confirms userExists), call `api.check_invitation_acceptance_eligibility` BEFORE emitting any `user.role.assigned` events. On `eligible=false`, return 403 with the RPC's error code/message + correlation_id. Do not emit any role events; do not emit `invitation.accepted` (invitation stays pending; admin can revoke).
+
+**Race condition (TOCTOU) consideration**: between the eligibility check and the role-event emission, the invitee could in principle gain a new role in another provider org (e.g., concurrent invite acceptance in a different tab). The window is small (single Edge Function execution) and the failure mode is benign — the second event lands in `domain_events` and the handler creates the row anyway. **No mitigation required for v1**; if this becomes observable, the correct fix is to push the check into a SQL RPC that emits the role event in the same transaction (Pattern A v2). For now, document the window in the EF docblock and move on.
+
+### Edge Function gate: `invite-user` (defense in depth)
+
+**ARCHITECT NOTE C2 2026-05-13 (must-fix)**: The plan originally said "manage-user invite-creation flow". **`manage-user` does NOT emit `user.invited`.** Verified via grep across `supabase/functions/`: the only Edge Function that emits `user.invited` is **`invite-user/index.ts:836`**. `manage-user` handles update/deactivate/role-modify operations. Renamed throughout.
+
+In `invite-user/index.ts`, before the `CREATE INVITATION` block (around line 786, after the existing 409-duplicate check), look up whether any existing user matches `requestData.email` (case-insensitive). If found, call `api.check_invitation_acceptance_eligibility(p_invitee_user_id, p_target_org_id)`. On block, return **422** (so invite-create UI shows a clear "cannot invite" error instead of letting the invitee follow a token and hit a 403 mid-OAuth).
+
+**Email→user lookup safety (ARCHITECT NOTE)**: `public.users.email` has NO UNIQUE constraint at the projection layer (verified at `baseline_v4.sql:12702-12717`). Uniqueness is enforced at the Supabase Auth layer (`auth.users.email`), but the projection could theoretically lag or hold duplicates during edge-case event ordering. **Required mitigation**: query with `WHERE LOWER(email) = LOWER($1) AND deleted_at IS NULL ORDER BY created_at LIMIT 1`. If zero rows: greenfield invitee, skip eligibility, continue. If 1+ rows: take the first row's id, run eligibility. The very-rare-multi-row case still gets a deterministic answer (first-created user wins the gate).
+
+**Alternative considered**: use `supabaseAdmin.auth.admin.listUsers({ filter: \`email.eq.\${email}\` })`. Rejected — `auth.admin.listUsers` is paginated, more network round-trips, and not part of the cached projection. The projection lookup is sufficient because the only Sally-relevant case is "user has a role in another org" which by definition requires the projection row to exist.
+
+### One-off cleanup: dakaratekid revoke
+
+Emit `user.role.revoked` for her testorg-20260329 Cypress Admin role inside the migration's DO block, idempotent (skip if row already absent). `handle_user_role_revoked` drops the `user_roles_projection` row and removes the role name from `users.roles[]`. Restores her to single-org liveforlife state.
+
+**ARCHITECT NOTE C5 2026-05-13 (must-fix, low-risk)**: The plan's `IF FOUND` idempotency is correct in effect (rerun finds no row → no-op), but the invariant should be stated explicitly. Re-run convergence relies on `handle_user_role_revoked` deleting the projection row on the first emit; therefore "row exists" ↔ "not yet revoked". If the handler's semantics ever change to soft-revoke (mark `revoked_at` instead of delete), this DO block must be revisited. Add a docblock above the migration documenting this dependency.
+
+**ARCHITECT NOTE on Pattern A v2**: Should this cleanup use Pattern A v2 readback? **No.** Pattern A v2 applies to user-facing `api.*` RPCs that need to surface handler failures via envelope. This is a one-time migration cleanup with no caller to surface to. If the emit fails (handler raises), the `BEFORE INSERT` trigger persists `processing_error` in `domain_events` and the migration itself fails — surfacing the error through the deploy log, which is the right channel here. PR #63's `api.deactivate_user` uses Pattern A v2 because it has a frontend caller; this DO block does not.
+
+**ARCHITECT NOTE on metadata.user_id**: Per `event-metadata-schema.md:247-251`, `metadata.user_id` is OPTIONAL and auto-injects from `auth.uid()` when omitted (NULL inside a DDL migration). The audit trail records this as a system event with no human operator — acceptable. Add `automated: true` to mark non-human source explicitly (consistent with the `automated: true` flag used in `accept-invitation/index.ts:616` for OAuth-driven `user.created`).
+
+```sql
+-- See ARCHITECT NOTE C5: idempotency depends on handle_user_role_revoked
+-- deleting the projection row. If that handler ever switches to soft-revoke,
+-- this block must be rewritten to check a revoked-marker instead of NOT FOUND.
+DO $$
+DECLARE
+  v_user_id uuid := 'bab8077f-6a76-46f4-a0cd-9363bbf313fb';
+  v_org_id uuid := '2d0829ae-224b-4a79-ac3a-726b00d6c172';
+  v_role_id uuid;
+BEGIN
+  SELECT role_id INTO v_role_id
+  FROM public.user_roles_projection
+  WHERE user_id = v_user_id AND organization_id = v_org_id;
+
+  IF FOUND THEN
+    PERFORM api.emit_domain_event(
+      p_stream_type := 'user',
+      p_stream_id := v_user_id,
+      p_event_type := 'user.role.revoked',
+      p_event_data := jsonb_build_object(
+        'role_id', v_role_id,
+        'org_id', v_org_id
+      ),
+      p_event_metadata := jsonb_build_object(
+        'reason', 'One-off cleanup: dakaratekid was accidentally cross-invited to testorg-20260329 (both type=provider). Per provider-partners-architecture.md, cross-provider invitations are forbidden. See card reject-cross-provider-invitations.',
+        'source', 'migration_reject_cross_provider_invitations',
+        'automated', true
+      )
+    );
+    RAISE NOTICE 'Revoked accidental cross-provider role: user=% org=% role=%', v_user_id, v_org_id, v_role_id;
+  ELSE
+    RAISE NOTICE 'No cleanup needed: dakaratekid has no role in testorg-20260329';
+  END IF;
+END $$;
+```
+
+Plus a diagnostic NOTICE-only audit query in the same migration that reports any OTHER users in the same situation (multi-row `user_roles_projection` across multiple `type='provider'` orgs) — so the team can decide case-by-case whether to revoke (no auto-cleanup beyond dakaratekid).
+
+**ARCHITECT NOTE (additional pre-deploy audit)**: The card lacks a query that enumerates **pending invitations** (`invitations_projection WHERE accepted_at IS NULL AND revoked_at IS NULL AND expires_at > now()`) joined against `public.users.email` to surface invitations that WOULD now be blocked at acceptance. Add this to the migration as a NOTICE-only audit. Users who have an in-flight token that the new gate will reject deserve an admin heads-up. Suggested:
+
+```sql
+DO $$
+DECLARE
+  v_rec record;
+  v_count int := 0;
+BEGIN
+  RAISE NOTICE 'Pre-deploy audit: pending invitations that the new gate WOULD reject:';
+  FOR v_rec IN
+    SELECT i.id AS invitation_id, i.email, i.org_id AS target_org_id,
+           u.id AS invitee_user_id
+    FROM public.invitations_projection i
+    JOIN public.users u ON LOWER(u.email) = LOWER(i.email) AND u.deleted_at IS NULL
+    JOIN public.organizations_projection ot ON ot.id = i.org_id AND ot.type = 'provider'
+    WHERE i.accepted_at IS NULL
+      AND i.revoked_at IS NULL
+      AND i.expires_at > NOW()
+      AND EXISTS (
+        SELECT 1 FROM public.user_roles_projection urp
+        JOIN public.organizations_projection oo ON oo.id = urp.organization_id
+        WHERE urp.user_id = u.id
+          AND urp.organization_id IS NOT NULL
+          AND urp.organization_id != i.org_id
+          AND oo.type = 'provider'
+          AND oo.is_active = true
+          AND (urp.role_valid_from IS NULL OR urp.role_valid_from <= CURRENT_DATE)
+          AND (urp.role_valid_until IS NULL OR urp.role_valid_until >= CURRENT_DATE)
+      )
+  LOOP
+    v_count := v_count + 1;
+    RAISE NOTICE '  invitation=% email=% target_org=% existing_user=%',
+      v_rec.invitation_id, v_rec.email, v_rec.target_org_id, v_rec.invitee_user_id;
+  END LOOP;
+  RAISE NOTICE 'Pre-deploy audit complete: % invitation(s) would now be rejected.', v_count;
+END $$;
+```
+
+Use the projection column names actually present in `invitations_projection` (verify in baseline_v4 before writing the migration — schema may differ).
+
+## Out of scope
+
+- Building the cross-tenant grant producer pipeline (`api.create_access_grant` / revoke / suspend RPCs, RLS on provider tables, partner-UI for grants) — `dev/active/sub-tenant-admin-design/`
+- Fixing `accessible_organizations` denormalization — symptomatic; if the gate ships, no future drift
+- AuthCallback Priority-2 fall-through routing investigation — separate follow-up card
+
+## Tasks (high level — `tasks.md` has the working checklist)
+
+1. Migration: `supabase migration new reject_cross_provider_invitations`
+2. Handler reference file
+3. `accept-invitation` Edge Function: Sally-path gate
+4. `manage-user` Edge Function: pre-issuance gate
+5. Deno tests (both Edge Functions)
+6. Regenerate RPC registry + database.types.ts (frontend + workflows)
+7. Pre-deploy smoke against dev (per 2026-05-12 pre-deploy ritual)
+8. UAT: Sally scenario rejected at invite-create + at accept; dakaratekid restored to single-org
+9. Doc updates: enum naming fix in provider-partners-architecture.md; boundary-repair note in supabase/CLAUDE.md
+10. Memory updates: close old seed in `MEMORY.md`; add `cross-provider-invitation-rejected.md`
+11. Seed follow-up: `dev/active/investigate-auth-callback-priority-2-fallthrough.md`
+
+## Risks
+
+- **Other accidental cross-provider users may exist** beyond dakaratekid. The migration runs a diagnostic NOTICE query but does NOT auto-cleanup. Triage in a follow-up if any are found.
+- **Eligibility check must NOT block legitimate provider_partner→provider invitations** (when grant pipeline ships) — explicit Deno tests for `type='provider_partner'` home → `type='provider'` target should pass eligibility (because the check only blocks when invitee's existing role org is `type='provider'`). **ARCHITECT NOTE**: the legacy doc uses `type='partner'`; the LIVE enum value is `provider_partner`. Test fixtures must use the live value.
+- **Edge Function deployment is manual** until CI preview deploy lands. Smoke artifact required before opening PR per the 2026-05-12 ritual.
+- **ARCHITECT NOTE — in-flight token risk**: invitations issued before the gate ships with a token that would NOW be rejected at acceptance create a poor admin UX (silent 403, admin sees pending invitation that won't accept). The diagnostic pre-deploy audit (NOTICE query above) surfaces these. Risk-mitigation options, in order of preference: (a) admin manually revokes the in-flight invitation pre-deploy; (b) auto-revoke them in the migration with an explicit per-row `invitation.revoked` emit (heavier surgery, not recommended for v1); (c) accept the UX bump and let the 403 land — the message tells the admin what to do.
+- **ARCHITECT NOTE — latent bug in `validate_cross_tenant_access`**: While auditing, I noticed `baseline_v4.sql:12120` references `org_id` column in `user_roles_projection` (which is actually `organization_id`). The function would error on any non-NULL `p_user_id` parameter. **NOT this card's concern** (no current caller traffic — verify before declaring); seed a separate follow-up only if a caller exists.
+- **ARCHITECT NOTE — TOCTOU window in accept-invitation**: documented inline above. No-mitigation-needed call; revisit if observed.
+
+## Files
+
+- New migration: `infrastructure/supabase/supabase/migrations/<TIMESTAMP>_reject_cross_provider_invitations.sql`
+- New handler reference: `infrastructure/supabase/handlers/api/check_invitation_acceptance_eligibility.sql`
+- Modify: `infrastructure/supabase/supabase/functions/accept-invitation/index.ts`
+- **ARCHITECT NOTE C2 — corrected file**: Modify: `infrastructure/supabase/supabase/functions/invite-user/index.ts` (NOT manage-user — verified via grep, `user.invited` is emitted only at `invite-user/index.ts:836`)
+- New tests:
+  - `infrastructure/supabase/supabase/functions/accept-invitation/__tests__/eligibility.test.ts`
+  - `infrastructure/supabase/supabase/functions/invite-user/__tests__/invite-eligibility.test.ts` (NOT manage-user)
+- Regenerated: `frontend/src/services/api/rpc-registry.generated.ts`, `frontend/src/types/database.types.ts`, `workflows/src/types/database.types.ts`
+- Doc edits:
+  - `documentation/architecture/data/provider-partners-architecture.md` — **scope expanded per ARCHITECT NOTE C3**: (a) enum naming (`family_consent`→`family_participation`, `agency_assignment`→`social_services_assignment`); (b) all `type='partner'` → `type='provider_partner'` references; (c) add a "Boundary Repair" note pointing to accept-invitation/invite-user Edge Function docblocks. Bump frontmatter `last_updated`.
+  - `infrastructure/supabase/CLAUDE.md` — short cross-reference (NOT a full subsection per ARCHITECT NOTE optional improvement); canonical statement lives in Edge Function docblocks.
+  - **NEW** docblock at top of `accept-invitation/index.ts` documenting the eligibility gate + TOCTOU window.
+  - **NEW** docblock at top of `invite-user/index.ts` documenting the defense-in-depth gate.
+- New seed: `dev/active/investigate-auth-callback-priority-2-fallthrough.md`
+- Memory: `MEMORY.md` index entry + new `cross-provider-invitation-rejected.md`
+- Old seed close-out note: `dev/active/fix-handle-user-role-assigned-update-accessible-organizations-seed.md`
+
+## Architecture Review Checklist
+
+**Filled in as part of the architect review 2026-05-13.** Re-evaluate at PR-open time; items marked NEEDS ATTENTION must be closed in-PR before merge.
+
+- [x] **CQRS Standards** — PASS. New `api.check_invitation_acceptance_eligibility` is a query (read-shape). It reads `organizations_projection` + `user_roles_projection`; no mutation. The cleanup DO block emits a domain event via `api.emit_domain_event` (command), routed to `handle_user_role_revoked` (projection write). Command/query boundary respected.
+- [x] **Naming Conventions** — PASS after C2 + C3 fixes. RPC name follows `api.check_*` precedent (`check_user_invitation_existence`, `check_field_definitions_exist`). Migration file follows `<TIMESTAMP>_<verb>_<noun>.sql` pattern.
+- [x] **Design Patterns** — PASS. Gateway/Boundary pattern at the Edge Function tier; defense-in-depth (two-tier check); event-sourced cleanup via existing handler reuse. No over-engineering.
+- [N/A] **data-testid Attributes** — N/A. No UI changes (only EF + SQL). Followup card for invite-user UI may add a `data-testid` on the rejection-message banner if it introduces a new element; that's out of scope.
+- [ ] **AsyncAPI Event Registration** — PASS-WITH-VERIFY. No NEW event types are introduced. `user.role.revoked` (cleanup emit) already exists in AsyncAPI; verify by checking `infrastructure/supabase/supabase/asyncapi.yaml`. The eligibility RPC is a function, not an event — not in scope for AsyncAPI.
+- [x] **Type Generation — No Anonymous Types** — PASS. The new RPC's response shape (`{eligible, error?, message?, details?}`) flows through `database.types.ts` regeneration. Frontend callers (if any in v1; currently only Edge Functions call it) must use the generated type, not inline `{eligible: boolean}` shorthand. **Action**: after running `gen types`, verify the generated type name lands in `ReadRpcs` and is consumable without per-call shape assertion.
+- [x] **Observability, Tracing & Monitoring** — PASS. EF gate calls go through `supabase.rpc(...)` which propagates correlation_id via the pre-request hook. Eligibility decision MUST be logged at INFO level on both branches with `correlationId`, `inviteeUserId`, `targetOrgId`, `decision` (eligible|blocked|error). On block, also log `existingOrgId` for audit. **Action**: confirm `console.log` calls present in both EFs in the task list.
+- [x] **Error Surfacing to UI** — PASS. invite-user returns 422 with the RPC's `message` text; the existing invite-user UI surfaces 4xx error bodies (verify in `UsersManagePage.tsx` invite flow). accept-invitation returns 403 with `correlationId`; the AuthCallback / acceptance UI must surface it (verify the existing 403-handling path).

--- a/dev/active/reject-cross-provider-invitations/tasks.md
+++ b/dev/active/reject-cross-provider-invitations/tasks.md
@@ -1,0 +1,165 @@
+# Tasks — reject-cross-provider-invitations
+
+**Architect-reviewed 2026-05-13.** See `plan.md` § ARCHITECT VERDICT for the must-fix list (C1–C5) and optional improvements. Tasks below incorporate the fixes inline.
+
+## Migration
+
+- [ ] `supabase migration new reject_cross_provider_invitations`
+- [ ] Write `api.check_invitation_acceptance_eligibility(uuid, uuid) RETURNS jsonb`:
+  - [ ] **STABLE** function marker (it's a pure read)
+  - [ ] **NO `auth.uid() IS NULL` guard** (ARCHITECT NOTE C1) — rely on GRANT for authn
+  - [ ] Filter: `urp.organization_id IS NOT NULL` (ARCHITECT NOTE C4a) to skip super_admin global rows
+  - [ ] Filter: `role_valid_from IS NULL OR <= CURRENT_DATE` (C4b)
+  - [ ] Filter: `op.is_active = true` on existing-role org (C4c)
+  - [ ] `@a4c-rpc-shape: read` comment
+- [ ] `GRANT EXECUTE ... TO authenticated` AND `TO service_role` (C1) — service_role is REQUIRED for accept-invitation's admin client
+- [ ] Inline pre-deploy audit DO block: NOTICE-only enumeration of pending invitations that the new gate would now reject (see plan.md "Risks" → "in-flight token risk" + suggested SQL)
+- [ ] Inline diagnostic NOTICE-only audit for other multi-provider users (cumulative analog for any unfound dakaratekids)
+- [ ] Inline dakaratekid cleanup `DO` block:
+  - [ ] Docblock above stating idempotency invariant (depends on `handle_user_role_revoked` row-delete semantics — ARCHITECT NOTE C5)
+  - [ ] `metadata.automated: true` flag added
+  - [ ] Named-arg `api.emit_domain_event` call (signature `(p_stream_id, p_stream_type, p_event_type, p_event_data, p_event_metadata)`)
+- [ ] `supabase db push --linked --dry-run` clean
+- [ ] `supabase db lint --level error` passes
+- [ ] Apply to dev: `supabase db push --linked`
+- [ ] Verify dakaratekid post-cleanup state via Management API SQL (per `memory/management-api-sql-endpoint.md`):
+  - [ ] `user_roles_projection` has only liveforlife row
+  - [ ] `users.roles[]` no longer contains 'Cypress Admin'
+  - [ ] `accessible_organizations` unchanged (still `[liveforlife]`)
+  - [ ] `domain_events` shows `user.role.revoked` event with cleanup reason
+- [ ] Run pre-deploy audit NOTICE output: capture any in-flight pending invitations that the new gate WOULD reject. If non-zero, decide per-case (revoke / let-403-land) BEFORE deploying gate to production.
+
+## Handler reference
+
+- [ ] Create `infrastructure/supabase/handlers/api/check_invitation_acceptance_eligibility.sql` matching migration body
+
+## Type regeneration
+
+- [ ] `supabase gen types typescript --linked > frontend/src/types/database.types.ts`
+- [ ] `supabase gen types typescript --linked > workflows/src/types/database.types.ts`
+- [ ] `cd frontend && npm run gen:rpc-registry` (registry adds `check_invitation_acceptance_eligibility` to ReadRpcs)
+- [ ] `cd frontend && npm run typecheck` passes
+- [ ] `cd workflows && npm run typecheck` passes
+
+## Edge Function: accept-invitation
+
+- [ ] Add eligibility check in Sally path (after `checkExistingUserPath` confirms userExists, before role-event emission — around `index.ts:580-660`)
+- [ ] Call via the EF's service-role admin client (no auth.uid() → service_role GRANT path; see ARCHITECT NOTE C1)
+- [ ] Log decision at INFO with `correlationId`, `inviteeUserId`, `targetOrgId`, `decision`; on block also log `existingOrgId` (from `details.existing_provider_org_id`)
+- [ ] On `eligible=false`: return 403 with the RPC's error code + message + correlation_id (use existing `createInternalError`/`handleRpcError` helpers)
+- [ ] On `eligible=true`: continue existing Sally flow unchanged
+- [ ] Bump `DEPLOY_VERSION` constant
+- [ ] Update top-of-file comment header with eligibility-gate note + document the TOCTOU window (race between check and emit; benign for v1)
+
+## Edge Function: invite-user (invite-creation, defense-in-depth)
+
+**ARCHITECT NOTE C2 2026-05-13**: this section originally targeted `manage-user`, which is the WRONG file. `user.invited` is emitted only at `invite-user/index.ts:836`. Tasks below corrected.
+
+- [ ] Open `infrastructure/supabase/supabase/functions/invite-user/index.ts`
+- [ ] Insert lookup BEFORE the `// CREATE INVITATION` block (around line 786, after the existing 409 duplicate-active-invite check)
+- [ ] Email→user lookup (ARCHITECT NOTE on safety):
+  - [ ] `SELECT id FROM public.users WHERE LOWER(email) = LOWER($1) AND deleted_at IS NULL ORDER BY created_at LIMIT 1`
+  - [ ] Use a SQL RPC wrapper (e.g., `api.find_user_id_by_email(p_email text)`) OR an existing `api.*` helper if one exists — DO NOT add a wire-tier `.from('users')` call (Rule 19 violation)
+  - [ ] **Check before adding new RPC**: grep for existing email-lookup RPCs first; reuse if available
+- [ ] If user found: call `api.check_invitation_acceptance_eligibility(p_invitee_user_id, p_target_org_id := orgId)` via `apiRpc<{ eligible: boolean; error?: string; message?: string }>` (read-shape helper)
+- [ ] On `eligible=false`: return 422 with `{ error: rpcResult.error, message: rpcResult.message, correlationId }`; do NOT create invitation token; do NOT emit `user.invited`
+- [ ] On user-not-found (greenfield invitee): skip eligibility, continue to existing flow
+- [ ] Bump `DEPLOY_VERSION` constant
+- [ ] Add docblock at top of file documenting the gate + cross-reference to `accept-invitation/index.ts` belt-and-suspenders gate
+
+## Tests
+
+### Deno tests — accept-invitation
+
+- [ ] `eligibility-gate.test.ts`:
+  - [ ] eligible=true → existing Sally path continues (mock asserts `user.role.assigned` emission)
+  - [ ] eligible=false (cross_provider_invitation_blocked) → 403, no role events emitted
+  - [ ] eligible=false (target_org_not_found) → 403, no role events emitted
+  - [ ] RPC error (eligError) → handleRpcError envelope, no role events emitted
+  - [ ] **`provider_partner` → provider invitee → eligible=true** (ARCHITECT NOTE — use the LIVE enum value `provider_partner`, not the legacy `partner` shown in the doc; guards the future grant pipeline)
+  - [ ] **NEW (ARCHITECT NOTE)**: Global super_admin invitee (existing role row with `organization_id IS NULL`) → eligible=true (super_admin should not be gated by this check)
+  - [ ] **NEW (ARCHITECT NOTE)**: Future-dated role (`role_valid_from > today`) at another provider → eligible=true (not yet active, so not blocking)
+  - [ ] **NEW (ARCHITECT NOTE)**: Expired role (`role_valid_until < today`) at another provider → eligible=true
+  - [ ] **NEW (ARCHITECT NOTE)**: Deactivated existing provider org → eligible=true (the stale role doesn't block fresh invite)
+
+### Deno tests — invite-user (NOT manage-user; see ARCHITECT NOTE C2)
+
+- [ ] `invite-eligibility.test.ts`:
+  - [ ] eligible=true → invitation created, `user.invited` emitted
+  - [ ] eligible=false → 422, no invitation token, no `user.invited` event
+  - [ ] No existing user (greenfield invitee, email doesn't match any users row) → no eligibility call, invitation created normally
+  - [ ] **NEW (ARCHITECT NOTE)**: Email lookup is case-insensitive (`User@Example.com` matches `user@example.com` projection row)
+  - [ ] **NEW (ARCHITECT NOTE)**: Soft-deleted user with matching email is treated as greenfield (deleted_at IS NOT NULL → skip eligibility)
+
+### SQL-level test (RPC unit test) — RECOMMENDED
+
+**ARCHITECT NOTE 2026-05-13**: Deno tests cover the EF integration but not the RPC's own logic in isolation. Add a SQL-level test against the dev DB using the Management API SQL endpoint + the `set_config('request.jwt.claims', ...)` pattern from `memory/simulate-jwt-claims-for-rpc-test.md`. Covers branches without needing an EF deployment:
+
+- [ ] **OPTIONAL but recommended**: Create `infrastructure/supabase/tests/rpc/check_invitation_acceptance_eligibility.test.sql` or document the test queries in the migration's NOTICE audit. Branches to assert:
+  - [ ] target_org_not_found
+  - [ ] eligible=true when invitee has no other roles
+  - [ ] eligible=true when invitee's other role is in `provider_partner` org
+  - [ ] eligible=false when invitee has active role in another `provider` org AND target is `provider`
+  - [ ] eligible=true when invitee's other role is `role_valid_until < today` (expired)
+  - [ ] eligible=true when invitee's other role is at an `is_active = false` org
+
+### CI
+
+- [ ] `supabase-edge-functions-test.yml` runs both new test files
+- [ ] `supabase-edge-functions-lint.yml` passes
+- [ ] `rpc-registry-sync.yml` passes (registry includes new ReadRpc entry)
+
+## Pre-deploy smoke (against dev, per 2026-05-12 pre-deploy ritual)
+
+- [ ] Apply migration to dev
+- [ ] Capture the pre-deploy audit NOTICE output (in-flight pending invitations the new gate would now reject) — paste into card
+- [ ] Deploy `accept-invitation` to dev
+- [ ] Deploy `invite-user` to dev (NOT manage-user — ARCHITECT NOTE C2)
+- [ ] Smoke 1: cross-provider invite-create (e.g., new test user already in liveforlife + invite to testorg) → expect 422 with `cross_provider_invitation_blocked`
+- [ ] Smoke 2: same-org re-invite (user re-invited to liveforlife) → expect 200, normal flow
+- [ ] Smoke 3: NEW user (no existing roles) invited to testorg → expect 200, new user.created + user.role.assigned (Sally check returns isExistingUser=false; eligibility not called)
+- [ ] Smoke 4: Management API SQL confirms dakaratekid restored (per `memory/management-api-sql-endpoint.md`)
+- [ ] **NEW**: Smoke 5 — accept-invitation Sally path with cross-provider scenario → expect 403 with `cross_provider_invitation_blocked`, no `user.role.assigned` emitted (verify in `domain_events` via Management API)
+- [ ] **NEW**: Smoke 6 — provider_partner-type user invited to provider org → expect 200 (guards future grant pipeline; matches Deno test case)
+- [ ] Paste log artifacts (Edge Function logs + DB query results) into card before opening PR
+
+## UAT (post-deploy, post-PR-merge)
+
+- [ ] Run Sally-style invitation acceptance with cleanly-reset state
+- [ ] Verify rejection at invite-create UI shows the 422 message clearly
+- [ ] Verify dakaratekid is restored to single-org liveforlife state
+- [ ] Verify routing for dakaratekid → liveforlife.firstovertheline.com (note: if routing symptom persists, it's the separate follow-up card)
+
+## Docs
+
+- [ ] Update `documentation/architecture/data/provider-partners-architecture.md` (**ARCHITECT NOTE C3 — expanded scope**):
+  - [ ] Fix authorization_type naming: `family_consent` → `family_participation`, `agency_assignment` → `social_services_assignment` (DB enum at `baseline_v4.sql:12516` is the source of truth)
+  - [ ] Fix `type='partner'` → `type='provider_partner'` throughout (live CHECK at `baseline_v4.sql:13111` is `('platform_owner', 'provider', 'provider_partner')`; legacy `'partner'` is wrong)
+  - [ ] Update Org Structure ASCII diagram (lines ~199-243) to use `provider_partner`
+  - [ ] Add "Boundary Repair" callout citing this card + cross-referencing the EF docblocks
+  - [ ] Bump frontmatter `last_updated` to today
+- [ ] **ARCHITECT NOTE (optional improvement)** — prefer EF-docblock as canonical home for boundary-repair rule:
+  - [ ] Add full docblock at top of `accept-invitation/index.ts` (eligibility gate, TOCTOU window, return contract)
+  - [ ] Add full docblock at top of `invite-user/index.ts` (defense-in-depth gate, email-lookup safety, response contract)
+  - [ ] Add a SHORT cross-reference in `infrastructure/supabase/CLAUDE.md` § Critical Rules (one bullet pointing to the two EF docblocks); do NOT duplicate full content there
+
+## Memory
+
+- [ ] Update `MEMORY.md` index entry: close `fix-handle-user-role-assigned-update-accessible-organizations-seed.md`, link to this card
+- [ ] New memory file `cross-provider-invitation-rejected.md`: the gate location, the eligibility RPC's return contract, dakaratekid cleanup, what's STILL not enforced (RLS on provider data, grant producer pipeline)
+
+## Follow-up cards (seed, don't work)
+
+- [ ] Seed `dev/active/investigate-auth-callback-priority-2-fallthrough.md`:
+  - Why did dakaratekid land on `a4c.firstovertheline.com/clients` when her JWT carries `org_id=liveforlife` and liveforlife's subdomain is verified?
+  - Hypothesis: `getOrganizationSubdomainInfo(liveforlife)` failed for her (RPC denial / RLS / thrown exception) → AuthCallback fell through to Priority 3.
+  - Suggested investigation: read `frontend/src/services/organization/getOrganizationSubdomainInfo.ts`, trace the underlying RPC, check RLS on `organizations_projection` for `provider_admin` callers viewing their own org.
+
+## PR
+
+- [ ] Branch name: `feat/reject-cross-provider-invitations` (or similar)
+- [ ] PR body uses standard template; links to provider-partners-architecture.md and this card
+- [ ] PR-D-style observability backfill not needed (no service-layer changes)
+- [ ] Architect review: APPROVE WITH IN-PR FIXES is the expected verdict shape per recent norms
+- [ ] **NEW (ARCHITECT NOTE)**: PR body must include a "Pre-deploy audit" subsection capturing the NOTICE output of in-flight pending invitations — empty list is the expected result if the gate is shipping ahead of legitimate cross-provider invites
+- [ ] **NEW (ARCHITECT NOTE)**: PR body must explicitly note the live enum constraint `('platform_owner', 'provider', 'provider_partner')` and link to the doc-naming fix; reviewers should not be confused by `provider-partners-architecture.md`'s outdated `type='partner'` references

--- a/dev/parked/eligibility-rpc-pgtap-coverage/plan.md
+++ b/dev/parked/eligibility-rpc-pgtap-coverage/plan.md
@@ -1,0 +1,62 @@
+# SQL-level regression coverage for `api.check_invitation_acceptance_eligibility`
+
+**Status**: parked (not yet triggered)
+**Priority**: Low (defensive — current behavior is correct; this card hardens regression coverage)
+**Origin**: PR #64 architect review finding #4 (2026-05-13)
+**Predecessor**: `dev/active/reject-cross-provider-invitations/` (PR #64; will be archived after merge)
+
+## Trigger conditions
+
+Activate this card when ANY of the following becomes true:
+
+1. A similar SQL-only filter branch is added to any `api.*` RPC that the wiring-tier helper tests cannot exercise.
+2. pg_tap (or any SQL test harness) is added to the project for an unrelated reason.
+3. A bug is discovered in one of the C4a/b/c filter branches (super_admin / future-dated / expired / deactivated-org) that the wiring-tier tests at `infrastructure/supabase/supabase/functions/_shared/__tests__/check-invitation-eligibility.test.ts` did not catch.
+
+If none of the above happens, this card stays parked indefinitely. The wiring-tier coverage shipped in PR #64 is adequate given the SQL branches are tightly-bounded WHERE clauses validated manually via Management API SQL smoke at deploy time.
+
+## Purpose
+
+Add SQL-level regression tests for the C4a/b/c filter branches in `api.check_invitation_acceptance_eligibility`:
+
+- **C4a**: `urp.organization_id IS NOT NULL` — global super_admin rows excluded
+- **C4b**: `role_valid_from IS NULL OR role_valid_from <= CURRENT_DATE` — future-dated roles excluded
+- **C4b**: `role_valid_until IS NULL OR role_valid_until >= CURRENT_DATE` — expired roles excluded
+- **C4c**: `op.is_active = true` — stale roles at deactivated orgs excluded
+
+Each branch produces `eligible=true` from a different cause; PR #64's wiring tests pin EF behavior (`eligible=true` → `{ok:true}`) but do not assert that the SQL filter is actually doing the exclusion.
+
+## Open questions for activation
+
+1. **Test harness choice**: pg_tap vs. plpgunit vs. a node-pg integration harness vs. seed-data-driven test SQL run via Management API. Decide at activation time based on what the project's other testing infrastructure looks like at the time.
+2. **Seed-data shape**: synthetic users + role assignments per branch, or use real-but-tagged fixtures? Likely the former (cleaner teardown).
+3. **CI integration**: where do these tests run? Likely a new GitHub Actions workflow that spins up a Supabase container and applies all migrations before running the test suite. Reuse the existing `rpc-registry-sync.yml` container if possible.
+
+## Suggested test scenarios
+
+For each C4a/b/c branch, seed data such that the eligibility check sees the relevant row state, then assert the RPC returns `{eligible: true}` (because the filter excluded the row from consideration):
+
+1. **C4a — super_admin**: invitee has `user_roles_projection` row with `organization_id IS NULL`. Assert eligible=true.
+2. **C4b — future-dated**: invitee has role with `role_valid_from = CURRENT_DATE + 1`. Assert eligible=true.
+3. **C4b — expired**: invitee has role with `role_valid_until = CURRENT_DATE - 1`. Assert eligible=true.
+4. **C4c — deactivated org**: invitee has role at an org with `is_active = false`. Assert eligible=true.
+5. **Negative**: invitee has an ACTIVE role at a DIFFERENT type='provider' org. Assert eligible=false with `error='cross_provider_invitation_blocked'`.
+
+Plus the existing branches already covered by wiring tests:
+6. **target_not_found**: target_org_id doesn't exist.
+7. **eligible (greenfield)**: invitee has no `user_roles_projection` rows.
+
+## Files involved (at activation)
+
+- `infrastructure/supabase/supabase/migrations/20260513213831_pr64_closeout.sql` — the RPC body being tested
+- New SQL test file (location TBD: `infrastructure/supabase/tests/rpc/`? `infrastructure/supabase/supabase/tests/`?)
+- New CI workflow (or extension of `rpc-registry-sync.yml`)
+
+## Out of scope for this card
+
+- Re-architecting how SQL tests run more broadly. This card is narrowly about `check_invitation_acceptance_eligibility`. If the activation triggers a broader investment in SQL test infrastructure, that's a separate card.
+
+## Related cards / PRs
+
+- `dev/active/reject-cross-provider-invitations/` — predecessor; will be archived after PR #64 merge
+- PR #64 (`feat/reject-cross-provider-invitations`) — closeout finding #4 seeded this card

--- a/dev/parked/eligibility-rpc-pgtap-coverage/tasks.md
+++ b/dev/parked/eligibility-rpc-pgtap-coverage/tasks.md
@@ -1,0 +1,29 @@
+# Tasks — eligibility-rpc-pgtap-coverage (parked)
+
+**Activate this card when a trigger condition fires.** See `plan.md` § Trigger conditions.
+
+## Activation checklist
+
+- [ ] Confirm the activation trigger (one of the three documented conditions) actually fired
+- [ ] Move card from `dev/parked/` to `dev/active/`
+- [ ] Decide test harness (pg_tap / plpgunit / node-pg / Management API SQL) — see plan.md § Open questions
+- [ ] Decide seed-data shape
+
+## Implementation (once activated)
+
+- [ ] Set up the chosen test harness (likely a new GitHub Actions workflow + a Supabase container spin-up step)
+- [ ] Write the 7 test scenarios listed in plan.md § Suggested test scenarios:
+  - [ ] C4a super_admin → eligible=true
+  - [ ] C4b future-dated → eligible=true
+  - [ ] C4b expired → eligible=true
+  - [ ] C4c deactivated org → eligible=true
+  - [ ] Negative: active provider role → cross_provider_invitation_blocked
+  - [ ] target_not_found
+  - [ ] greenfield eligible
+- [ ] Verify all pass against current dev DB
+- [ ] CI integration: tests run on every PR that touches `api.check_invitation_acceptance_eligibility` or `api.check_user_exists`
+- [ ] Tighten wiring-test docblock in `_shared/__tests__/check-invitation-eligibility.test.ts` to reference the new SQL-level coverage
+
+## Out of scope
+
+- Broader investment in SQL test infrastructure (separate card if needed)

--- a/documentation/architecture/data/provider-partners-architecture.md
+++ b/documentation/architecture/data/provider-partners-architecture.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last_updated: 2026-05-06
+last_updated: 2026-05-13
 ---
 
 <!-- TL;DR-START -->
@@ -40,6 +40,20 @@ last_updated: 2026-05-06
 **Version**: 2.2 (Updated for foundation implementation)
 **Last Updated**: 2025-12-02
 **Authentication**: Supabase Auth
+
+> [!IMPORTANT]
+> **Boundary Repair (2026-05-13)** — `accept-invitation` and `invite-user` Edge
+> Functions now reject direct cross-provider invitations at the boundary via
+> `api.check_invitation_acceptance_eligibility`. Provider→provider native
+> multi-tenant role assignment was previously silently allowed by the Sally
+> path; that drift is now closed. Partner→provider invitations are NOT yet
+> wired (grant producer pipeline is still un-implemented, see "NOT
+> Implemented" list above). Canonical statement of the gate lives in the
+> top-of-file docblocks of:
+> - `infrastructure/supabase/supabase/functions/accept-invitation/index.ts`
+> - `infrastructure/supabase/supabase/functions/invite-user/index.ts`
+>
+> Card: `dev/active/reject-cross-provider-invitations/`.
 
 ## Executive Summary
 
@@ -207,25 +221,25 @@ organizations_projection (PostgreSQL)
 │   └── Can manage all provider partner relationships
 │
 ├── VAR Partner ABC (Provider Partner Org) - Root level
-│   ├── type: 'partner'
+│   ├── type: 'provider_partner'
 │   ├── partner_type: 'var'
 │   ├── Roles: Partner Administrator, VAR Consultant
 │   └── Access: Via cross_tenant_access_grants (future)
 │
 ├── Juvenile Court XYZ (Provider Partner Org) - Root level
-│   ├── type: 'partner'
+│   ├── type: 'provider_partner'
 │   ├── partner_type: 'court'
 │   ├── Roles: Court Administrator, Guardian ad Litem
 │   └── Access: Court order-based grants (future)
 │
 ├── County CPS (Provider Partner Org) - Root level
-│   ├── type: 'partner'
+│   ├── type: 'provider_partner'
 │   ├── partner_type: 'other' (social services)
 │   ├── Roles: Agency Administrator, Case Worker
 │   └── Access: Assignment-based grants (future)
 │
 ├── Johnson Family Org (Provider Partner Org) - Root level
-│   ├── type: 'partner'
+│   ├── type: 'provider_partner'
 │   ├── partner_type: 'family'
 │   ├── Roles: Parent/Guardian
 │   └── Access: Consent-based grants (future)
@@ -281,7 +295,7 @@ family_consents_projection:          -- Family member consents
 cross_tenant_access_grants_projection:
   consultant_org_id: [partner_org_id]
   provider_org_id: org_provider_a
-  authorization_type: 'var_contract' | 'court_order' | 'agency_assignment' | 'family_consent'
+  authorization_type: 'var_contract' | 'court_order' | 'social_services_assignment' | 'family_participation'
   authorization_reference: [relationship_record_id]
   status: 'active'
 ```
@@ -307,7 +321,7 @@ interface AccessGrantCreatedEvent {
     consultant_user_id: string;     // Partner user
     consultant_org_id: string;      // Partner organization
     provider_org_id: string;        // Target provider
-    authorization_type: 'var_contract' | 'court_order' | 'agency_assignment' | 'family_consent';
+    authorization_type: 'var_contract' | 'court_order' | 'social_services_assignment' | 'family_participation';
     authorization_reference: string; // Relationship record ID
     scope: {
       data_types: string[];          // Type-specific data access
@@ -368,7 +382,7 @@ interface AccessGrantCreatedEvent {
 **Agency Assignment Authorization**:
 ```typescript
 {
-  authorization_type: 'agency_assignment',
+  authorization_type: 'social_services_assignment',
   authorization_reference: 'assignment_uuid',
   scope: {
     data_types: ['case_notes', 'service_plans', 'progress_reports'],
@@ -383,7 +397,7 @@ interface AccessGrantCreatedEvent {
 **Family Consent Authorization**:
 ```typescript
 {
-  authorization_type: 'family_consent',
+  authorization_type: 'family_participation',
   authorization_reference: 'consent_uuid',
   scope: {
     data_types: ['basic_health_status', 'appointment_schedules'],
@@ -431,14 +445,14 @@ USING (
         ))
         OR
         -- Agency: Check active assignment
-        (ctag.authorization_type = 'agency_assignment' AND EXISTS (
+        (ctag.authorization_type = 'social_services_assignment' AND EXISTS (
           SELECT 1 FROM agency_assignments_projection aa
           WHERE aa.id = ctag.authorization_reference::uuid
             AND aa.status = 'active'
         ))
         OR
         -- Family: Check valid consent
-        (ctag.authorization_type = 'family_consent' AND EXISTS (
+        (ctag.authorization_type = 'family_participation' AND EXISTS (
           SELECT 1 FROM family_consents_projection fc
           WHERE fc.id = ctag.authorization_reference::uuid
             AND fc.status = 'active'
@@ -579,7 +593,7 @@ CREATE TABLE cross_tenant_access_grants_projection (
   consultant_org_id UUID NOT NULL,
   provider_org_id UUID NOT NULL,
   authorization_type TEXT NOT NULL CHECK (authorization_type IN (
-    'var_contract', 'court_order', 'agency_assignment', 'family_consent'
+    'var_contract', 'court_order', 'social_services_assignment', 'family_participation'
   )),
   authorization_reference UUID,  -- References type-specific relationship record
   scope JSONB NOT NULL,
@@ -643,7 +657,7 @@ Enhanced metadata captures provider partner context:
       partnerOrgId: 'partner_org_uuid',
       partnerType: 'var' | 'court' | 'agency' | 'family',
       grantId: 'grant_uuid',
-      authorizationType: 'var_contract' | 'court_order' | 'agency_assignment' | 'family_consent',
+      authorizationType: 'var_contract' | 'court_order' | 'social_services_assignment' | 'family_participation',
       authorizationReference: 'relationship_uuid',
       legalBasis: 'Court Order #2024-JV-1234' | 'CPS Assignment' | 'Parental Consent',
       dataScope: ['basic_info', 'treatment_notes'],
@@ -674,13 +688,17 @@ Enhanced metadata captures provider partner context:
 
 **Database Schema (Implemented)**:
 ```sql
--- organizations_projection supports partner organizations
-CREATE TYPE organization_type AS ENUM ('provider', 'partner');
+-- organizations_projection supports partner organizations. NOTE: the live
+-- schema does NOT use a dedicated ENUM type — the column is `text` constrained
+-- by CHECK (`baseline_v4.sql:13111`):
+--   CHECK (type = ANY (ARRAY['platform_owner'::text, 'provider'::text, 'provider_partner'::text]))
+-- The legacy `'partner'` value documented in earlier drafts is incorrect.
 CREATE TYPE partner_type AS ENUM ('var', 'family', 'court', 'other');
 
 -- organizations_projection includes:
---   type: organization_type (provider or partner)
---   partner_type: partner_type (for partner orgs only)
+--   type: text CHECK (type IN ('platform_owner', 'provider', 'provider_partner'))
+--   partner_type: partner_type (REQUIRED for type='provider_partner' rows,
+--                  enforced by CHECK chk_partner_type_required)
 --   referring_partner_id: UUID (optional, who referred this org)
 ```
 

--- a/documentation/architecture/data/provider-partners-architecture.md
+++ b/documentation/architecture/data/provider-partners-architecture.md
@@ -37,8 +37,8 @@ last_updated: 2026-05-13
 > - ❌ Type-specific relationship projections (VAR contracts, court authorizations, etc.)
 
 **Status**: ✅ Foundation Implemented | ⏳ Type-Specific Features Planned
-**Version**: 2.2 (Updated for foundation implementation)
-**Last Updated**: 2025-12-02
+**Version**: 2.3 (Boundary repair: cross-provider invitation gate)
+**Last Updated**: 2026-05-13
 **Authentication**: Supabase Auth
 
 > [!IMPORTANT]
@@ -814,7 +814,7 @@ CREATE TYPE partner_type AS ENUM ('var', 'family', 'court', 'other');
 
 ---
 
-**Document Version:** 2.2
-**Last Updated:** 2025-12-02
+**Document Version:** 2.3
+**Last Updated:** 2026-05-13
 **Status:** Foundation Implemented | Type-Specific Features Planned
 **Owner:** A4C Architecture Team

--- a/frontend/src/services/api/rpc-registry.generated.ts
+++ b/frontend/src/services/api/rpc-registry.generated.ts
@@ -105,6 +105,7 @@ export type EnvelopeRpcs =
 export type ReadRpcs =
   | 'bulk_assign_role'
   | 'check_field_definitions_exist'
+  | 'check_invitation_acceptance_eligibility'
   | 'check_organization_by_name'
   | 'check_organization_by_slug'
   | 'check_pending_invitation'

--- a/frontend/src/types/database.types.ts
+++ b/frontend/src/types/database.types.ts
@@ -179,6 +179,10 @@ export type Database = {
         Args: { p_org_id: string }
         Returns: boolean
       }
+      check_invitation_acceptance_eligibility: {
+        Args: { p_invitee_user_id: string; p_target_org_id: string }
+        Returns: Json
+      }
       check_organization_by_name: {
         Args: { p_name: string }
         Returns: {
@@ -1609,31 +1613,6 @@ export type Database = {
       }
       validate_role_assignment: {
         Args: { p_role_ids: string[] }
-        Returns: Json
-      }
-    }
-    Enums: {
-      [_ in never]: never
-    }
-    CompositeTypes: {
-      [_ in never]: never
-    }
-  }
-  graphql_public: {
-    Tables: {
-      [_ in never]: never
-    }
-    Views: {
-      [_ in never]: never
-    }
-    Functions: {
-      graphql: {
-        Args: {
-          extensions?: Json
-          operationName?: string
-          query?: string
-          variables?: Json
-        }
         Returns: Json
       }
     }
@@ -5908,9 +5887,6 @@ export type CompositeTypes<
 
 export const Constants = {
   api: {
-    Enums: {},
-  },
-  graphql_public: {
     Enums: {},
   },
   public: {

--- a/infrastructure/supabase/CLAUDE.md
+++ b/infrastructure/supabase/CLAUDE.md
@@ -382,6 +382,17 @@ handlers/
 > `documentation/architecture/decisions/adr-rpc-readback-pattern.md`;
 > `documentation/architecture/decisions/adr-edge-function-vs-sql-rpc.md`.
 
+> **⚠️ Cross-provider invitations are rejected at the Edge Function boundary**
+>
+> `accept-invitation` and `invite-user` call `api.check_invitation_acceptance_eligibility`
+> to reject direct provider→provider invitations (the invitee is already a
+> member of a different `type='provider'` org). Per
+> `documentation/architecture/data/provider-partners-architecture.md`,
+> cross-tenant access between providers requires a grant via a
+> `type='provider_partner'` org, not native multi-tenant role assignment.
+> Canonical statement of the rule lives in the EF docblocks; the RPC is
+> sourced at `infrastructure/supabase/supabase/migrations/20260513203931_reject_cross_provider_invitations.sql`.
+
 ## CQRS Query Rule
 
 > **⚠️ CRITICAL: All frontend queries MUST use `api.` schema RPC functions.**

--- a/infrastructure/supabase/supabase/functions/_shared/__tests__/check-invitation-eligibility.test.ts
+++ b/infrastructure/supabase/supabase/functions/_shared/__tests__/check-invitation-eligibility.test.ts
@@ -13,9 +13,11 @@
  *     caller-specified status: 403 for acceptance-time, 422 for pre-issuance).
  *   - Returns `{ response }` on RPC-level error (delegated to handleRpcError).
  *   - Architect cases C4a/b/c: super_admin, future-dated, expired, deactivated-
- *     org — these are RPC-side logic and are exercised in the RPC's SQL-level
- *     tests (live DB via Management API). At the helper layer, we test the
- *     transport / wiring contract only.
+ *     org — RPC-side filter logic. Wiring-tier coverage for these branches
+ *     is appended below (RPC returns eligible=true → helper returns ok:true,
+ *     regardless of which SQL filter produced the result). True SQL-level
+ *     regression coverage is parked at `dev/parked/eligibility-rpc-pgtap-coverage/`
+ *     pending a pg_tap (or equivalent) test harness in the project.
  */
 
 import { assertEquals } from 'https://deno.land/std@0.220.1/assert/mod.ts';
@@ -81,16 +83,16 @@ Deno.test('eligible=true → ok:true; RPC called with documented arg shape', asy
 });
 
 Deno.test('eligible=false (cross_provider) → 403 response with RPC error code/message', async () => {
+  // PR #64 closeout (Finding #1): RPC no longer returns a `details` object on
+  // cross_provider_invitation_blocked. Operator correlation continues via the
+  // server-side log line (warn path) in the helper, which carries the full
+  // RPC response including any details that may appear on other branches.
   const client = makeMockClient({
     fixture: {
       data: {
         eligible: false,
         error: 'cross_provider_invitation_blocked',
         message: 'This user is already a member of another provider organization.',
-        details: {
-          existing_provider_org_id: '00000000-0000-0000-0000-000000000333',
-          target_provider_org_id: TARGET,
-        },
       },
     },
   });
@@ -111,11 +113,9 @@ Deno.test('eligible=false (cross_provider) → 403 response with RPC error code/
   assertEquals(body.error, 'This user is already a member of another provider organization.');
   assertEquals(body.code, 'cross_provider_invitation_blocked');
   assertEquals(body.correlation_id, 'c-2');
-  // details should be surfaced via context
-  assertEquals(
-    (body.context as { existing_provider_org_id: string }).existing_provider_org_id,
-    '00000000-0000-0000-0000-000000000333',
-  );
+  // PR #64 closeout (Finding #1): body.context is no longer populated on this
+  // branch — verifying the disclosure-surface removal.
+  assertEquals(body.context, undefined);
 });
 
 Deno.test('eligible=false (cross_provider) with blockedStatus=422 → 422 response (pre-issuance gate)', async () => {
@@ -210,4 +210,57 @@ Deno.test('malformed RPC response (missing eligible field) treated as blocked (f
 
   if (!('response' in result)) throw new Error('expected fail-closed response');
   assertEquals(result.response.status, 403);
+});
+
+// =============================================================================
+// PR #64 closeout — wiring-tier coverage for RPC-side filter branches
+// =============================================================================
+// These tests pin down EF behavior given each documented RPC return shape.
+// They do NOT exercise the SQL itself — that's tracked at
+// `dev/parked/eligibility-rpc-pgtap-coverage/` (follow-up card).
+//
+// Per the architect review (Finding #4), the RPC's C4a/b/c filter branches
+// are tightly-bounded WHERE clauses that all collapse to `eligible=true` at
+// the response shape. The helper must not second-guess that signal —
+// regardless of which SQL filter caused the role to be excluded, eligible=true
+// means proceed. These tests pin that invariant.
+// =============================================================================
+
+Deno.test('super_admin caller path: RPC returns eligible=true (C4a filter excluded global role) → ok:true', async () => {
+  // Scenario: invitee has a super_admin role with organization_id IS NULL.
+  // RPC's WHERE clause includes `urp.organization_id IS NOT NULL`, so the
+  // super_admin row is excluded from the cross-provider check. With no other
+  // type='provider' role, the RPC returns eligible=true. The helper MUST
+  // propagate that as ok:true without inspecting the cause.
+  const client = makeMockClient({ fixture: { data: { eligible: true } } });
+  const result = await checkInvitationEligibility({
+    client,
+    inviteeUserId: INVITEE,
+    targetOrgId: TARGET,
+    correlationId: 'c-super-admin',
+    corsHeaders: CORS,
+    blockedStatus: 403,
+    logTag: '[test-super-admin]',
+  });
+  assertEquals(result, { ok: true });
+});
+
+Deno.test('stale-role paths (C4b future-dated / C4b expired / C4c deactivated-org): RPC returns eligible=true → ok:true', async () => {
+  // Scenarios bundled — all collapse to the same RPC response shape:
+  //   C4b future-dated: role_valid_from > today → excluded
+  //   C4b expired:      role_valid_until < today → excluded
+  //   C4c deactivated:  op.is_active = false → excluded
+  // RPC returns eligible=true in all three. Helper must not infer blocked
+  // from the absence of an explicit error.
+  const client = makeMockClient({ fixture: { data: { eligible: true } } });
+  const result = await checkInvitationEligibility({
+    client,
+    inviteeUserId: INVITEE,
+    targetOrgId: TARGET,
+    correlationId: 'c-stale-role',
+    corsHeaders: CORS,
+    blockedStatus: 422,
+    logTag: '[test-stale-role]',
+  });
+  assertEquals(result, { ok: true });
 });

--- a/infrastructure/supabase/supabase/functions/_shared/__tests__/check-invitation-eligibility.test.ts
+++ b/infrastructure/supabase/supabase/functions/_shared/__tests__/check-invitation-eligibility.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Unit tests for the shared cross-provider invitation eligibility gate
+ * (`_shared/check-invitation-eligibility.ts`).
+ *
+ * Run with:
+ *   deno test --allow-import _shared/__tests__/check-invitation-eligibility.test.ts
+ *
+ * Test scope:
+ *   - Calls `api.check_invitation_acceptance_eligibility` with the documented
+ *     arg shape `{ p_invitee_user_id, p_target_org_id }`.
+ *   - Returns `{ ok: true }` on eligible=true.
+ *   - Returns `{ response }` on eligible=false (translated to the
+ *     caller-specified status: 403 for acceptance-time, 422 for pre-issuance).
+ *   - Returns `{ response }` on RPC-level error (delegated to handleRpcError).
+ *   - Architect cases C4a/b/c: super_admin, future-dated, expired, deactivated-
+ *     org — these are RPC-side logic and are exercised in the RPC's SQL-level
+ *     tests (live DB via Management API). At the helper layer, we test the
+ *     transport / wiring contract only.
+ */
+
+import { assertEquals } from 'https://deno.land/std@0.220.1/assert/mod.ts';
+
+import {
+  checkInvitationEligibility,
+  type EligibilityRpcResponse,
+} from '../check-invitation-eligibility.ts';
+
+// =============================================================================
+// Mock client + harness
+// =============================================================================
+
+interface CapturedRpcCall {
+  fnName: string;
+  args: Record<string, unknown>;
+}
+
+function makeMockClient(opts: {
+  fixture: { data?: EligibilityRpcResponse; error?: { message: string } | null };
+  onRpc?: (call: CapturedRpcCall) => void;
+}) {
+  return {
+    async rpc(fnName: string, args: Record<string, unknown>) {
+      opts.onRpc?.({ fnName, args });
+      return { data: opts.fixture.data ?? null, error: opts.fixture.error ?? null };
+    },
+  };
+}
+
+const INVITEE = '00000000-0000-0000-0000-000000000111';
+const TARGET = '00000000-0000-0000-0000-000000000222';
+const CORS = { 'Access-Control-Allow-Origin': '*' };
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+Deno.test('eligible=true → ok:true; RPC called with documented arg shape', async () => {
+  const calls: CapturedRpcCall[] = [];
+  const client = makeMockClient({
+    fixture: { data: { eligible: true } },
+    onRpc: (c) => calls.push(c),
+  });
+
+  const result = await checkInvitationEligibility({
+    client,
+    inviteeUserId: INVITEE,
+    targetOrgId: TARGET,
+    correlationId: 'c-1',
+    corsHeaders: CORS,
+    blockedStatus: 403,
+    logTag: '[test]',
+  });
+
+  assertEquals(result, { ok: true });
+  assertEquals(calls.length, 1);
+  assertEquals(calls[0].fnName, 'check_invitation_acceptance_eligibility');
+  assertEquals(calls[0].args, {
+    p_invitee_user_id: INVITEE,
+    p_target_org_id: TARGET,
+  });
+});
+
+Deno.test('eligible=false (cross_provider) → 403 response with RPC error code/message', async () => {
+  const client = makeMockClient({
+    fixture: {
+      data: {
+        eligible: false,
+        error: 'cross_provider_invitation_blocked',
+        message: 'This user is already a member of another provider organization.',
+        details: {
+          existing_provider_org_id: '00000000-0000-0000-0000-000000000333',
+          target_provider_org_id: TARGET,
+        },
+      },
+    },
+  });
+
+  const result = await checkInvitationEligibility({
+    client,
+    inviteeUserId: INVITEE,
+    targetOrgId: TARGET,
+    correlationId: 'c-2',
+    corsHeaders: CORS,
+    blockedStatus: 403,
+    logTag: '[test-accept]',
+  });
+
+  if (!('response' in result)) throw new Error('expected response');
+  assertEquals(result.response.status, 403);
+  const body = await result.response.json();
+  assertEquals(body.error, 'This user is already a member of another provider organization.');
+  assertEquals(body.code, 'cross_provider_invitation_blocked');
+  assertEquals(body.correlation_id, 'c-2');
+  // details should be surfaced via context
+  assertEquals(
+    (body.context as { existing_provider_org_id: string }).existing_provider_org_id,
+    '00000000-0000-0000-0000-000000000333',
+  );
+});
+
+Deno.test('eligible=false (cross_provider) with blockedStatus=422 → 422 response (pre-issuance gate)', async () => {
+  const client = makeMockClient({
+    fixture: {
+      data: {
+        eligible: false,
+        error: 'cross_provider_invitation_blocked',
+        message: 'Blocked.',
+      },
+    },
+  });
+
+  const result = await checkInvitationEligibility({
+    client,
+    inviteeUserId: INVITEE,
+    targetOrgId: TARGET,
+    correlationId: 'c-3',
+    corsHeaders: CORS,
+    blockedStatus: 422,
+    logTag: '[test-invite]',
+  });
+
+  if (!('response' in result)) throw new Error('expected response');
+  assertEquals(result.response.status, 422);
+});
+
+Deno.test('eligible=false (target_org_not_found) → response with RPC error code', async () => {
+  const client = makeMockClient({
+    fixture: {
+      data: {
+        eligible: false,
+        error: 'target_org_not_found',
+        message: 'Target organization does not exist.',
+      },
+    },
+  });
+
+  const result = await checkInvitationEligibility({
+    client,
+    inviteeUserId: INVITEE,
+    targetOrgId: TARGET,
+    correlationId: 'c-4',
+    corsHeaders: CORS,
+    blockedStatus: 403,
+    logTag: '[test]',
+  });
+
+  if (!('response' in result)) throw new Error('expected response');
+  assertEquals(result.response.status, 403);
+  const body = await result.response.json();
+  assertEquals(body.code, 'target_org_not_found');
+});
+
+Deno.test('RPC error → response from handleRpcError (no role events leak)', async () => {
+  const client = makeMockClient({
+    fixture: { error: { message: 'permission denied for function ...' } },
+  });
+
+  const result = await checkInvitationEligibility({
+    client,
+    inviteeUserId: INVITEE,
+    targetOrgId: TARGET,
+    correlationId: 'c-5',
+    corsHeaders: CORS,
+    blockedStatus: 403,
+    logTag: '[test]',
+  });
+
+  if (!('response' in result)) throw new Error('expected response on RPC error');
+  // handleRpcError uses 400 status for RPC errors (non-event-processing)
+  assertEquals(result.response.status, 400);
+});
+
+Deno.test('malformed RPC response (missing eligible field) treated as blocked (fail-closed)', async () => {
+  // Defense in depth: if the RPC ever returns an unexpected shape (schema
+  // drift, partial response), we MUST NOT default to allow. The helper
+  // coerces a missing `eligible` field to a block.
+  const client = makeMockClient({
+    fixture: { data: {} as EligibilityRpcResponse },
+  });
+
+  const result = await checkInvitationEligibility({
+    client,
+    inviteeUserId: INVITEE,
+    targetOrgId: TARGET,
+    correlationId: 'c-6',
+    corsHeaders: CORS,
+    blockedStatus: 403,
+    logTag: '[test]',
+  });
+
+  if (!('response' in result)) throw new Error('expected fail-closed response');
+  assertEquals(result.response.status, 403);
+});

--- a/infrastructure/supabase/supabase/functions/_shared/check-invitation-eligibility.ts
+++ b/infrastructure/supabase/supabase/functions/_shared/check-invitation-eligibility.ts
@@ -1,0 +1,166 @@
+/**
+ * Cross-provider invitation eligibility gate (shared helper).
+ *
+ * Wraps `api.check_invitation_acceptance_eligibility` and adapts the read-shape
+ * response to a `{ ok: true } | { response: Response }` discriminated union so
+ * the two call sites (accept-invitation Sally path, invite-user pre-issuance)
+ * can use the same logic with different HTTP status codes on block:
+ *
+ *   - invite-user (pre-issuance):  422 — the invitation should never be created
+ *   - accept-invitation (Sally):   403 — the in-flight token is rejected
+ *
+ * On `ok: true`, the caller proceeds. On `response`, the caller returns the
+ * Response directly (gate has logged the decision and constructed the body).
+ *
+ * Card: dev/active/reject-cross-provider-invitations/ (2026-05-13).
+ * RPC:  infrastructure/supabase/supabase/migrations/20260513203931_reject_cross_provider_invitations.sql
+ */
+
+import {
+  handleRpcError,
+  createErrorResponse,
+  ErrorCodes,
+} from './error-response.ts';
+
+/**
+ * Read-shape response from api.check_invitation_acceptance_eligibility.
+ *
+ * Exposed for test fixtures.
+ */
+export interface EligibilityRpcResponse {
+  eligible?: boolean;
+  error?: string;
+  message?: string;
+  details?: Record<string, unknown>;
+}
+
+/**
+ * Discriminated union returned by checkInvitationEligibility().
+ *
+ *   - { ok: true }                  → caller proceeds with the flow
+ *   - { response: Response }         → caller returns the Response immediately
+ */
+export type EligibilityGateResult =
+  | { ok: true }
+  | { response: Response };
+
+/**
+ * Minimal Supabase client surface this helper needs. The Supabase JS client's
+ * `.rpc()` returns a thenable PostgrestFilterBuilder (not a Promise), so we
+ * declare `rpc` as returning `any` to accept both the real client and test
+ * mocks without having to model the entire SupabaseClient generic-parameter
+ * surface. Same pattern as `checkExistingUserPath`'s `client: any`.
+ */
+// deno-lint-ignore no-explicit-any
+export type EligibilityRpcClient = { rpc(fnName: string, args: Record<string, unknown>): any };
+
+export interface CheckInvitationEligibilityParams {
+  /** Supabase client capable of invoking `api.check_invitation_acceptance_eligibility`. */
+  client: EligibilityRpcClient;
+  /** UUID of the invitee. */
+  inviteeUserId: string;
+  /** UUID of the target organization. */
+  targetOrgId: string;
+  /** Correlation ID for structured logging + response body. */
+  correlationId: string;
+  /** CORS headers for the Response when the gate blocks. */
+  corsHeaders: Record<string, string>;
+  /**
+   * HTTP status code returned when the gate blocks. 422 for pre-issuance
+   * (invite-user), 403 for acceptance (accept-invitation).
+   */
+  blockedStatus: 403 | 422;
+  /**
+   * Tag prefix for log lines, e.g. `[invite-user v18-...]`. Helps distinguish
+   * which gate fired in aggregated logs.
+   */
+  logTag: string;
+}
+
+/**
+ * Check eligibility for an invitation to a target org by invoking
+ * `api.check_invitation_acceptance_eligibility`. Returns a discriminated
+ * union: `{ok:true}` means proceed, `{response}` means return immediately.
+ *
+ * Side effects: console.log/warn/error to surface the decision in EF logs.
+ *
+ * Throws: never. RPC errors are translated to `handleRpcError` responses.
+ *
+ * @param params see CheckInvitationEligibilityParams
+ * @returns Either { ok: true } (proceed) or { response } (return to client)
+ */
+export async function checkInvitationEligibility(
+  params: CheckInvitationEligibilityParams,
+): Promise<EligibilityGateResult> {
+  const {
+    client,
+    inviteeUserId,
+    targetOrgId,
+    correlationId,
+    corsHeaders,
+    blockedStatus,
+    logTag,
+  } = params;
+
+  const { data, error: rpcError } = await client.rpc(
+    'check_invitation_acceptance_eligibility',
+    {
+      p_invitee_user_id: inviteeUserId,
+      p_target_org_id: targetOrgId,
+    },
+  );
+
+  if (rpcError) {
+    console.error(`${logTag} Eligibility check RPC failed:`, rpcError);
+    return {
+      response: handleRpcError(
+        rpcError,
+        correlationId,
+        corsHeaders,
+        'Check invitation acceptance eligibility',
+      ),
+    };
+  }
+
+  const eligibility = (data ?? {}) as EligibilityRpcResponse;
+
+  if (eligibility.eligible === true) {
+    console.log(
+      `${logTag} Eligibility check passed`,
+      {
+        correlationId,
+        invitee_user_id: inviteeUserId,
+        target_org_id: targetOrgId,
+        decision: 'eligible',
+      },
+    );
+    return { ok: true };
+  }
+
+  // Blocked branch (eligible !== true). Log + return a Response with the
+  // RPC's error code and message. Status is caller-determined.
+  console.warn(
+    `${logTag} Eligibility blocked: ${eligibility.error ?? 'unknown'}`,
+    {
+      correlationId,
+      invitee_user_id: inviteeUserId,
+      target_org_id: targetOrgId,
+      decision: 'blocked',
+      error_code: eligibility.error,
+      details: eligibility.details,
+    },
+  );
+
+  return {
+    response: createErrorResponse(
+      {
+        error: eligibility.message ?? 'This invitation cannot be accepted.',
+        code: eligibility.error ?? ErrorCodes.FORBIDDEN,
+        status: blockedStatus,
+        correlationId,
+        context: eligibility.details,
+      },
+      corsHeaders,
+    ),
+  };
+}

--- a/infrastructure/supabase/supabase/functions/accept-invitation/index.ts
+++ b/infrastructure/supabase/supabase/functions/accept-invitation/index.ts
@@ -5,6 +5,35 @@
  * It handles both email/password and OAuth (Google) authentication methods.
  *
  * CQRS-compliant: Emits domain events for user creation and role assignment.
+ *
+ * # Cross-provider invitation boundary gate (2026-05-13, card reject-cross-provider-invitations)
+ *
+ * After the Sally-scenario detector (`checkExistingUserPath`) confirms the
+ * invitee is an existing user (has ≥1 role in any org), this function calls
+ * `api.check_invitation_acceptance_eligibility(invitee_user_id, target_org_id)`
+ * BEFORE emitting any `user.role.assigned` events.
+ *
+ * If the RPC returns `eligible=false` with `error='cross_provider_invitation_blocked'`,
+ * the request is rejected with HTTP 403. No role events are emitted; the
+ * invitation row stays in `pending` status (admin can revoke manually).
+ *
+ * Rationale: per `documentation/architecture/data/provider-partners-architecture.md`,
+ * cross-tenant access between `type='provider'` orgs is reserved for users
+ * whose home org is `type='provider_partner'`, mediated by
+ * `cross_tenant_access_grants_projection`. Direct cross-provider invitations
+ * were silently creating native multi-tenant role rows — closed in this commit.
+ *
+ * Defense-in-depth: `invite-user/index.ts` runs the same eligibility check at
+ * invitation-creation time (returns 422), so most blocked cases never produce
+ * an invitation token. This gate catches in-flight tokens issued before the
+ * `invite-user` gate shipped.
+ *
+ * TOCTOU window: between the eligibility check and the role-event emit, the
+ * invitee could in principle gain a new role in another provider org via a
+ * concurrent accept in a different tab. The window is single-EF-execution
+ * (~100ms) and the failure mode is benign — the second event still routes
+ * through `handle_user_role_assigned` which is idempotent on
+ * `(user_id, role_id, org_id)`. No mitigation in v1; revisit if observable.
  */
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
@@ -19,6 +48,7 @@ import {
   createCorsPreflightResponse,
   standardCorsHeaders,
 } from '../_shared/error-response.ts';
+import { checkInvitationEligibility } from '../_shared/check-invitation-eligibility.ts';
 import {
   extractTracingContext,
   createSpan,
@@ -27,7 +57,7 @@ import {
 import { buildEventMetadata } from '../_shared/emit-event.ts';
 
 // Deployment version tracking
-const DEPLOY_VERSION = 'v24-existing-user-check-sql-rpc-pivot';
+const DEPLOY_VERSION = 'v25-cross-provider-invitation-gate';
 
 // CORS headers for frontend requests
 const corsHeaders = standardCorsHeaders;
@@ -595,6 +625,31 @@ serve(async (req) => {
         // Continue - we'll emit user.created to be safe (idempotent via projections)
       }
       const isExistingUser = existingUserCheck.isExistingUser;
+
+      // ====================================================================
+      // CROSS-PROVIDER INVITATION GATE (Sally path only)
+      // ====================================================================
+      // Card: reject-cross-provider-invitations (2026-05-13).
+      // For existing users (Sally), call api.check_invitation_acceptance_eligibility
+      // BEFORE emitting role events. If blocked, return 403. Skipping for
+      // greenfield users is safe: they have no existing roles to gate against,
+      // so the RPC would always return eligible=true.
+      //
+      // See top-of-file docblock for rationale + TOCTOU notes.
+      if (isExistingUser) {
+        const gate = await checkInvitationEligibility({
+          client: supabase,
+          inviteeUserId: userId,
+          targetOrgId: invitation.organization_id,
+          correlationId,
+          corsHeaders,
+          blockedStatus: 403,
+          logTag: `[accept-invitation v${DEPLOY_VERSION}]`,
+        });
+        if ('response' in gate) {
+          return gate.response;
+        }
+      }
 
       // Only emit user.created for NEW users (Sally scenario: skip for existing)
       if (!isExistingUser) {

--- a/infrastructure/supabase/supabase/functions/invite-user/index.ts
+++ b/infrastructure/supabase/supabase/functions/invite-user/index.ts
@@ -6,6 +6,28 @@
  *
  * CQRS-compliant: Emits user.invited domain event.
  * Permission required: user.create
+ *
+ * # Cross-provider invitation boundary gate (2026-05-13, card reject-cross-provider-invitations)
+ *
+ * When `checkEmailStatus` returns `other_org_member` (user exists in some
+ * organization other than the target), this function calls
+ * `api.check_invitation_acceptance_eligibility(invitee_user_id, target_org_id)`
+ * BEFORE generating the invitation token or emitting `user.invited`.
+ *
+ * If the RPC returns `eligible=false` with `error='cross_provider_invitation_blocked'`,
+ * the request is rejected with HTTP 422. No invitation token is issued; no
+ * `user.invited` event is emitted. This is the canonical (pre-issuance) gate
+ * — preferred over the `accept-invitation` Sally-path gate because it
+ * prevents a bad token from ever reaching the invitee.
+ *
+ * Rationale: per `documentation/architecture/data/provider-partners-architecture.md`,
+ * cross-tenant access between `type='provider'` orgs is reserved for users
+ * whose home org is `type='provider_partner'`, mediated by
+ * `cross_tenant_access_grants_projection`. Direct cross-provider invitations
+ * were silently creating native multi-tenant role rows — closed in this commit.
+ *
+ * Defense-in-depth: `accept-invitation/index.ts` runs the SAME eligibility
+ * check at acceptance time (returns 403). Both gates call the same RPC.
  */
 
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
@@ -25,6 +47,7 @@ import {
   standardCorsHeaders,
   createErrorResponse,
 } from '../_shared/error-response.ts';
+import { checkInvitationEligibility } from '../_shared/check-invitation-eligibility.ts';
 import {
   extractTracingContext,
   createSpan,
@@ -35,7 +58,7 @@ import { buildEventMetadata } from '../_shared/emit-event.ts';
 import { maskPii } from '../_shared/maskPii.ts';
 
 // Deployment version tracking
-const DEPLOY_VERSION = 'v17-revoke-extracted';
+const DEPLOY_VERSION = 'v18-cross-provider-invitation-gate';
 
 // CORS headers for frontend requests
 const corsHeaders = standardCorsHeaders;
@@ -780,6 +803,32 @@ serve(async (req) => {
         } as InviteUserResponse),
         { status: 409, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
+    }
+
+    // ==========================================================================
+    // CROSS-PROVIDER INVITATION GATE (pre-issuance, defense in depth)
+    // ==========================================================================
+    // Card: reject-cross-provider-invitations (2026-05-13).
+    // If checkEmailStatus identified the invitee as a member of some OTHER
+    // organization (other_org_member), run api.check_invitation_acceptance_eligibility
+    // to confirm the cross-org invitation is allowed. Block at 422 BEFORE
+    // generating the invitation token / emitting user.invited.
+    //
+    // See top-of-file docblock for full rationale + reference to the
+    // acceptance-time gate in accept-invitation/index.ts.
+    if (emailStatus.status === 'other_org_member' && emailStatus.userId) {
+      const gate = await checkInvitationEligibility({
+        client: supabaseAdmin,
+        inviteeUserId: emailStatus.userId,
+        targetOrgId: orgId,
+        correlationId,
+        corsHeaders,
+        blockedStatus: 422,
+        logTag: `[invite-user v${DEPLOY_VERSION}]`,
+      });
+      if ('response' in gate) {
+        return gate.response;
+      }
     }
 
     // ==========================================================================

--- a/infrastructure/supabase/supabase/functions/invite-user/index.ts
+++ b/infrastructure/supabase/supabase/functions/invite-user/index.ts
@@ -225,7 +225,14 @@ async function checkEmailStatus(
     }
   }
 
-  // Check if user exists in system (other orgs)
+  // Check if user exists in system (other orgs).
+  // PR #64 closeout (Finding #3): api.check_user_exists now filters
+  // `deleted_at IS NULL`, so a soft-deleted email returns no row here and is
+  // treated as greenfield (correct for re-invite-after-delete flow). The
+  // downstream cross-provider eligibility gate also relies on this filter
+  // to avoid blocking re-invitations of formerly-deleted users; the audit
+  // query in migration 20260513203931:185-187 mirrors the same filter, so
+  // audit and runtime are now aligned.
   const { data: existingUser, error: userError } = await supabase
     .rpc('check_user_exists', { p_email: email });
 

--- a/infrastructure/supabase/supabase/migrations/20260513203931_reject_cross_provider_invitations.sql
+++ b/infrastructure/supabase/supabase/migrations/20260513203931_reject_cross_provider_invitations.sql
@@ -1,0 +1,300 @@
+-- =============================================================================
+-- Migration: reject_cross_provider_invitations
+-- Card:      dev/active/reject-cross-provider-invitations/
+-- Architect: reviewed 2026-05-13 (see plan.md § ARCHITECT VERDICT)
+-- =============================================================================
+-- Purpose:
+--   1. Introduce api.check_invitation_acceptance_eligibility(uuid, uuid) — a
+--      read-shape SQL RPC that closes the architectural drift identified in
+--      PR #63 UAT Test 5. Provider→provider Sally invitations currently emit
+--      user.role.assigned with no eligibility check, creating native multi-
+--      tenant role rows. Per provider-partners-architecture.md, cross-tenant
+--      access between provider orgs is reserved for users whose home org is
+--      type='provider_partner', mediated by cross_tenant_access_grants_projection.
+--
+--   2. Run a NOTICE-only pre-deploy audit listing pending invitations the new
+--      gate WOULD reject. Operators triage these case-by-case before the
+--      gate is deployed; the migration itself does NOT auto-revoke them.
+--
+--   3. Run a NOTICE-only diagnostic listing other users currently in a
+--      cross-provider native-role state (multi-row user_roles_projection
+--      across multiple type='provider' orgs). No auto-cleanup beyond
+--      dakaratekid; operators triage these case-by-case.
+--
+--   4. One-off cleanup: emit user.role.revoked for dakaratekid@gmail.com's
+--      Cypress Admin @ testorg-20260329 role (the known victim of the drift).
+--      handle_user_role_revoked drops the user_roles_projection row and
+--      removes 'Cypress Admin' from users.roles[]. Restores her to single-
+--      org liveforlife state.
+--
+-- Contract (Design-by-Contract):
+--   See `dev/active/reject-cross-provider-invitations/plan.md` for the full
+--   pre/post/invariant spec on api.check_invitation_acceptance_eligibility.
+--
+-- Architect must-fix items addressed:
+--   C1: NO auth.uid() runtime guard — accept-invitation calls via service_role
+--       admin client; auth.uid() legitimately returns NULL. GRANT to BOTH
+--       authenticated AND service_role for authn.
+--   C4a: WHERE urp.organization_id IS NOT NULL — skip global super_admin rows.
+--   C4b: AND (role_valid_from IS NULL OR <= CURRENT_DATE) — exclude future-dated.
+--   C4c: AND op.is_active = true — exclude stale roles at deactivated orgs.
+--   C5: Cleanup DO block idempotency invariant documented (depends on
+--       handle_user_role_revoked deleting the projection row).
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- api.check_invitation_acceptance_eligibility — read-shape eligibility check
+-- -----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION api.check_invitation_acceptance_eligibility(
+    p_invitee_user_id uuid,
+    p_target_org_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+STABLE
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $$
+DECLARE
+    v_target_org_type text;
+    v_target_is_active boolean;
+    v_existing_org_id uuid;
+BEGIN
+    -- Authn enforced via GRANT (authenticated + service_role).
+    -- accept-invitation invokes via service_role admin client where auth.uid()
+    -- legitimately returns NULL; a runtime auth.uid() IS NULL guard would
+    -- break that path. Mirrors api.check_user_invitation_existence precedent.
+    --
+    -- Threat model: read-only org-type check. Worst case if reachable by an
+    -- unauthorized caller — they learn whether a known user_id has an active
+    -- provider role and (on block) one provider org_id. No PII (no names,
+    -- emails, role names, role ids) is returned.
+
+    SELECT type, is_active
+      INTO v_target_org_type, v_target_is_active
+      FROM public.organizations_projection
+     WHERE id = p_target_org_id;
+
+    IF NOT FOUND THEN
+        RETURN jsonb_build_object(
+            'eligible', false,
+            'error', 'target_org_not_found',
+            'message', 'Target organization does not exist.'
+        );
+    END IF;
+
+    -- Find any ACTIVE native role in a DIFFERENT type='provider' org.
+    -- Filters (C4a/b/c per architect review):
+    --   * organization_id IS NOT NULL  -> skip global super_admin rows.
+    --   * role_valid_from <= today      -> exclude pre-provisioned future roles.
+    --   * role_valid_until IS NULL OR >= today -> exclude expired roles.
+    --   * op.is_active = true           -> stale role at deactivated org
+    --                                      should not block fresh invite.
+    SELECT urp.organization_id
+      INTO v_existing_org_id
+      FROM public.user_roles_projection urp
+      JOIN public.organizations_projection op ON op.id = urp.organization_id
+     WHERE urp.user_id = p_invitee_user_id
+       AND urp.organization_id IS NOT NULL
+       AND urp.organization_id != p_target_org_id
+       AND op.type = 'provider'
+       AND op.is_active = true
+       AND (urp.role_valid_from IS NULL OR urp.role_valid_from <= CURRENT_DATE)
+       AND (urp.role_valid_until IS NULL OR urp.role_valid_until >= CURRENT_DATE)
+     LIMIT 1;
+
+    IF FOUND AND v_target_org_type = 'provider' THEN
+        RETURN jsonb_build_object(
+            'eligible', false,
+            'error', 'cross_provider_invitation_blocked',
+            'message', 'This user is already a member of another provider organization. '
+                    || 'Cross-tenant access between providers requires a cross-tenant access '
+                    || 'grant via a partner organization, not a direct invitation.',
+            'details', jsonb_build_object(
+                'existing_provider_org_id', v_existing_org_id,
+                'target_provider_org_id', p_target_org_id
+            )
+        );
+    END IF;
+
+    RETURN jsonb_build_object('eligible', true);
+END;
+$$;
+
+-- authenticated: callable from invite-user (user-initiated, has JWT subject).
+-- service_role: REQUIRED -- accept-invitation invokes via admin client
+--               (no JWT subject during OAuth/SSO accept flow).
+GRANT EXECUTE ON FUNCTION api.check_invitation_acceptance_eligibility(uuid, uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION api.check_invitation_acceptance_eligibility(uuid, uuid) TO service_role;
+
+COMMENT ON FUNCTION api.check_invitation_acceptance_eligibility(uuid, uuid) IS
+$comment$Check whether an invitee may accept (or be issued) an invitation to a target org.
+
+Rejects when the invitee already has an active native role in a different
+provider-type org AND the target org is also provider-type. Aligns with
+provider-partners-architecture.md: cross-tenant access between providers is
+reserved for provider_partner-org users via cross_tenant_access_grants_projection.
+
+Active-role filter:
+  organization_id IS NOT NULL  (skip global super_admin)
+  role_valid_from IS NULL OR <= today
+  role_valid_until IS NULL OR >= today
+  existing-role org is_active = true
+
+Response shape (read-shape, no envelope):
+  {"eligible": true}                                            -- proceed
+  {"eligible": false, "error": "target_org_not_found", ...}     -- HTTP 422
+  {"eligible": false, "error": "cross_provider_invitation_blocked",
+                      "details": {...}}                           -- HTTP 403/422
+
+Called from:
+- accept-invitation Edge Function (Sally path, after isExistingUser=true)
+- invite-user Edge Function (pre-issuance, defense in depth)
+
+@a4c-rpc-shape: read$comment$;
+
+-- -----------------------------------------------------------------------------
+-- Pre-deploy audit: pending invitations the new gate WOULD reject
+-- -----------------------------------------------------------------------------
+-- NOTICE-only. Operators capture this output and decide per-row whether to
+-- revoke the pending invitation, contact the inviter, etc. The migration
+-- itself does NOT auto-revoke (heavier surgery deferred per ARCHITECT NOTE
+-- on in-flight token risk).
+-- -----------------------------------------------------------------------------
+
+DO $$
+DECLARE
+    v_rec record;
+    v_count int := 0;
+BEGIN
+    RAISE NOTICE '--- Pre-deploy audit: pending invitations the new gate WOULD reject ---';
+    FOR v_rec IN
+        SELECT
+            i.id              AS invitation_id,
+            i.email           AS invitee_email,
+            i.organization_id AS target_org_id,
+            ot.name           AS target_org_name,
+            u.id              AS invitee_user_id,
+            uo.id             AS existing_provider_org_id,
+            uo.name           AS existing_provider_org_name
+          FROM public.invitations_projection i
+          JOIN public.organizations_projection ot
+            ON ot.id = i.organization_id
+           AND ot.type = 'provider'
+          JOIN public.users u
+            ON LOWER(u.email) = LOWER(i.email)
+           AND u.deleted_at IS NULL
+          JOIN public.user_roles_projection urp
+            ON urp.user_id = u.id
+           AND urp.organization_id IS NOT NULL
+           AND urp.organization_id != i.organization_id
+           AND (urp.role_valid_from IS NULL OR urp.role_valid_from <= CURRENT_DATE)
+           AND (urp.role_valid_until IS NULL OR urp.role_valid_until >= CURRENT_DATE)
+          JOIN public.organizations_projection uo
+            ON uo.id = urp.organization_id
+           AND uo.type = 'provider'
+           AND uo.is_active = true
+         WHERE i.status = 'pending'
+           AND i.expires_at > NOW()
+    LOOP
+        v_count := v_count + 1;
+        RAISE NOTICE '  invitation=% email=% target=%(%) blocked_by_existing=%(%)',
+            v_rec.invitation_id,
+            v_rec.invitee_email,
+            v_rec.target_org_name, v_rec.target_org_id,
+            v_rec.existing_provider_org_name, v_rec.existing_provider_org_id;
+    END LOOP;
+    RAISE NOTICE 'Pre-deploy audit complete: % pending invitation(s) would now be rejected.', v_count;
+END $$;
+
+-- -----------------------------------------------------------------------------
+-- Diagnostic audit: other users in cross-provider drift state
+-- -----------------------------------------------------------------------------
+-- NOTICE-only. Lists users with active roles in 2+ distinct type='provider'
+-- orgs (the dakaratekid pattern). No auto-cleanup; operators triage.
+-- -----------------------------------------------------------------------------
+
+DO $$
+DECLARE
+    v_rec record;
+    v_count int := 0;
+BEGIN
+    RAISE NOTICE '--- Diagnostic audit: users with native roles across multiple type=''provider'' orgs ---';
+    FOR v_rec IN
+        SELECT
+            u.id    AS user_id,
+            u.email AS user_email,
+            COUNT(DISTINCT urp.organization_id) AS provider_org_count,
+            array_agg(DISTINCT op.name)         AS provider_org_names
+          FROM public.users u
+          JOIN public.user_roles_projection urp
+            ON urp.user_id = u.id
+           AND urp.organization_id IS NOT NULL
+           AND (urp.role_valid_from IS NULL OR urp.role_valid_from <= CURRENT_DATE)
+           AND (urp.role_valid_until IS NULL OR urp.role_valid_until >= CURRENT_DATE)
+          JOIN public.organizations_projection op
+            ON op.id = urp.organization_id
+           AND op.type = 'provider'
+           AND op.is_active = true
+         WHERE u.deleted_at IS NULL
+         GROUP BY u.id, u.email
+        HAVING COUNT(DISTINCT urp.organization_id) > 1
+    LOOP
+        v_count := v_count + 1;
+        RAISE NOTICE '  user=% email=% provider_org_count=% orgs=%',
+            v_rec.user_id,
+            v_rec.user_email,
+            v_rec.provider_org_count,
+            v_rec.provider_org_names;
+    END LOOP;
+    RAISE NOTICE 'Diagnostic audit complete: % user(s) with cross-provider native-role state.', v_count;
+END $$;
+
+-- -----------------------------------------------------------------------------
+-- One-off cleanup: dakaratekid revoke
+-- -----------------------------------------------------------------------------
+-- Idempotency invariant (ARCHITECT NOTE C5):
+--   IF FOUND on user_roles_projection works because handle_user_role_revoked
+--   DELETES the projection row on successful emit. Rerun: row already absent
+--   -> NOT FOUND -> no-op. If handle_user_role_revoked semantics ever change
+--   to soft-revoke (mark revoked_at without delete), THIS BLOCK MUST BE
+--   REWRITTEN to check a revoked-marker column instead of NOT FOUND.
+-- -----------------------------------------------------------------------------
+
+DO $$
+DECLARE
+    v_user_id uuid := 'bab8077f-6a76-46f4-a0cd-9363bbf313fb';  -- dakaratekid@gmail.com
+    v_org_id  uuid := '2d0829ae-224b-4a79-ac3a-726b00d6c172';  -- testorg-20260329
+    v_role_id uuid;
+BEGIN
+    SELECT role_id
+      INTO v_role_id
+      FROM public.user_roles_projection
+     WHERE user_id = v_user_id
+       AND organization_id = v_org_id;
+
+    IF FOUND THEN
+        PERFORM api.emit_domain_event(
+            p_stream_id      := v_user_id,
+            p_stream_type    := 'user',
+            p_event_type     := 'user.role.revoked',
+            p_event_data     := jsonb_build_object(
+                'role_id', v_role_id,
+                'org_id',  v_org_id
+            ),
+            p_event_metadata := jsonb_build_object(
+                'reason',    'One-off cleanup: dakaratekid was accidentally cross-invited to '
+                          || 'testorg-20260329 (both type=provider). Per '
+                          || 'provider-partners-architecture.md, cross-provider invitations '
+                          || 'are forbidden. See card reject-cross-provider-invitations.',
+                'source',    'migration_reject_cross_provider_invitations',
+                'automated', true
+            )
+        );
+        RAISE NOTICE 'Revoked accidental cross-provider role: user=% org=% role=%',
+            v_user_id, v_org_id, v_role_id;
+    ELSE
+        RAISE NOTICE 'No cleanup needed: dakaratekid has no role in testorg-20260329 (already cleaned up or never landed).';
+    END IF;
+END $$;

--- a/infrastructure/supabase/supabase/migrations/20260513213831_pr64_closeout.sql
+++ b/infrastructure/supabase/supabase/migrations/20260513213831_pr64_closeout.sql
@@ -1,0 +1,206 @@
+-- =============================================================================
+-- Migration: pr64_closeout
+-- Card:      dev/active/reject-cross-provider-invitations/ (PR #64)
+-- Architect: closeout for review findings #1, #2, #3, #5 (P2/P3, in-PR fixes)
+-- =============================================================================
+-- Purpose: address architect review findings on PR #64 with a single migration:
+--
+--   #1 [P2] Drop `details` from api.check_invitation_acceptance_eligibility's
+--           cross-provider block. Internal-org-id disclosure was load-bearing
+--           on no UI consumer; server-side log (caller-side) preserves the
+--           operator correlation path.
+--   #2 [P3] Remove `v_target_is_active` dead variable from
+--           api.check_invitation_acceptance_eligibility.
+--   #3 [P3] Add `AND u.deleted_at IS NULL` to api.check_user_exists; brings
+--           audit + runtime into alignment and tags the function with
+--           `@a4c-rpc-shape: read` defensively.
+--   #5 [P3] Add inline docblock comment at api.check_invitation_acceptance_eligibility
+--           capturing the deliberate provider→provider-only scope and the
+--           open policy question for provider→provider_partner.
+--
+-- Findings #4 (wiring tests) and #6 (doc footer dates + version bump) are
+-- non-SQL and ship in the second commit of the closeout.
+--
+-- All changes are CREATE OR REPLACE (idempotent in shape; both functions
+-- already exist in 20260212010625_baseline_v4.sql and
+-- 20260513203931_reject_cross_provider_invitations.sql respectively).
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- api.check_invitation_acceptance_eligibility — closeout re-emit
+-- -----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION api.check_invitation_acceptance_eligibility(
+    p_invitee_user_id uuid,
+    p_target_org_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+STABLE
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $$
+DECLARE
+    v_target_org_type text;
+    -- (Finding #2 closeout) Removed `v_target_is_active boolean` — dead code.
+    -- Target-org activeness validation is handled by callers (invite-user
+    -- via api.get_organization_by_id later in the flow). If a target-org
+    -- active check belongs here, that's a deliberate scope expansion.
+    --
+    -- (Finding #1 closeout downstream) Removed `v_existing_org_id uuid` —
+    -- it was the SELECT target for an org_id that was only ever surfaced
+    -- in `details.existing_provider_org_id`. With `details` dropped, the
+    -- query just needs an existence check (PERFORM ... LIMIT 1; IF FOUND).
+BEGIN
+    -- Authn enforced via GRANT (authenticated + service_role).
+    -- accept-invitation invokes via service_role admin client where auth.uid()
+    -- legitimately returns NULL; a runtime auth.uid() IS NULL guard would
+    -- break that path. Mirrors api.check_user_invitation_existence precedent.
+    --
+    -- Threat model (Finding #1 closeout): read-only org-type check. Worst
+    -- case if reachable by an unauthorized caller — they learn whether a
+    -- known user_id has an active provider role. No org_ids, names, emails,
+    -- role names, or role ids are returned. (Prior shape returned
+    -- existing_provider_org_id in `details`; removed in PR #64 closeout to
+    -- eliminate the lateral-disclosure surface — operator correlation
+    -- continues via the server-side log in _shared/check-invitation-eligibility.ts.)
+
+    SELECT type
+      INTO v_target_org_type
+      FROM public.organizations_projection
+     WHERE id = p_target_org_id;
+
+    IF NOT FOUND THEN
+        RETURN jsonb_build_object(
+            'eligible', false,
+            'error', 'target_org_not_found',
+            'message', 'Target organization does not exist.'
+        );
+    END IF;
+
+    -- Find any ACTIVE native role in a DIFFERENT type='provider' org.
+    -- Filters (C4a/b/c per PR #64 pre-merge architect review):
+    --   * organization_id IS NOT NULL  -> skip global super_admin rows.
+    --   * role_valid_from <= today      -> exclude pre-provisioned future roles.
+    --   * role_valid_until IS NULL OR >= today -> exclude expired roles.
+    --   * op.is_active = true           -> stale role at deactivated org
+    --                                      should not block fresh invite.
+    PERFORM 1
+      FROM public.user_roles_projection urp
+      JOIN public.organizations_projection op ON op.id = urp.organization_id
+     WHERE urp.user_id = p_invitee_user_id
+       AND urp.organization_id IS NOT NULL
+       AND urp.organization_id != p_target_org_id
+       AND op.type = 'provider'
+       AND op.is_active = true
+       AND (urp.role_valid_from IS NULL OR urp.role_valid_from <= CURRENT_DATE)
+       AND (urp.role_valid_until IS NULL OR urp.role_valid_until >= CURRENT_DATE)
+     LIMIT 1;
+
+    -- Gate scope (Finding #5 closeout): this check covers provider→provider
+    -- only. provider→provider_partner direction is silently allowed pending
+    -- an explicit policy decision. Per provider-partners-architecture.md,
+    -- the cross-tenant model is partner-USER → provider-DATA, mediated by
+    -- cross_tenant_access_grants_projection. Whether a user with a primary
+    -- type='provider' role may also hold a type='provider_partner' role is
+    -- unspecified. If the answer becomes "no", extend this branch to also
+    -- fire when v_target_org_type = 'provider_partner' AND the invitee has
+    -- any active type='provider' role. No card yet — seed if a stakeholder
+    -- request emerges.
+    IF FOUND AND v_target_org_type = 'provider' THEN
+        RETURN jsonb_build_object(
+            'eligible', false,
+            'error', 'cross_provider_invitation_blocked',
+            'message', 'This user is already a member of another provider organization. '
+                    || 'Cross-tenant access between providers requires a cross-tenant access '
+                    || 'grant via a partner organization, not a direct invitation.'
+            -- (Finding #1 closeout) Removed `details` object that previously
+            -- carried existing_provider_org_id + target_provider_org_id.
+            -- Operator correlation continues via the server-side log in
+            -- _shared/check-invitation-eligibility.ts at the warn path,
+            -- which still includes `details: eligibility.details` from the
+            -- helper-internal RPC response object.
+        );
+    END IF;
+
+    RETURN jsonb_build_object('eligible', true);
+END;
+$$;
+
+-- Defensive re-issue of the shape tag per the DROP+CREATE rule in
+-- infrastructure/supabase/CLAUDE.md § RPC Shape Registry. CREATE OR REPLACE
+-- preserves the comment on a same-signature function (OID retained), but
+-- re-emitting documents the contract change inline and makes the migration
+-- self-describing.
+COMMENT ON FUNCTION api.check_invitation_acceptance_eligibility(uuid, uuid) IS
+$comment$Check whether an invitee may accept (or be issued) an invitation to a target org.
+
+Rejects when the invitee already has an active native role in a different
+provider-type org AND the target org is also provider-type. Aligns with
+provider-partners-architecture.md: cross-tenant access between providers is
+reserved for provider_partner-org users via cross_tenant_access_grants_projection.
+
+Active-role filter:
+  organization_id IS NOT NULL  (skip global super_admin)
+  role_valid_from IS NULL OR <= today
+  role_valid_until IS NULL OR >= today
+  existing-role org is_active = true
+
+Response shape (read-shape, no envelope):
+  {"eligible": true}                                            -- proceed
+  {"eligible": false, "error": "target_org_not_found", ...}     -- HTTP 422
+  {"eligible": false, "error": "cross_provider_invitation_blocked"} -- HTTP 403/422
+
+PR #64 closeout: removed `details` object from cross_provider_invitation_blocked
+response (Finding #1 — lateral-disclosure of one other-tenant org id with no
+UI consumer). Internal correlation continues via server-side log in
+_shared/check-invitation-eligibility.ts.
+
+Called from:
+- accept-invitation Edge Function (Sally path, after isExistingUser=true)
+- invite-user Edge Function (pre-issuance, defense in depth)
+
+@a4c-rpc-shape: read$comment$;
+
+-- -----------------------------------------------------------------------------
+-- api.check_user_exists — closeout re-emit with deleted_at filter
+-- -----------------------------------------------------------------------------
+-- Finding #3: original baseline (20260212010625_baseline_v4.sql:572-583) did
+-- NOT filter `deleted_at IS NULL`. The runtime check via this function in
+-- invite-user (and the frontend smart-email-lookup) implicitly relied on
+-- handle_user_deleted nuking user_roles_projection rows. Tightening the
+-- function aligns it with the pre-deploy audit at
+-- 20260513203931_reject_cross_provider_invitations.sql:185-187, which
+-- correctly filters `deleted_at IS NULL`. Single source of truth.
+-- -----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION api.check_user_exists(p_email text)
+RETURNS TABLE(user_id uuid, email text)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT u.id AS user_id, u.email
+    FROM public.users u
+   WHERE u.email = p_email
+     AND u.deleted_at IS NULL   -- PR #64 finding #3: align with audit query at
+                                -- 20260513203931_reject_cross_provider_invitations.sql:185-187
+                                -- and prevent false-positive cross-provider blocks for
+                                -- formerly-deleted users.
+   LIMIT 1;
+END;
+$$;
+
+COMMENT ON FUNCTION api.check_user_exists(text) IS
+$comment$Check if a user with the given email exists anywhere in the system.
+
+Filters out soft-deleted users (deleted_at IS NOT NULL) so callers do not
+treat tombstoned rows as live identities. See PR #64 finding #3.
+
+Consumers:
+- invite-user Edge Function (checkEmailStatus smart-email-lookup)
+- frontend SupabaseUserQueryService.checkUserExists (UI smart-email-lookup)
+
+@a4c-rpc-shape: read$comment$;

--- a/workflows/src/types/database.types.ts
+++ b/workflows/src/types/database.types.ts
@@ -179,6 +179,10 @@ export type Database = {
         Args: { p_org_id: string }
         Returns: boolean
       }
+      check_invitation_acceptance_eligibility: {
+        Args: { p_invitee_user_id: string; p_target_org_id: string }
+        Returns: Json
+      }
       check_organization_by_name: {
         Args: { p_name: string }
         Returns: {
@@ -1609,31 +1613,6 @@ export type Database = {
       }
       validate_role_assignment: {
         Args: { p_role_ids: string[] }
-        Returns: Json
-      }
-    }
-    Enums: {
-      [_ in never]: never
-    }
-    CompositeTypes: {
-      [_ in never]: never
-    }
-  }
-  graphql_public: {
-    Tables: {
-      [_ in never]: never
-    }
-    Views: {
-      [_ in never]: never
-    }
-    Functions: {
-      graphql: {
-        Args: {
-          extensions?: Json
-          operationName?: string
-          query?: string
-          variables?: Json
-        }
         Returns: Json
       }
     }
@@ -5908,9 +5887,6 @@ export type CompositeTypes<
 
 export const Constants = {
   api: {
-    Enums: {},
-  },
-  graphql_public: {
     Enums: {},
   },
   public: {


### PR DESCRIPTION
## Summary

Closes the architectural drift identified in PR #63 UAT Test 5: `accept-invitation` silently allowed provider→provider Sally invitations, emitting `user.role.assigned` events that created native multi-tenant role rows.

Per [`provider-partners-architecture.md`](documentation/architecture/data/provider-partners-architecture.md), cross-tenant access between `type='provider'` orgs is reserved for users whose home org is `type='provider_partner'`, mediated by `cross_tenant_access_grants_projection` — **not** native role assignment.

- New SQL RPC `api.check_invitation_acceptance_eligibility` (read-shape; GRANT to `authenticated` + `service_role`)
- Boundary gates in `accept-invitation` (HTTP 403, Sally path) and `invite-user` (HTTP 422, pre-issuance)
- One-off cleanup: revokes dakaratekid's accidental `Cypress Admin @ testorg-20260329` role (the known victim) inline in the migration

Card: [`dev/active/reject-cross-provider-invitations/`](dev/active/reject-cross-provider-invitations/) (architect-reviewed inline — 5 must-fix items C1–C5 addressed before code).

## Architect review — must-fix items addressed

| # | Item | Resolution |
|---|---|---|
| **C1** | `auth.uid() IS NULL` guard would break `accept-invitation`'s service-role admin client (no JWT subject) | No runtime guard; GRANT to both `authenticated` AND `service_role`, mirroring `api.check_user_invitation_existence` precedent |
| **C2** | Pre-issuance gate target was wrong | Verified via grep that `user.invited` is emitted only at `invite-user/index.ts:836`; gate placed there (NOT `manage-user`) |
| **C3** | Doc enum mismatch (legacy `type='partner'` + `'agency_assignment'`/`'family_consent'`) | Live CHECK is `('platform_owner', 'provider', 'provider_partner')`; DB enum is `'social_services_assignment'`/`'family_participation'`. Doc edits applied |
| **C4** | Eligibility filter blind spots | (a) `organization_id IS NOT NULL` excludes super_admin; (b) `role_valid_from <= today` excludes future-dated; (c) `op.is_active = true` excludes deactivated-org stale roles |
| **C5** | Cleanup idempotency invariant implicit | Documented inline: depends on `handle_user_role_revoked` deleting the projection row |

## Pre-deploy audit (NOTICE-only, run by the migration)

- **Pending invitations the new gate WOULD reject**: **0** (no in-flight token risk on dev)
- **Users in cross-provider drift state**: **1** (dakaratekid@gmail.com — cleaned up by this migration)

## Files

| Area | File |
|---|---|
| Migration | `infrastructure/supabase/supabase/migrations/20260513203931_reject_cross_provider_invitations.sql` |
| Shared helper | `infrastructure/supabase/supabase/functions/_shared/check-invitation-eligibility.ts` |
| Unit tests | `infrastructure/supabase/supabase/functions/_shared/__tests__/check-invitation-eligibility.test.ts` (6 new tests) |
| EF gate (acceptance, 403) | `infrastructure/supabase/supabase/functions/accept-invitation/index.ts` (v25) |
| EF gate (pre-issuance, 422) | `infrastructure/supabase/supabase/functions/invite-user/index.ts` (v18) |
| Types | `frontend/src/types/database.types.ts`, `workflows/src/types/database.types.ts`, `frontend/src/services/api/rpc-registry.generated.ts` |
| Docs | `documentation/architecture/data/provider-partners-architecture.md`, `infrastructure/supabase/CLAUDE.md` |
| Follow-up seed | `dev/active/investigate-auth-callback-priority-2-fallthrough.md` |

## Test plan

- [x] **Migration applied to dev** (`supabase db push --linked`) — clean apply, audits captured
- [x] **dakaratekid cleanup verified** via Management API SQL — `user_roles_projection` reduced to 1 row (liveforlife), `users.roles` no longer contains 'Cypress Admin', `domain_events` records the `user.role.revoked` event with cleanup reason
- [x] **RPC smoke-tested** all four branches via Management API SQL (eligible / cross_provider_blocked / target_not_found / greenfield)
- [x] **6 helper unit tests pass** — eligible, blocked (403), blocked (422), target_not_found, RPC error, malformed-response-fail-closed
- [x] **All 104 Deno tests under `functions/` pass** (`deno test --allow-net --allow-env`)
- [x] **Both Edge Functions deployed to dev**, OPTIONS preflight returns 200
- [x] **Typecheck** clean for frontend + workflows after regenerating `database.types.ts`
- [ ] **CI green** — `supabase-edge-functions-test.yml`, `supabase-edge-functions-lint.yml`, `rpc-registry-sync.yml` (last verifies registry against a fresh local container)
- [ ] **UAT** — log in as dakaratekid post-deploy, verify she lands on `liveforlife.firstovertheline.com/dashboard` (if NOT, see follow-up card `investigate-auth-callback-priority-2-fallthrough.md` — that routing symptom is a separate body of work, NOT caused by this drift)
- [ ] **UAT** — attempt provider→provider Sally invitation via the UI, expect 422 at invite-create (and 403 if a stale token is used at acceptance)
- [ ] **UAT** — same-org re-invitation continues to work (gate does not fire)
- [ ] **UAT** — greenfield invitation continues to work (gate not called)

## Out of scope (documented in card)

- Building the cross-tenant grant producer pipeline (`api.create_access_grant`, RLS on provider data, partner-UI) — belongs to parked `dev/active/sub-tenant-admin-design/`
- The AuthCallback Priority-2 fall-through routing symptom — seeded as a separate card
- Symptomatic `accessible_organizations` denormalization fix — superseded by this card in `e98daf2e`; the drift class closes automatically once this gate ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)