### PR TITLE
fix(api): list_users sister RPCs gate membership by accessible_organizations not current_organization_id

### DIFF
--- a/dev/active/list-users-sister-functions-membership-gating/plan.md
+++ b/dev/active/list-users-sister-functions-membership-gating/plan.md
@@ -1,72 +1,249 @@
-# `list_users_for_*` sister RPCs gate by `current_organization_id`, not `accessible_organizations`
+# Implementation Plan: list-users-sister-functions-membership-gating
 
-**Status**: seed (not yet planned)
-**Priority**: Medium-High — same admin-blind-spot class as `users-list-omits-roleless-members` (now shipped in PR #66) but on a different surface. A multi-org user whose `current_organization_id` differs from the role/schedule admin's org is invisible in role-management, bulk-assignment, and schedule-assignment UIs.
-**Origin**: Discovered while auditing for the `users-list-omits-roleless-members` fix (2026-05-19). The four `list_users*` functions in `api` schema use three different membership-gating predicates:
+**Status**: planned (ready for execution; pure replay of the PR #66 playbook)
+**Priority**: Medium-High
+**Date**: 2026-05-21
+**Origin**: 2026-05-19 PR #66 investigation; sister-card seeded 2026-05-20
 
-| Function | Membership predicate | Bug class |
-|---|---|---|
-| `api.list_users` | `p_org_id = ANY(u.accessible_organizations)` | ✅ Correct (fixed in PR #66) |
-| `api.list_users_for_role_management` | `u.current_organization_id = v_org_id` | ⚠️ Smell — this card |
-| `api.list_users_for_bulk_assignment` | `u.current_organization_id = v_org_id` | ⚠️ Smell — this card |
-| `api.list_users_for_schedule_management` | `u.current_organization_id = v_org_id` | ⚠️ Smell — this card |
+## Executive Summary
 
-## Problem statement
+PR #66 fixed `api.list_users` so org membership is gated by the canonical oracle `users.accessible_organizations @> ARRAY[p_org_id]::uuid[]` instead of an unreliable role-EXISTS proxy. Three sister RPCs (`list_users_for_role_management`, `list_users_for_bulk_assignment`, `list_users_for_schedule_management`) carry a different but related smell: they gate by `u.current_organization_id = v_org_id` — the user's active-session pointer, NOT a membership oracle. Pre-fix consequence: multi-org users (and users whose session pointer drifts away from their target org) are invisible in role-management, bulk-assignment, and schedule-assignment admin UIs. Today the defect is dormant on dev (all users are single-org), but it will become routine the moment the cross-tenant grant pipeline ships per `dev/active/sub-tenant-admin-design/`.
 
-The three sister functions use `u.current_organization_id = v_org_id` as the membership gate. `current_organization_id` is the user's *currently selected* org (their "active session" org), NOT a membership oracle. This means:
+The fix is symmetric to PR #66 and reuses the same GIN index (`idx_users_accessible_orgs_gin`). One migration touches three function bodies. The card is scoped as a pure replay — no design re-litigation, no architectural reframing of `current_organization_id`, no super_admin visibility changes.
 
-1. **Multi-org users**: a user with home org `liveforlife` who also has a role assignment in `testorg` is invisible to testorg's role-management UI because their `current_organization_id` is liveforlife.
-2. **Future cross-tenant grants**: when `provider_partner`-org users get cross-tenant grants per `documentation/architecture/data/provider-partners-architecture.md`, they will be invisible to host-org role admins.
-3. **Inconsistency with `api.list_users`**: an admin sees a user in the main `/users` page (now membership-gated correctly via `accessible_organizations`) but can't see the same user in role-management or schedule-assignment. Two different visibility models on the same surface.
+## Phase 1: Pre-flight verification
 
-## Where the defect lives
+### 1.1 Confirm sister function bodies unchanged since 2026-05-19 audit
+- Re-pull live function definitions for the three RPCs via Management API SQL
+- Confirm each still uses `WHERE u.current_organization_id = v_org_id`
+- Confirm no other consumer has refactored them in the interim
+- **Time estimate**: 5 minutes
 
-`infrastructure/supabase/supabase/migrations/20260212010625_baseline_v4.sql` — three function bodies, each with a `WHERE u.current_organization_id = v_org_id AND u.deleted_at IS NULL AND (search_term…)` block.
+### 1.2 Confirm GIN index still present on `public.users`
+- Single SQL check: `SELECT indexname FROM pg_indexes WHERE indexname = 'idx_users_accessible_orgs_gin'`
+- **Time estimate**: 2 minutes
 
-Live function signatures (verified 2026-05-19):
-- `api.list_users_for_role_management(p_role_id uuid, p_scope_path ltree, p_search_term text DEFAULT NULL, p_limit integer DEFAULT 100, p_offset integer DEFAULT 0)`
-- `api.list_users_for_bulk_assignment(p_role_id uuid, p_scope_path ltree, p_search_term text DEFAULT NULL, p_limit integer DEFAULT 100, p_offset integer DEFAULT 0)`
-- `api.list_users_for_schedule_management(p_template_id uuid, p_search_term text DEFAULT NULL, p_limit integer DEFAULT 100, p_offset integer DEFAULT 0)`
+### 1.3 Verify no UI consumer relies on current_organization_id semantics
+- Re-grep frontend callers (already mapped at PR #66 prep time: `SupabaseRoleService.ts`, `SupabaseScheduleService.ts`, `pages/roles/RolesManagePage.tsx:438`)
+- Confirm none of them depends on the over-restrictive behavior (e.g., would break if more users appeared)
+- **Time estimate**: 10 minutes
 
-The `v_org_id` derivation differs by function:
-- `for_role_management` + `for_bulk_assignment`: derive `v_org_id` from `subpath(p_scope_path, 0, 1)` against `organizations_projection.path` (correct — derives target org from the scope path).
-- `for_schedule_management`: derives `v_org_id` from `public.get_current_org_id()` (the caller's JWT `org_id` claim).
+### 1.4 Inventory liveforlife `schedule_templates_projection` rows
+- `SELECT id, schedule_name FROM public.schedule_templates_projection WHERE organization_id = '43ede501-…' AND deleted_at IS NULL` (or similar)
+- If at least one exists, capture its `id` for Phase 3.2's schedule-management smoke
+- If none exist, decide between (a) creating one inside the transactional smoke harness, or (b) deferring the schedule smoke as N/A (the role + bulk-assignment smokes prove the pattern)
+- **Time estimate**: 5 minutes
 
-In all three, the eventual membership filter is `u.current_organization_id = v_org_id` — which is wrong regardless of how `v_org_id` was obtained.
+### 1.5 Pin a content hash of the three live function bodies as the audit anchor
+- Capture `md5(pg_get_functiondef(...))` for each of the three RPCs as of plan-execution date
+- If at execution time the hash differs from this anchor, integrate the diff before writing the migration (prevents silent body-drift between plan-write and plan-execute)
+- **Time estimate**: 2 minutes
 
-## Fix sketch
+## Phase 2: Migration
 
-Replace each `WHERE u.current_organization_id = v_org_id` with:
+### 2.1 Create migration via Supabase CLI
+- `cd infrastructure/supabase && supabase migration new fix_list_users_sister_functions_membership_gating`
+- **Time estimate**: 1 minute
+
+### 2.2 Rewrite the three function bodies
+Replace the predicate in all three function bodies (full bodies copied from live DB; only the WHERE clause + RPC shape comment change):
 
 ```sql
+-- BEFORE
+WHERE u.current_organization_id = v_org_id
+
+-- AFTER
 WHERE u.accessible_organizations @> ARRAY[v_org_id]::uuid[]
 ```
 
-Use the **`@>` containment form, NOT `= ANY(...)`** — PostgreSQL's GIN `array_ops` opclass indexes `@>`, `<@`, `&&`, `=` but does **not** support `scalar = ANY(column)`. PR #66 established this convention after a reviewer caught the `= ANY` form leaving the GIN index unused (see PR #66 architectural review, Finding 1). The same backing index (`idx_users_accessible_orgs_gin`, created in PR #66) covers all three sister functions; no new index needed.
+Single migration covering all three. Each function uses `CREATE OR REPLACE FUNCTION` (signature unchanged → OID preserved → existing COMMENT preserved). Re-emit `@a4c-rpc-shape: read` COMMENT defensively on each per Rule 17.
 
-Single migration covering all three functions. Each function should also consider whether the sister-specific tenancy guard (already present via `has_effective_permission('user.role_assign', ...)` for two of them; `public.get_current_org_id()` for `schedule_management`) needs adjustment after broadening the visible rowset — review case-by-case.
+**COMMENT prose differs by function** (verified live 2026-05-21):
+- `api.list_users_for_bulk_assignment` carries full descriptive prose today — **edit** to mention `accessible_organizations` as the membership oracle
+- `api.list_users_for_role_management` carries only the bare `@a4c-rpc-shape: read` tag — **author new prose** following the `list_users` shape (purpose + membership oracle + permission gate + shape tag)
+- `api.list_users_for_schedule_management` carries only the bare `@a4c-rpc-shape: read` tag — **author new prose** likewise
 
-## Test subjects (synthesize if absent)
+- **Time estimate**: 40 minutes (15 min rewrite predicates + 25 min author/edit prose for all three)
 
-A multi-org user is needed:
-- Has a `user_organizations_projection` row in two distinct orgs (so `accessible_organizations` contains both)
-- Has `current_organization_id` set to one of them
-- Has a role at the *other* org
+### 2.3 Local lint + dry-run
+- `supabase db lint --level warning` clean
+- `supabase db push --linked --dry-run` to confirm migration is recognized
+- **Time estimate**: 5 minutes
 
-Pre-fix: invisible in the other org's role-management UI.
-Post-fix: visible with their other-org role label.
+### 2.4 Deploy to dev
+- `supabase db push --linked`
+- If body iteration mid-PR is needed (as with PR #66): `supabase migration repair --linked --status reverted <timestamp>` + re-push (safe on feature branch per `memory/pr-63-close-out.md`)
+- **Time estimate**: 5 minutes
 
-On 2026-05-19 dev: this is the dakaratekid-style scenario described in PR #64 — but dakaratekid had her cross-provider native role revoked in the same migration. May need to construct a new synthetic test subject.
+## Phase 3: SQL smoke verification
 
-## Out of scope
+### 3.1 Construct or identify a multi-org test subject
+On dev today, **no multi-org users exist** (PR #66 pre-flight survey confirmed all 9 active users have `org_count ≤ 1`). Synthesize one for the smoke test using a **transactional harness** — INSERT, run all three RPCs, ROLLBACK in a single Management API SQL request so the projection-as-read-model invariant is never violated outside the transaction window:
 
-- Reframing what `current_organization_id` means architecturally — it's the active-session pointer, not a membership oracle, and changing that is a much larger card.
-- Fixing the routing-quirk symptom in `dev/active/investigate-auth-callback-priority-2-fallthrough.md` — different bug class, different cause.
-- The trigger-into-handler refactor proposed and declined for `trg_sync_accessible_orgs` (decided "needlessly heavy" 2026-05-19).
+```sql
+BEGIN;
+  -- Synthesize multi-org membership for lars.tice+test2 (currently testorg-only)
+  INSERT INTO public.user_organizations_projection (user_id, org_id, ...)
+    VALUES (
+      (SELECT id FROM public.users WHERE email = 'lars.tice+test2@gmail.com'),
+      '43ede501-5d88-44b5-a84b-53edeec0781f'  -- liveforlife
+    );
+  -- trg_sync_accessible_orgs reconciles users.accessible_organizations within-tx
+  -- Run the three RPC smoke calls here (Phase 3.2) — they observe the in-tx INSERT
+  SELECT email FROM api.list_users_for_role_management(...);
+  SELECT email FROM api.list_users_for_bulk_assignment(...);
+  SELECT email FROM api.list_users_for_schedule_management(...);
+ROLLBACK;
+-- Post-rollback: no projection drift, no event-stream divergence, no audit-trail noise
+```
+
+**Why transactional**: a direct INSERT without an event row violates the "projections derive from `domain_events`" invariant. ROLLBACK collapses the window to zero externally-observable state. If you must persist for any reason (e.g., UI walkthrough later), document the precise INSERT/DELETE SQL keyed on `(user_id, org_id)` and run a post-cleanup verification query (`SELECT accessible_organizations FROM users WHERE email = 'lars.tice+test2@gmail.com'`) to confirm the trigger reconciled back to the original.
+
+- **Time estimate**: 20 minutes (incl. building the transactional harness)
+
+### 3.2 Smoke each of the three RPCs
+For each sister function, call against `liveforlife` scope/template and assert the multi-org subject appears. **Schedule-management smoke prerequisite**: a liveforlife `schedule_templates_projection` row must exist. Add a Phase 1.4 inventory check; if absent, either (a) include template creation inside the transactional smoke harness (CREATE template → run RPC → ROLLBACK collapses both), or (b) skip the schedule-management smoke and accept the role+bulk-assignment smokes as sufficient evidence the pattern works (the schedule function uses the same predicate shape).
+
+```sql
+-- list_users_for_role_management
+SELECT email, current_roles, is_assigned
+  FROM api.list_users_for_role_management('<liveforlife-role-id>', 'liveforlife'::ltree, NULL, 100, 0);
+-- expected: synthesized multi-org subject is in the result set
+
+-- list_users_for_bulk_assignment
+SELECT email FROM api.list_users_for_bulk_assignment('<role-id>', 'liveforlife'::ltree, NULL, 100, 0);
+
+-- list_users_for_schedule_management
+SELECT email FROM api.list_users_for_schedule_management('<template-id>', NULL, 100, 0);
+```
+
+- **Time estimate**: 20 minutes
+
+### 3.3 Regression — pre-existing role-bearing users still appear
+For each of the three RPCs, confirm that liveforlife's known users (dakaratekid, rachel, troy) still appear with their correct roles/state flags. No over-restriction.
+
+- **Time estimate**: 10 minutes
+
+### 3.4 Cleanup
+- Revert the synthesized multi-org row (delete the `user_organizations_projection` row for the test subject; trigger reconciles `accessible_organizations`)
+- Confirm test subject returns to single-org state
+- **Time estimate**: 5 minutes
+
+## Phase 4: Documentation
+
+### 4.1 Update `documentation/architecture/authorization/rbac-architecture.md`
+- Section currently mentions `list_users_for_role_management` — verify its description doesn't make a claim about `current_organization_id`-based membership semantics that this PR invalidates
+- If yes: update to cite `accessible_organizations` and link to the new migration
+- Bump `last_updated` to ship date
+- **Time estimate**: 15 minutes
+
+### 4.2 Optional: note the GIN index is now load-bearing for 4 RPCs in `tables/users.md`
+- The `idx_users_accessible_orgs_gin` section already calls out the predicate-shape requirement and lists `api.list_users` as the consumer
+- Add a one-line note that the three sister RPCs also use it post-PR
+- Bump `last_updated`
+- **Time estimate**: 5 minutes
+
+### 4.3 Run docs Drift Checklist
+- Combined docs-writing skill + AGENT-GUIDELINES checks per the discipline established in PR #66
+- **Time estimate**: 5 minutes
+
+## Phase 5: Frontend validation (no code change expected)
+
+The frontend types (`database.types.ts`, `rpc-registry.generated.ts`) should be byte-identical to current state because:
+- No signature change (params, returns unchanged)
+- No new functions added or dropped
+- COMMENT body changes don't affect generated TS types
+
+Confirm via:
+- `cd frontend && npm run typecheck && npm run lint && npm run docs:check && npm run build`
+- All four checks must be green
+
+- **Time estimate**: 5 minutes
+
+## Phase 6: PR + closeout
+
+### 6.1 Open PR
+- Branch: `feat/list-users-sister-functions-membership-gating` (off main)
+- Title: `fix(api): list_users sister RPCs gate membership by accessible_organizations not current_organization_id`
+- Body: enumerate the three functions changed, cite PR #66 as the convention origin, call out super_admin invisibility as known-out-of-scope, note explicitly that PR #66's `COUNT(*) OVER ()` pattern is intentionally NOT applied here (these three RPCs don't return `total_count` — pagination total is consumer-side). Include before/after EXPLAIN if interesting (won't be — all three are tiny dev queries; index engagement is the same as PR #66)
+- **Time estimate**: 15 minutes
+
+### 6.2 Self-review (architect-style)
+- Apply the same review checklist used on PR #66
+- Verify: predicate shape correct, no over-restriction regression, no tenancy guard needed (the three RPCs already have permission gates — `has_effective_permission('user.role_assign', ...)` for two; `get_current_org_id()` for schedule)
+- **Time estimate**: 15 minutes
+
+### 6.3 UAT post-merge
+- Mechanical: re-deploy via CI; EXPLAIN sanity; CI gate for rpc-registry passes
+- UI (if a test subject can be synthesized in dev easily): johnltice (testorg admin) opens RolesManagePage → delete a role with assignments → verify the assigned-users dialog includes the synthetic multi-org user
+- **Time estimate**: 30 minutes
+
+### 6.4 Archive + memory closeout
+- `git mv dev/active/list-users-sister-functions-membership-gating/ dev/archived/`
+- Append closeout block to tasks.md
+- Update MEMORY.md last-groomed entry; demote previous entries one rung
+- The `pr-66-close-out.md` memory file already captures the `@>` convention — no new memory file needed unless surprises emerge
+- **Time estimate**: 20 minutes
+
+## Success Metrics
+
+### Immediate
+- [ ] All three function bodies in dev use `accessible_organizations @>` predicate (verified via `pg_get_functiondef`)
+- [ ] Synthesized multi-org subject appears in all three sister RPCs against the secondary org
+- [ ] Regression-free: pre-existing single-org users still appear correctly
+
+### Medium-Term
+- [ ] PR merges with re-review verdict (or zero new findings)
+- [ ] No CI gate regressions (`rpc-registry-sync.yml`, frontend gates all green)
+- [ ] Card archived to `dev/archived/`
+
+### Long-Term
+- [ ] When the cross-tenant grant pipeline ships (per `sub-tenant-admin-design/`), multi-org users are visible in role/schedule admin UIs by default — no separate fix needed
+- [ ] Future contributors writing user-listing RPCs follow the unified `accessible_organizations` membership pattern
+
+## Implementation Schedule
+
+| Phase | Duration | Cumulative |
+|---|---|---|
+| Phase 1 — Pre-flight | 15 min | 15 min |
+| Phase 2 — Migration | 40 min | 55 min |
+| Phase 3 — SQL smoke | 50 min | 1h 45m |
+| Phase 4 — Documentation | 25 min | 2h 10m |
+| Phase 5 — Frontend validation | 5 min | 2h 15m |
+| Phase 6 — PR + closeout | 80 min | 3h 35m |
+
+**Realistic estimate**: half a day end-to-end including PR review wait time.
+
+## Risk Mitigation
+
+| Risk | Mitigation |
+|---|---|
+| Synthesizing a multi-org test subject requires triggering full invitation lifecycle (slow + state-mutating on dev) | Use direct SQL insert into `user_organizations_projection` (the trigger reconciles `accessible_organizations` mechanically); cleanup via DELETE |
+| One of the three RPC bodies has drifted since 2026-05-19 (someone else touched it) | Phase 1.1 re-confirms; if drift exists, integrate the new shape and update the migration accordingly |
+| Migration body iteration mid-PR (as in PR #66) | Use `supabase migration repair --status reverted` + re-push pattern from `memory/pr-63-close-out.md` (safe on feature branches) |
+| Tenancy guard accidentally needed | The three RPCs already have permission gates (`user.role_assign` for two, `user.schedule_manage` for schedule). The membership predicate change doesn't broaden the attack surface beyond what those gates already allow. Confirm in self-review. |
+| docs:check or rpc-registry CI gate fails | Both already proven on PR #66; signature is unchanged so neither should trip. If they do, treat as a normal CI failure and fix in-PR. |
+| Super_admins still invisible (the known concern) | Acknowledged out-of-scope; document in the PR description so reviewers don't flag as a new issue. |
+
+## Risks NOT Mitigated (acknowledged out of scope)
+
+- **Super_admin invisibility in narrow-scope UIs**: super_admins (`current_organization_id = NULL`, `accessible_organizations IS NULL` per live dev — note: `memory/pr-66-close-out.md` mis-states this as `= []`; correct on next groom) remain invisible in all three sister UIs after this fix. PostgreSQL: `NULL::uuid[] @> ARRAY[v_org_id]::uuid[]` returns `NULL`, which WHERE clauses treat as not-matching → excluded. Super_admins have global permissions and rarely have specific `role_id` assignments at narrow ltree paths, so this is probably correct behavior — but if UX feedback says otherwise, file a separate card.
+- **Reframing `current_organization_id` semantics**: stays as the active-session pointer for direct-care use.
+- **Routing-quirk symptoms** in `dev/active/investigate-auth-callback-priority-2-fallthrough.md`: different bug class.
+- **Trigger-into-handler refactor** for `sync_accessible_organizations`: decided "needlessly heavy" during PR #66.
+
+## Next Steps After Completion
+
+After this card archives, the unified-visibility model is property of the system: all four `list_users*` RPCs share one membership oracle. Natural follow-ups (not blocking):
+
+1. If super_admin invisibility becomes a real UX issue, file a card to special-case `has_platform_privilege()` in the sister functions
+2. If the broader "URL-bar-vs-data divergence" observation from PR #66 T8 becomes painful, that's a separate cross-cutting card
+3. When `sub-tenant-admin-design/` work picks up, the membership predicate stays correct for the new multi-org grant flow — no rework needed
 
 ## Related
 
-- **Origin context**: `dev/archived/users-list-omits-roleless-members/` (PR #66) — surfaced this finding during the audit phase
-- **Architectural reference**: `documentation/architecture/data/provider-partners-architecture.md` — explains why multi-org users will become more common as cross-tenant grants land
-- **Trigger maintaining the membership oracle**: `public.sync_accessible_organizations()` (AFTER INSERT/UPDATE/DELETE on `user_organizations_projection`)
-- **Documentation that will need a similar review**: `documentation/architecture/authorization/rbac-architecture.md` (mentions `list_users_for_role_management`)
+- **Origin / convention source**: `dev/archived/users-list-omits-roleless-members/` (PR #66, merged 2026-05-20). Memory: `memory/pr-66-close-out.md`.
+- **Architectural reference**: `documentation/architecture/data/provider-partners-architecture.md` — explains why multi-org users will become more common as cross-tenant grants land.
+- **Trigger maintaining the membership oracle**: `public.sync_accessible_organizations()` (AFTER INSERT/UPDATE/DELETE on `user_organizations_projection`).
+- **Docs requiring review during Phase 4**: `documentation/architecture/authorization/rbac-architecture.md`, `documentation/infrastructure/reference/database/tables/users.md`.
+- **Pattern memory**: `memory/pr-66-close-out.md` — GIN `@>`-vs-`= ANY` predicate trap, read-RPC tenancy-guard pattern (not used here but documented), `COUNT(*) OVER ()` dedup precedent (not used here — these three RPCs don't paginate count separately).

--- a/dev/active/list-users-sister-functions-membership-gating/tasks.md
+++ b/dev/active/list-users-sister-functions-membership-gating/tasks.md
@@ -1,36 +1,104 @@
-# Tasks — list-users-sister-functions-membership-gating
+# Tasks: list-users-sister-functions-membership-gating
 
-## Investigation (do before planning)
+## Phase 1: Pre-flight verification ⏸️ PENDING
 
-- [ ] Re-confirm the three sister function bodies haven't changed since 2026-05-19 (run `SELECT pg_get_functiondef(...)` for each via Management API SQL).
-- [ ] Read each sister function's frontend caller to understand the UX implications of broadening the user list (any sort, pagination, or "already assigned" indicator that might surprise users).
-- [ ] Construct or identify a multi-org test subject (or document why one needs to be synthesized for UAT).
+- [ ] **1.1** Re-pull the three sister function bodies from live DB; confirm each still uses `WHERE u.current_organization_id = v_org_id` (no drift since 2026-05-19 audit)
+- [ ] **1.2** Confirm `idx_users_accessible_orgs_gin` is still present on `public.users`
+- [ ] **1.3** Re-grep frontend callers; confirm no consumer relies on the over-restrictive `current_organization_id` semantics:
+  - `frontend/src/services/roles/SupabaseRoleService.ts` (uses `list_users_for_bulk_assignment` + `list_users_for_role_management`)
+  - `frontend/src/services/schedule/SupabaseScheduleService.ts` (uses `list_users_for_schedule_management`)
+  - `frontend/src/pages/roles/RolesManagePage.tsx:438` (UI invocation of `listUsersForRoleManagement` during role deletion)
+- [ ] **1.4** Inventory liveforlife `schedule_templates_projection` rows; capture an `id` for the Phase 3.2 schedule-management smoke. If none exist, decide: create one inside the transactional harness, OR mark schedule smoke as N/A (the role + bulk-assignment smokes prove the pattern)
+- [ ] **1.5** Capture `md5(pg_get_functiondef(...))` for each of the three RPCs as a body-drift anchor; if hashes differ at migration-write time, integrate the diff first
 
-## Planning (after investigation)
+## Phase 2: Migration ⏸️ PENDING
 
-- [ ] Confirm the membership predicate replacement is `v_org_id = ANY(u.accessible_organizations)` and not a different shape (e.g., `EXISTS (SELECT 1 FROM user_organizations_projection ...)`).
-- [ ] Decide whether all three functions ship in one migration or three separate ones (one migration is simpler; per-function may be safer for review).
+- [ ] **2.1** `cd infrastructure/supabase && supabase migration new fix_list_users_sister_functions_membership_gating`
+- [ ] **2.2** Rewrite the three function bodies with `accessible_organizations @> ARRAY[v_org_id]::uuid[]` predicate:
+  - [ ] `api.list_users_for_role_management(p_role_id uuid, p_scope_path ltree, p_search_term text, p_limit int, p_offset int)`
+  - [ ] `api.list_users_for_bulk_assignment(p_role_id uuid, p_scope_path ltree, p_search_term text, p_limit int, p_offset int)`
+  - [ ] `api.list_users_for_schedule_management(p_template_id uuid, p_search_term text, p_limit int, p_offset int)`
+- [ ] **2.3** Re-emit `@a4c-rpc-shape: read` `COMMENT ON FUNCTION` on each (defensive per Rule 17)
+- [ ] **2.4a** Edit `api.list_users_for_bulk_assignment` COMMENT prose (existing prose) to mention `accessible_organizations` as the membership oracle
+- [ ] **2.4b** Author new COMMENT prose for `api.list_users_for_role_management` (currently bare `@a4c-rpc-shape: read` only); template after `list_users` shape — purpose + membership oracle + permission gate + shape tag
+- [ ] **2.4c** Author new COMMENT prose for `api.list_users_for_schedule_management` (currently bare `@a4c-rpc-shape: read` only); same template
+- [ ] **2.5** `supabase db lint --level warning` clean
+- [ ] **2.6** `supabase db push --linked --dry-run` confirms migration recognized
+- [ ] **2.7** `supabase db push --linked` applies cleanly
+- [ ] **2.8** If body iteration needed mid-PR: `supabase migration repair --linked --status reverted 2026...` + re-push (per `memory/pr-63-close-out.md`)
 
-## Migration
+## Phase 3: SQL smoke verification ⏸️ PENDING
 
-- [ ] `supabase migration new fix_list_users_sister_functions_membership_gating`
-- [ ] Replace the predicate in each of the three function bodies.
-- [ ] Re-emit `@a4c-rpc-shape: read` `COMMENT ON FUNCTION` per Rule 17 (defensive).
-- [ ] `supabase db lint --level warning` clean.
-- [ ] `supabase db push --linked` clean on dev.
+- [ ] **3.1** Build the transactional smoke harness (single Management API SQL request, `BEGIN; ... ROLLBACK;`):
+  - [ ] INSERT `user_organizations_projection` row giving `lars.tice+test2@gmail.com` liveforlife membership
+  - [ ] (Within same transaction) confirm `trg_sync_accessible_orgs` reconciled `accessible_organizations` to include liveforlife
+  - [ ] (Within same transaction) confirm `current_organization_id` stayed at testorg
+  - [ ] (Within same transaction) optionally CREATE a temporary `schedule_templates_projection` row for liveforlife if Phase 1.4 found none
+- [ ] **3.2** Inside the same transaction, smoke each of the three RPCs:
+  - [ ] `api.list_users_for_role_management('<liveforlife-role-id>', 'liveforlife'::ltree, NULL, 100, 0)` includes test subject
+  - [ ] `api.list_users_for_bulk_assignment('<role-id>', 'liveforlife'::ltree, NULL, 100, 0)` includes test subject
+  - [ ] `api.list_users_for_schedule_management('<template-id>', NULL, 100, 0)` includes test subject (skipped if Phase 1.4 found no template AND we chose not to create one in-tx)
+- [ ] **3.3** Regression (also within the same transaction): existing liveforlife members (dakaratekid, rachel, troy) still appear correctly in each
+- [ ] **3.4** ROLLBACK; confirm post-rollback state matches pre-flight (no projection drift; `accessible_organizations` for test subject is back to `[testorg]`; no temporary schedule template persists)
 
-## Verification
+## Phase 4: Documentation ⏸️ PENDING
 
-- [ ] SQL-level: call each of the three functions on dev with the multi-org test subject; assert the user now appears.
-- [ ] SQL-level: regression — pre-existing role-bearing users still appear.
-- [ ] UI walkthrough: open the Roles management page, Bulk Assignment dialog, and Schedule Management page; verify the multi-org user shows up and can be acted on.
+- [ ] **4.1** Review `documentation/architecture/authorization/rbac-architecture.md` for any claim about sister-RPC membership semantics that this PR invalidates; update + bump `last_updated`
+- [ ] **4.2** (Optional) Append note to `documentation/infrastructure/reference/database/tables/users.md` `idx_users_accessible_orgs_gin` section that the index is now load-bearing for 4 RPCs (was 1)
+- [ ] **4.3** Run combined docs-skill + AGENT-GUIDELINES Drift Checklist (last_updated, links, paths, code fences, AGENT-INDEX triggers — see `frontend/CLAUDE.md` and the docs-writing skill body)
 
-## Documentation
+## Phase 5: Frontend validation ⏸️ PENDING
 
-- [ ] `documentation/infrastructure/reference/database/tables/users.md` — add a note in the indexes section if the GIN index is now load-bearing for three more RPCs.
-- [ ] `documentation/architecture/authorization/rbac-architecture.md` — review the `list_users_for_role_management` section; if the doc body describes membership semantics, update to match.
+No frontend code change expected (signatures unchanged).
 
-## Closeout
+- [ ] **5.1** `cd frontend && npm run typecheck` — green
+- [ ] **5.2** `npm run lint` — green
+- [ ] **5.3** `npm run docs:check` — green
+- [ ] **5.4** `npm run build` — green
 
-- [ ] Open PR; reference this card and PR #66 as the origin.
-- [ ] On merge: archive card; update memory.
+## Phase 6: PR + closeout ⏸️ PENDING
+
+- [ ] **6.1** Create branch `feat/list-users-sister-functions-membership-gating` off main
+- [ ] **6.2** Commit all changes; push
+- [ ] **6.3** Open PR with title `fix(api): list_users sister RPCs gate membership by accessible_organizations not current_organization_id`
+- [ ] **6.4** PR body cites PR #66 as convention origin; enumerates the three functions; calls out the super_admin invisibility concern as known-out-of-scope; explicitly notes PR #66's `COUNT(*) OVER ()` pattern is NOT applied here (these RPCs don't return `total_count`) to preempt a "you should be consistent" review comment
+- [ ] **6.4a** UAT — UI walkthrough (post-merge, if multi-org subject can be reconstituted): johnltice (testorg admin) opens `RolesManagePage`; clicks **Delete role** on a role with assignments; verify the assigned-users dialog (driven by `RolesManagePage.tsx:438` → `listUsersForRoleManagement`) lists the synthesized multi-org subject
+- [ ] **6.5** Self-review (architect-style); apply PR #66 checklist
+- [ ] **6.6** On merge: monitor CI `Deploy Database Migrations` + `RPC Shape Registry Sync` for green
+- [ ] **6.7** Post-merge UAT — at minimum, EXPLAIN sanity + CI gate verification + (optional) UI walkthrough of role-deletion dialog if multi-org test subject can be reconstituted
+- [ ] **6.8** Archive card: `git mv dev/active/list-users-sister-functions-membership-gating/ dev/archived/`
+- [ ] **6.9** Append closeout block to archived `tasks.md` (UAT results table)
+- [ ] **6.10** Update `memory/MEMORY.md` last-groomed entry; demote previous entries one rung. The `pr-66-close-out.md` memory file already captures the `@>` convention — no new memory file needed unless surprises emerge.
+
+## Success Validation Checkpoints
+
+### Immediate Validation (post-Phase 3)
+- [ ] All three function bodies in dev use `accessible_organizations @>` predicate (verified via `pg_get_functiondef`)
+- [ ] Synthesized multi-org subject appears in all three sister RPCs against the secondary org
+- [ ] Pre-existing single-org users still appear correctly (zero regression)
+- [ ] `idx_users_accessible_orgs_gin` is the load-bearing index when seqscan is disabled (EXPLAIN sanity)
+
+### Feature Complete Validation (post-Phase 6)
+- [ ] PR merged; CI `Deploy Database Migrations` SUCCESS
+- [ ] CI `RPC Shape Registry Sync` SUCCESS (signatures unchanged but defensive re-emission of `@a4c-rpc-shape: read` should land cleanly)
+- [ ] Card archived; MEMORY.md groomed
+- [ ] Super_admin invisibility concern explicitly NOT fixed (per scope decision) and documented as such in PR description
+
+## Current Status
+
+**Phase**: Phase 1 — Pre-flight verification
+**Status**: ⏸️ PENDING (plan written 2026-05-21; architect-reviewed APPROVE WITH FINDINGS; punch list folded in; ready for execution)
+**Last Updated**: 2026-05-21
+**Next Step**: Run Phase 1.1–1.5 pre-flight checks (~22 min); then if all green, proceed to Phase 2 migration creation.
+
+## Architect-review punch list (already folded into the phases above)
+
+- ✅ **Finding #1** (Must-fix) — Phase 3.1 switched to transactional `BEGIN; ... ROLLBACK;` harness; no projection drift outside the in-tx window
+- ✅ **Finding #3** (Should-consider) — Phase 2.4 split into 2.4a/b/c reflecting that only `list_users_for_bulk_assignment` has existing prose; the other two need new prose authored
+- ✅ **Finding #4** (Should-consider) — Phase 1.4 added: inventory liveforlife schedule templates; if none, create in-tx or skip schedule smoke
+- ✅ **Finding #5** (Should-consider) — Phase 6.4 PR body explicitly preempts the `COUNT(*) OVER ()`-consistency review comment
+- ✅ **Finding #2** (Should-consider) — plan's risks section corrected to note super_admin `accessible_organizations IS NULL` (not `= []`); memory file note for next groom
+- ✅ **Finding #6** (Nit) — Phase 1.5 added: capture body-hash as drift anchor
+- ✅ **Finding #7** (Nit) — Phase 2.2 time estimate bumped to 40 min (15+25 split)
+- ✅ **Finding #8** (Nit) — Phase 6.4a UI walkthrough explicit on click-path and verification target
+- ⏸️ **Finding #9** (Nit) — `frontend/src/services/CLAUDE.md` + `infrastructure/supabase/CLAUDE.md` quick search-pass deferred to Phase 4 task 4.3 as part of the Drift Checklist

--- a/documentation/architecture/authorization/rbac-architecture.md
+++ b/documentation/architecture/authorization/rbac-architecture.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last_updated: 2026-05-06
+last_updated: 2026-05-21
 ---
 
 <!-- TL;DR-START -->
@@ -491,20 +491,30 @@ For bulk operations where administrators need to add and remove multiple role as
 
 #### `api.list_users_for_role_management`
 
-Returns all users in the organization with their current assignment status for a specific role.
+Returns all users in the organization with their current assignment status for a specific role at a specific scope. Membership gated by `users.accessible_organizations` (the canonical membership oracle, maintained by `trg_sync_accessible_orgs` from `user_organizations_projection`). Permission gated by `has_permission('user.role_assign')` within the requested scope path.
 
 ```sql
 -- Signature
-api.list_users_for_role_management(p_role_id uuid)
+api.list_users_for_role_management(
+  p_role_id     uuid,
+  p_scope_path  ltree,
+  p_search_term text    DEFAULT NULL,
+  p_limit       integer DEFAULT 100,
+  p_offset      integer DEFAULT 0
+)
 RETURNS TABLE (
-  user_id uuid,
-  email text,
-  name text,
-  is_assigned boolean  -- True if user currently has this role
+  id            uuid,
+  email         text,
+  display_name  text,            -- COALESCE(u.name, u.email)
+  is_active     boolean,
+  current_roles text[],          -- All role names this user currently holds
+  is_assigned   boolean          -- True if user currently has THIS role at THIS scope
 )
 ```
 
 **Usage**: Called when opening the role assignment dialog to show all eligible users with their current assignment state.
+
+**Sister functions** (`api.list_users_for_bulk_assignment`, `api.list_users_for_schedule_management`) share the same membership-oracle pattern. See migration `20260521195657_fix_list_users_sister_functions_membership_gating.sql` for the unified-visibility predicate convention established across all four `list_users*` RPCs (origin: PR #66).
 
 #### `api.sync_role_assignments`
 

--- a/documentation/architecture/authorization/rbac-architecture.md
+++ b/documentation/architecture/authorization/rbac-architecture.md
@@ -2,6 +2,8 @@
 status: current
 last_updated: 2026-05-21
 ---
+<!-- last_updated note: also touched on 2026-05-21 for PR #67 review-response — permission-gate description updated to has_effective_permission per architect Finding #5 -->
+
 
 <!-- TL;DR-START -->
 ## TL;DR
@@ -491,7 +493,7 @@ For bulk operations where administrators need to add and remove multiple role as
 
 #### `api.list_users_for_role_management`
 
-Returns all users in the organization with their current assignment status for a specific role at a specific scope. Membership gated by `users.accessible_organizations` (the canonical membership oracle, maintained by `trg_sync_accessible_orgs` from `user_organizations_projection`). Permission gated by `has_permission('user.role_assign')` within the requested scope path.
+Returns all users in the organization with their current assignment status for a specific role at a specific scope. Membership gated by `users.accessible_organizations` (the canonical membership oracle, maintained by `trg_sync_accessible_orgs` from `user_organizations_projection`). Permission gated by `has_effective_permission('user.role_assign', p_scope_path)` (verifies the caller holds the permission at a scope that contains the requested path).
 
 ```sql
 -- Signature

--- a/documentation/infrastructure/reference/database/tables/users.md
+++ b/documentation/infrastructure/reference/database/tables/users.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last_updated: 2026-05-20
+last_updated: 2026-05-21
 ---
 
 <!-- TL;DR-START -->
@@ -188,7 +188,7 @@ CREATE INDEX idx_users_accessible_orgs_gin ON public.users USING GIN (accessible
 - **Type**: GIN (Generalized Inverted Index) for array containment
 - **Usage**:
   - Find all users with access to an organization: `WHERE accessible_organizations @> ARRAY['<org-uuid>'::uuid]`
-  - Membership oracle queries in `api.list_users` and any other admin-list RPC
+  - Membership oracle queries in **all four** `list_users*` RPCs: `api.list_users`, `api.list_users_for_role_management`, `api.list_users_for_bulk_assignment`, `api.list_users_for_schedule_management`
   - Multi-tenant access queries
 - **Performance**: Essential for array containment queries
 - **Predicate-shape requirement**: PostgreSQL's GIN `array_ops` opclass indexes the containment operators (`@>`, `<@`, `&&`, `=`) but **not** the `scalar = ANY(column)` form. Always write `accessible_organizations @> ARRAY[<uuid>]::uuid[]` — the planner cannot rewrite `<uuid> = ANY(accessible_organizations)` into a GIN-eligible predicate, so the latter form will fall back to a sequential scan even with the index present.

--- a/infrastructure/supabase/CLAUDE.md
+++ b/infrastructure/supabase/CLAUDE.md
@@ -83,6 +83,29 @@ supabase migration repair --status reverted <version>
 
 **Note**: Docker/Podman is required for some Supabase CLI commands. Set `DOCKER_HOST=unix:///run/user/1000/podman/podman.sock` if using Podman.
 
+### Migration-session `SET search_path` gotcha (extension-typed parameters)
+
+Function-attribute `SET search_path TO 'public', 'extensions', ...` applies INSIDE the function body but **NOT during `CREATE OR REPLACE FUNCTION` parameter-type parsing**. Any migration that uses extension-typed parameters in a signature (`ltree`, `vector`, `pg_trgm`, etc.) will fail with `type "<type>" does not exist (SQLSTATE 42704)` unless the migration session's search_path includes `extensions`. Add a session-level `SET search_path = public, extensions, pg_temp;` at the top of the migration file before any such `CREATE OR REPLACE FUNCTION` statements. (Discovered in PR #67 when migration with `p_scope_path ltree` parameter failed first push.)
+
+### `list_users*` family pattern — three-step skeleton
+
+The four `api.list_users*` RPCs share a normalized three-step skeleton (established across PR #66 and PR #67):
+
+1. **Permission gate**: `IF NOT public.has_effective_permission('<perm>', <scope_path>) THEN RAISE EXCEPTION 'Missing permission: <perm>' USING ERRCODE = 'insufficient_privilege'; END IF;` (or, for the org-param shape, the early-return tenancy guard — see `list_users` exception below).
+2. **`v_org_id` derivation** (signature-dependent):
+   - org-param signature (`list_users`): `v_org_id := p_org_id` directly (with tenancy guard)
+   - scope-path signature (`list_users_for_role_management`, `list_users_for_bulk_assignment`): `SELECT o.id INTO v_org_id FROM organizations_projection o WHERE o.path = subpath(p_scope_path, 0, 1) AND o.deleted_at IS NULL;`
+   - template-id signature (`list_users_for_schedule_management`): `v_org_id := public.get_current_org_id();` then validate template belongs to that org
+3. **Membership-predicate query**: `WHERE u.accessible_organizations @> ARRAY[v_org_id]::uuid[]` — the canonical membership oracle, GIN-indexed via `idx_users_accessible_orgs_gin`. NEVER use `current_organization_id = v_org_id` (that's the user's active-session pointer, not a membership oracle) and NEVER use `scalar = ANY(accessible_organizations)` (GIN `array_ops` doesn't index that form — the `@>` containment form is required).
+
+**Variant**: `api.list_users` (PR #66) uses an early-return tenancy guard (`IF NOT (has_platform_privilege() OR p_org_id = get_current_org_id()) THEN RETURN; END IF;`) in place of the scope-bound permission gate, because its signature takes an explicit `p_org_id` parameter without a permission name. This guard is correct for the org-internal admin use case but is potentially incompatible with future cross-tenant grants — flagged for future audit when partner-grant work activates.
+
+**Two-step → one-step normalization (PR #67)**: legacy bodies that derived `v_user_scope := public.get_permission_scope(perm)` and then manually checked `v_user_scope @> p_scope_path` should be collapsed to a single `has_effective_permission(perm, p_scope_path)` call. This is strictly more correct under multi-scope JWT entries (cross-tenant grant scenario): `get_permission_scope` does `LIMIT 1`; `has_effective_permission` does `EXISTS`. Today they're observationally equivalent because `compute_effective_permissions` ends in `DISTINCT ON (permission_name)`, but that invariant is one cross-tenant-grant feature away from breaking.
+
+**Four-site distribution audit** (baseline_v4 grep for the two-step `'Requested scope is outside your permission scope'` error): `api.bulk_assign_role` (L362, mutation), `api.list_users_for_bulk_assignment` (L4705, visibility — normalized in PR #67), `api.list_users_for_role_management` (L4793, visibility — normalized in PR #67), `api.sync_role_assignments` (L5571, mutation). The two mutation siblings remain on the legacy pattern; a future card may extend normalization to them.
+
+**Pattern origin**: PR #66 introduced the `accessible_organizations @>` membership convention; PR #67 extended it to the three sister RPCs + normalized the permission-check helper. See `memory/pr-66-close-out.md` and (when written post-merge) `memory/pr-67-close-out.md` for the full close-out narratives.
+
 ## PL/pgSQL Validation (plpgsql_check)
 
 CI/CD validates all PL/pgSQL functions before deploying migrations. Catches column name mismatches, type errors, and other issues before reaching production.

--- a/infrastructure/supabase/supabase/migrations/20260521195657_fix_list_users_sister_functions_membership_gating.sql
+++ b/infrastructure/supabase/supabase/migrations/20260521195657_fix_list_users_sister_functions_membership_gating.sql
@@ -1,0 +1,428 @@
+-- ============================================================================
+-- Migration: fix_list_users_sister_functions_membership_gating
+-- Origin:    dev/active/list-users-sister-functions-membership-gating/
+-- Precedent: PR #66 (merged 2026-05-20, commit 33e77a4f) — established the
+--            `accessible_organizations @> ARRAY[<uuid>]::uuid[]` convention
+--            for membership-gated user-listing RPCs.
+-- ============================================================================
+--
+-- Problem
+-- -------
+-- Three sister RPCs to api.list_users carry a different but related smell:
+-- they gate user-list membership by `u.current_organization_id = v_org_id`.
+-- `current_organization_id` is the user's ACTIVE SESSION pointer (per memory,
+-- set via api.switch_org_unit at clock-in for direct-care staff; NULL for
+-- super_admin and platform-only users). It is NOT the membership oracle.
+--
+-- Consequence pre-fix: multi-org users (users with a row in
+-- user_organizations_projection for multiple orgs) are invisible in
+-- role-management, bulk-assignment, and schedule-assignment admin UIs unless
+-- their `current_organization_id` happens to match the target org. Same gap
+-- as PR #66's api.list_users, on three additional surfaces.
+--
+-- Today on dev the defect is dormant (no multi-org users exist), but it
+-- will become routine when the cross-tenant grant pipeline ships per
+-- dev/active/sub-tenant-admin-design/.
+--
+-- Fix
+-- ---
+-- Replace the predicate in all three function bodies:
+--
+--   BEFORE: WHERE u.current_organization_id = v_org_id
+--   AFTER:  WHERE u.accessible_organizations @> ARRAY[v_org_id]::uuid[]
+--
+-- `users.accessible_organizations` (uuid[]) is the canonical membership
+-- oracle, maintained by trigger trg_sync_accessible_orgs from
+-- user_organizations_projection. Same predicate shape PR #66 established
+-- for api.list_users; reuses the GIN index idx_users_accessible_orgs_gin
+-- created in that PR.
+--
+-- Predicate-shape note (re-stated from PR #66): PostgreSQL's GIN array_ops
+-- opclass indexes the containment operators (@>, <@, &&, =) but NOT
+-- `scalar = ANY(col)`. The `@>` form is the GIN-indexable shape; do not
+-- rewrite to `= ANY` without dropping the index.
+--
+-- Scope decisions (per architect-reviewed plan)
+-- ---------------------------------------------
+-- - NOT changing the per-function permission gates (each RPC already has
+--   one: has_effective_permission('user.role_assign', p_scope_path) for the
+--   two role-functions; has_effective_permission('user.schedule_manage',
+--   <ou_or_org_path>) for schedule_management). The predicate swap broadens
+--   what's enumerable AT a given scope, but the scope itself is still
+--   gated by the existing checks.
+-- - NOT reframing `current_organization_id` semantics — it remains the
+--   active-session pointer for direct-care use.
+-- - NOT addressing super_admin invisibility. Super_admins on dev have
+--   `current_organization_id IS NULL` AND `accessible_organizations IS NULL`.
+--   `NULL::uuid[] @> ARRAY[<uuid>]::uuid[]` returns NULL (treated as
+--   not-matching by WHERE), so super_admins remain excluded post-fix.
+--   They have global permissions and rarely have specific role_id
+--   assignments at narrow ltree paths, so this is acceptable. If UX
+--   feedback later disagrees, file a separate card.
+-- - NOT applying PR #66's COUNT(*) OVER () dedup pattern: these three RPCs
+--   don't return total_count; they paginate directly with LIMIT/OFFSET.
+--   Pagination total is a consumer-side concern.
+--
+-- COMMENT prose
+-- -------------
+-- - list_users_for_bulk_assignment had descriptive COMMENT prose pre-fix:
+--   edit to mention `accessible_organizations` as the membership oracle.
+-- - list_users_for_role_management and list_users_for_schedule_management
+--   carried only the bare `@a4c-rpc-shape: read` tag pre-fix: author full
+--   new prose blocks (purpose + membership oracle + permission gate +
+--   shape tag), modeled on api.list_users.
+--
+-- Body-drift anchor (captured 2026-05-21 pre-write — Phase 1.5):
+--   list_users_for_bulk_assignment    md5: 49e14e620a8b6fc8900cbc018ad5d6bc
+--   list_users_for_role_management    md5: e0805df19e3ae848c51df6a50103d059
+--   list_users_for_schedule_management md5: 3a08d7940a5e322e291ed558426706d8
+--
+-- Idempotent: all three are CREATE OR REPLACE FUNCTION (signature unchanged
+-- -> OID preserved -> existing COMMENT preserved; defensive re-emission
+-- handles future DROP+CREATE).
+--
+-- Session search_path note: the `ltree` parameter type lives in the
+-- `extensions` schema. The function-body `SET search_path` clauses apply
+-- inside the function but NOT during CREATE-time parameter type resolution.
+-- Set the migration-session search_path explicitly so `ltree` resolves.
+-- ============================================================================
+
+SET search_path = public, extensions, pg_temp;
+
+
+-- ============================================================================
+-- 1/3: api.list_users_for_bulk_assignment
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION api.list_users_for_bulk_assignment(
+  p_role_id     uuid,
+  p_scope_path  ltree,
+  p_search_term text    DEFAULT NULL,
+  p_limit       integer DEFAULT 100,
+  p_offset      integer DEFAULT 0
+)
+RETURNS TABLE(
+  id                  uuid,
+  email               text,
+  display_name        text,
+  is_active           boolean,
+  current_roles       text[],
+  is_already_assigned boolean
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $function$
+DECLARE
+  v_user_scope extensions.ltree;
+  v_org_id UUID;
+BEGIN
+  -- Get user's scope for permission check
+  v_user_scope := public.get_permission_scope('user.role_assign');
+
+  IF v_user_scope IS NULL THEN
+    RAISE EXCEPTION 'Missing permission: user.role_assign'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Verify requested scope is within user's scope
+  IF NOT (v_user_scope @> p_scope_path) THEN
+    RAISE EXCEPTION 'Requested scope is outside your permission scope'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Get organization ID from scope path (root of path)
+  SELECT o.id INTO v_org_id
+  FROM organizations_projection o
+  WHERE o.path = subpath(p_scope_path, 0, 1)
+    AND o.deleted_at IS NULL;
+
+  IF v_org_id IS NULL THEN
+    RAISE EXCEPTION 'Organization not found for scope path'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  RETURN QUERY
+  WITH user_current_roles AS (
+    -- Get current role names for each user
+    SELECT
+      ur.user_id,
+      array_agg(DISTINCT r.name ORDER BY r.name) AS role_names
+    FROM user_roles_projection ur
+    JOIN roles_projection r ON r.id = ur.role_id
+    WHERE r.deleted_at IS NULL
+      AND r.is_active = true
+    GROUP BY ur.user_id
+  ),
+  already_assigned AS (
+    -- Users already assigned to this role at this scope
+    SELECT ur.user_id
+    FROM user_roles_projection ur
+    WHERE ur.role_id = p_role_id
+      AND ur.scope_path = p_scope_path
+  )
+  SELECT
+    u.id,
+    u.email::TEXT,
+    COALESCE(u.name, u.email)::TEXT AS display_name,  -- Fallback to email if name is null
+    u.is_active,
+    COALESCE(ucr.role_names, ARRAY[]::TEXT[]) AS current_roles,
+    (aa.user_id IS NOT NULL) AS is_already_assigned
+  FROM users u
+  LEFT JOIN user_current_roles ucr ON ucr.user_id = u.id
+  LEFT JOIN already_assigned aa ON aa.user_id = u.id
+  -- Membership: canonical oracle is users.accessible_organizations (maintained
+  -- by trg_sync_accessible_orgs from user_organizations_projection). Replaces
+  -- the previous u.current_organization_id = v_org_id check, which conflated
+  -- the active-session pointer with organizational membership. See PR #66 and
+  -- migration 20260519233323_fix_list_users_include_roleless.sql for the
+  -- convention origin and the GIN-index rationale (idx_users_accessible_orgs_gin).
+  WHERE u.accessible_organizations @> ARRAY[v_org_id]::uuid[]
+    AND u.deleted_at IS NULL
+    AND (
+      p_search_term IS NULL
+      OR u.name ILIKE '%' || p_search_term || '%'
+      OR u.email ILIKE '%' || p_search_term || '%'
+    )
+  ORDER BY
+    is_already_assigned ASC,  -- Non-assigned first
+    COALESCE(u.name, u.email) ASC
+  LIMIT p_limit
+  OFFSET p_offset;
+END;
+$function$;
+
+-- Edit existing prose to mention accessible_organizations as the membership oracle.
+COMMENT ON FUNCTION api.list_users_for_bulk_assignment(uuid, ltree, text, integer, integer) IS
+$comment$List users in an organization eligible for bulk role assignment to a specific role at a specific scope. Includes current role names per user and an is_already_assigned flag. Membership gated by users.accessible_organizations (the canonical membership oracle, maintained by trg_sync_accessible_orgs from user_organizations_projection). Permission gated by has_permission('user.role_assign') within the requested scope path.
+
+@a4c-rpc-shape: read$comment$;
+
+
+-- ============================================================================
+-- 2/3: api.list_users_for_role_management
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION api.list_users_for_role_management(
+  p_role_id     uuid,
+  p_scope_path  ltree,
+  p_search_term text    DEFAULT NULL,
+  p_limit       integer DEFAULT 100,
+  p_offset      integer DEFAULT 0
+)
+RETURNS TABLE(
+  id            uuid,
+  email         text,
+  display_name  text,
+  is_active     boolean,
+  current_roles text[],
+  is_assigned   boolean
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $function$
+DECLARE
+  v_user_scope extensions.ltree;
+  v_org_id UUID;
+BEGIN
+  -- Get user's scope for permission check
+  v_user_scope := public.get_permission_scope('user.role_assign');
+
+  IF v_user_scope IS NULL THEN
+    RAISE EXCEPTION 'Missing permission: user.role_assign'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Verify requested scope is within user's scope
+  IF NOT (v_user_scope @> p_scope_path) THEN
+    RAISE EXCEPTION 'Requested scope is outside your permission scope'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Get organization ID from scope path (root of path)
+  SELECT o.id INTO v_org_id
+  FROM organizations_projection o
+  WHERE o.path = subpath(p_scope_path, 0, 1)
+    AND o.deleted_at IS NULL;
+
+  IF v_org_id IS NULL THEN
+    RAISE EXCEPTION 'Organization not found for scope path'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  RETURN QUERY
+  WITH user_current_roles AS (
+    -- Get current role names for each user (all roles, not just this one)
+    SELECT
+      ur.user_id,
+      array_agg(DISTINCT r.name ORDER BY r.name) AS role_names
+    FROM user_roles_projection ur
+    JOIN roles_projection r ON r.id = ur.role_id
+    WHERE r.deleted_at IS NULL
+      AND r.is_active = true
+    GROUP BY ur.user_id
+  ),
+  assigned_to_this_role AS (
+    -- Users assigned to THIS role at THIS scope
+    SELECT ur.user_id
+    FROM user_roles_projection ur
+    WHERE ur.role_id = p_role_id
+      AND ur.scope_path = p_scope_path
+  )
+  SELECT
+    u.id,
+    u.email::TEXT,
+    COALESCE(u.name, u.email)::TEXT AS display_name,
+    u.is_active,
+    COALESCE(ucr.role_names, ARRAY[]::TEXT[]) AS current_roles,
+    (atr.user_id IS NOT NULL) AS is_assigned
+  FROM users u
+  LEFT JOIN user_current_roles ucr ON ucr.user_id = u.id
+  LEFT JOIN assigned_to_this_role atr ON atr.user_id = u.id
+  -- See bulk_assignment comment block above for the membership-oracle rationale.
+  WHERE u.accessible_organizations @> ARRAY[v_org_id]::uuid[]
+    AND u.deleted_at IS NULL
+    AND (
+      p_search_term IS NULL
+      OR u.name ILIKE '%' || p_search_term || '%'
+      OR u.email ILIKE '%' || p_search_term || '%'
+    )
+  ORDER BY
+    is_assigned DESC,  -- Assigned users first (for easier review)
+    COALESCE(u.name, u.email) ASC
+  LIMIT p_limit
+  OFFSET p_offset;
+END;
+$function$;
+
+-- Author new prose (function previously carried only the bare shape tag).
+COMMENT ON FUNCTION api.list_users_for_role_management(uuid, ltree, text, integer, integer) IS
+$comment$List users in an organization with their assignment status for a specific role at a specific scope. Returns is_assigned flag distinguishing role-bearing users from candidates. Membership gated by users.accessible_organizations (the canonical membership oracle, maintained by trg_sync_accessible_orgs from user_organizations_projection). Permission gated by has_permission('user.role_assign') within the requested scope path. Used by the Roles management UI to enumerate assigned users when reviewing or deleting a role.
+
+@a4c-rpc-shape: read$comment$;
+
+
+-- ============================================================================
+-- 3/3: api.list_users_for_schedule_management
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION api.list_users_for_schedule_management(
+  p_template_id uuid,
+  p_search_term text    DEFAULT NULL,
+  p_limit       integer DEFAULT 100,
+  p_offset      integer DEFAULT 0
+)
+RETURNS TABLE(
+  id                    uuid,
+  email                 text,
+  display_name          text,
+  is_active             boolean,
+  is_assigned           boolean,
+  current_schedule_id   uuid,
+  current_schedule_name text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $function$
+#variable_conflict use_column
+DECLARE
+  v_org_id UUID;
+  v_template RECORD;
+BEGIN
+  -- Get organization from JWT
+  v_org_id := public.get_current_org_id();
+
+  IF v_org_id IS NULL THEN
+    RAISE EXCEPTION 'No organization context'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Validate template exists and belongs to org
+  -- Columns: schedule_templates_projection(id, schedule_name, org_unit_id, organization_id, ...)
+  SELECT t.id, t.schedule_name, t.org_unit_id INTO v_template
+  FROM schedule_templates_projection t
+  WHERE t.id = p_template_id
+    AND t.organization_id = v_org_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Schedule template not found'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  -- Permission check
+  -- Subqueries: organization_units_projection(id, path), organizations_projection(id, path)
+  IF NOT public.has_effective_permission(
+    'user.schedule_manage',
+    COALESCE(
+      (SELECT oup.path FROM organization_units_projection oup WHERE oup.id = v_template.org_unit_id),
+      (SELECT op.path FROM organizations_projection op WHERE op.id = v_org_id)
+    )
+  ) THEN
+    RAISE EXCEPTION 'Missing permission: user.schedule_manage'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  RETURN QUERY
+  WITH user_current_schedule AS (
+    -- For each user, find their current schedule assignment (if any)
+    -- Columns: schedule_user_assignments_projection(user_id, schedule_template_id, organization_id, ...)
+    -- Columns: schedule_templates_projection(id, schedule_name, ...)
+    SELECT
+      sua.user_id,
+      sua.schedule_template_id,
+      st.schedule_name AS schedule_name
+    FROM schedule_user_assignments_projection sua
+    JOIN schedule_templates_projection st ON st.id = sua.schedule_template_id
+    WHERE sua.organization_id = v_org_id
+  ),
+  assigned_to_this_template AS (
+    -- Users assigned to THIS template
+    SELECT sua.user_id
+    FROM schedule_user_assignments_projection sua
+    WHERE sua.schedule_template_id = p_template_id
+  )
+  SELECT
+    u.id,
+    u.email::TEXT,
+    COALESCE(u.name, u.email)::TEXT AS display_name,
+    u.is_active,
+    (att.user_id IS NOT NULL) AS is_assigned,
+    -- Only show current schedule if on a DIFFERENT template
+    CASE
+      WHEN ucs.schedule_template_id IS NOT NULL
+        AND ucs.schedule_template_id <> p_template_id
+      THEN ucs.schedule_template_id
+      ELSE NULL
+    END AS current_schedule_id,
+    CASE
+      WHEN ucs.schedule_template_id IS NOT NULL
+        AND ucs.schedule_template_id <> p_template_id
+      THEN ucs.schedule_name
+      ELSE NULL
+    END AS current_schedule_name
+  FROM users u
+  LEFT JOIN user_current_schedule ucs ON ucs.user_id = u.id
+  LEFT JOIN assigned_to_this_template att ON att.user_id = u.id
+  -- See bulk_assignment comment block above for the membership-oracle rationale.
+  WHERE u.accessible_organizations @> ARRAY[v_org_id]::uuid[]
+    AND u.deleted_at IS NULL
+    AND (
+      p_search_term IS NULL
+      OR u.name ILIKE '%' || p_search_term || '%'
+      OR u.email ILIKE '%' || p_search_term || '%'
+    )
+  ORDER BY
+    is_assigned DESC,
+    display_name ASC
+  LIMIT p_limit
+  OFFSET p_offset;
+END;
+$function$;
+
+-- Author new prose (function previously carried only the bare shape tag).
+COMMENT ON FUNCTION api.list_users_for_schedule_management(uuid, text, integer, integer) IS
+$comment$List users in an organization with their assignment status for a specific schedule template. Returns is_assigned flag plus current_schedule_id/name when the user is on a DIFFERENT template (helps reviewers see where they'd move from). Membership gated by users.accessible_organizations (the canonical membership oracle, maintained by trg_sync_accessible_orgs from user_organizations_projection). Permission gated by has_effective_permission('user.schedule_manage', <ou_path OR org_path>) where the path derives from the template's org_unit_id (or the org root if the template is org-scoped).
+
+@a4c-rpc-shape: read$comment$;

--- a/infrastructure/supabase/supabase/migrations/20260521195657_fix_list_users_sister_functions_membership_gating.sql
+++ b/infrastructure/supabase/supabase/migrations/20260521195657_fix_list_users_sister_functions_membership_gating.sql
@@ -3,74 +3,61 @@
 -- Origin:    dev/active/list-users-sister-functions-membership-gating/
 -- Precedent: PR #66 (merged 2026-05-20, commit 33e77a4f) — established the
 --            `accessible_organizations @> ARRAY[<uuid>]::uuid[]` convention
---            for membership-gated user-listing RPCs.
+--            as the canonical membership oracle for user-listing RPCs.
 -- ============================================================================
 --
--- Problem
--- -------
--- Three sister RPCs to api.list_users carry a different but related smell:
--- they gate user-list membership by `u.current_organization_id = v_org_id`.
--- `current_organization_id` is the user's ACTIVE SESSION pointer (per memory,
--- set via api.switch_org_unit at clock-in for direct-care staff; NULL for
--- super_admin and platform-only users). It is NOT the membership oracle.
+-- What this does
+-- --------------
+-- Two changes across the three `list_users_for_*` visibility-class RPCs:
 --
--- Consequence pre-fix: multi-org users (users with a row in
--- user_organizations_projection for multiple orgs) are invisible in
--- role-management, bulk-assignment, and schedule-assignment admin UIs unless
--- their `current_organization_id` happens to match the target org. Same gap
--- as PR #66's api.list_users, on three additional surfaces.
+-- (1) Membership predicate swap: `WHERE u.current_organization_id = v_org_id`
+--     → `WHERE u.accessible_organizations @> ARRAY[v_org_id]::uuid[]`.
+--     Reuses the GIN index idx_users_accessible_orgs_gin from PR #66.
+--     Fixes the multi-org-user invisibility gap that the active-session
+--     pointer (`current_organization_id`) created.
 --
--- Today on dev the defect is dormant (no multi-org users exist), but it
--- will become routine when the cross-tenant grant pipeline ships per
--- dev/active/sub-tenant-admin-design/.
+-- (2) Permission-check normalization (role-functions only — schedule already
+--     uses this shape): collapse `v_user_scope := get_permission_scope(...)
+--     + manual ltree @> check` into a single `has_effective_permission(perm,
+--     scope_path)` call. All three sister RPCs now share the permission-
+--     check helper. See infrastructure/supabase/CLAUDE.md §"`list_users*`
+--     family pattern — three-step skeleton" for the full pattern doc.
 --
--- Fix
--- ---
--- Replace the predicate in all three function bodies:
+-- Four-site distribution of the prior two-step pattern
+-- ----------------------------------------------------
+-- A grep of baseline_v4 for the two-step pattern's "Requested scope is
+-- outside your permission scope" error message finds FOUR sites:
 --
---   BEFORE: WHERE u.current_organization_id = v_org_id
---   AFTER:  WHERE u.accessible_organizations @> ARRAY[v_org_id]::uuid[]
+--   L362  api.bulk_assign_role            (mutation; out of scope)
+--   L4705 api.list_users_for_bulk_assignment (visibility; normalized here)
+--   L4793 api.list_users_for_role_management (visibility; normalized here)
+--   L5571 api.sync_role_assignments        (mutation; out of scope)
 --
--- `users.accessible_organizations` (uuid[]) is the canonical membership
--- oracle, maintained by trigger trg_sync_accessible_orgs from
--- user_organizations_projection. Same predicate shape PR #66 established
--- for api.list_users; reuses the GIN index idx_users_accessible_orgs_gin
--- created in that PR.
+-- This PR normalizes the two VISIBILITY-class siblings only. The two
+-- MUTATION-class siblings are intentionally out of scope: mutations carry
+-- side-effect risk warranting a focused diff, and PR #67 is scoped by both
+-- card title and architect-blessed plan to "list_users sister RPCs." Short-
+-- term visibility/mutation inconsistency in permission-check style is
+-- acceptable; no user-observable behavior changes. Future normalization
+-- card may extend to the mutation siblings.
 --
--- Predicate-shape note (re-stated from PR #66): PostgreSQL's GIN array_ops
--- opclass indexes the containment operators (@>, <@, &&, =) but NOT
--- `scalar = ANY(col)`. The `@>` form is the GIN-indexable shape; do not
--- rewrite to `= ANY` without dropping the index.
+-- Tripwire — why the permission-check refactor is strictly more correct
+-- ---------------------------------------------------------------------
+-- The two-step pattern (get_permission_scope LIMIT 1, manual @> check) is
+-- observationally equivalent to has_effective_permission (EXISTS) TODAY
+-- because compute_effective_permissions (baseline_v4:6932-6985) ends in
+-- `SELECT DISTINCT ON (permission_name)` — JWT carries at most one entry
+-- per permission name. If that invariant is ever broken (e.g., cross-tenant
+-- grants ship and produce multiple effective_permissions entries for the
+-- same permission at different scopes), the LIMIT-1 pattern silently picks
+-- first and may miss a valid match; the EXISTS pattern correctly ORs across
+-- all entries. The refactor removes a latent correctness bug ahead of the
+-- cross-tenant grant work captured in dev/active/sub-tenant-admin-design/.
 --
--- Scope decisions (per architect-reviewed plan)
--- ---------------------------------------------
--- - NOT changing the per-function permission gates (each RPC already has
---   one: has_effective_permission('user.role_assign', p_scope_path) for the
---   two role-functions; has_effective_permission('user.schedule_manage',
---   <ou_or_org_path>) for schedule_management). The predicate swap broadens
---   what's enumerable AT a given scope, but the scope itself is still
---   gated by the existing checks.
--- - NOT reframing `current_organization_id` semantics — it remains the
---   active-session pointer for direct-care use.
--- - NOT addressing super_admin invisibility. Super_admins on dev have
---   `current_organization_id IS NULL` AND `accessible_organizations IS NULL`.
---   `NULL::uuid[] @> ARRAY[<uuid>]::uuid[]` returns NULL (treated as
---   not-matching by WHERE), so super_admins remain excluded post-fix.
---   They have global permissions and rarely have specific role_id
---   assignments at narrow ltree paths, so this is acceptable. If UX
---   feedback later disagrees, file a separate card.
--- - NOT applying PR #66's COUNT(*) OVER () dedup pattern: these three RPCs
---   don't return total_count; they paginate directly with LIMIT/OFFSET.
---   Pagination total is a consumer-side concern.
---
--- COMMENT prose
--- -------------
--- - list_users_for_bulk_assignment had descriptive COMMENT prose pre-fix:
---   edit to mention `accessible_organizations` as the membership oracle.
--- - list_users_for_role_management and list_users_for_schedule_management
---   carried only the bare `@a4c-rpc-shape: read` tag pre-fix: author full
---   new prose blocks (purpose + membership oracle + permission gate +
---   shape tag), modeled on api.list_users.
+-- Migration-session search_path note: the `ltree` parameter type lives in
+-- the `extensions` schema. Function-attribute `SET search_path` does NOT
+-- apply during CREATE-time parameter parsing — set session-level so `ltree`
+-- resolves. (Pattern codified in infrastructure/supabase/CLAUDE.md.)
 --
 -- Body-drift anchor (captured 2026-05-21 pre-write — Phase 1.5):
 --   list_users_for_bulk_assignment    md5: 49e14e620a8b6fc8900cbc018ad5d6bc
@@ -80,11 +67,6 @@
 -- Idempotent: all three are CREATE OR REPLACE FUNCTION (signature unchanged
 -- -> OID preserved -> existing COMMENT preserved; defensive re-emission
 -- handles future DROP+CREATE).
---
--- Session search_path note: the `ltree` parameter type lives in the
--- `extensions` schema. The function-body `SET search_path` clauses apply
--- inside the function but NOT during CREATE-time parameter type resolution.
--- Set the migration-session search_path explicitly so `ltree` resolves.
 -- ============================================================================
 
 SET search_path = public, extensions, pg_temp;
@@ -114,20 +96,16 @@ SECURITY DEFINER
 SET search_path TO 'public', 'extensions', 'pg_temp'
 AS $function$
 DECLARE
-  v_user_scope extensions.ltree;
   v_org_id UUID;
 BEGIN
-  -- Get user's scope for permission check
-  v_user_scope := public.get_permission_scope('user.role_assign');
-
-  IF v_user_scope IS NULL THEN
+  -- Permission gate: caller must hold user.role_assign at a scope that
+  -- contains p_scope_path. Uses has_effective_permission (EXISTS over JWT
+  -- effective_permissions) which correctly ORs across multiple matching
+  -- entries — forward-compatible with future cross-tenant grants. See
+  -- header for the DISTINCT ON tripwire that makes the prior two-step
+  -- pattern observationally equivalent today.
+  IF NOT public.has_effective_permission('user.role_assign', p_scope_path) THEN
     RAISE EXCEPTION 'Missing permission: user.role_assign'
-      USING ERRCODE = 'insufficient_privilege';
-  END IF;
-
-  -- Verify requested scope is within user's scope
-  IF NOT (v_user_scope @> p_scope_path) THEN
-    RAISE EXCEPTION 'Requested scope is outside your permission scope'
       USING ERRCODE = 'insufficient_privilege';
   END IF;
 
@@ -192,9 +170,8 @@ BEGIN
 END;
 $function$;
 
--- Edit existing prose to mention accessible_organizations as the membership oracle.
 COMMENT ON FUNCTION api.list_users_for_bulk_assignment(uuid, ltree, text, integer, integer) IS
-$comment$List users in an organization eligible for bulk role assignment to a specific role at a specific scope. Includes current role names per user and an is_already_assigned flag. Membership gated by users.accessible_organizations (the canonical membership oracle, maintained by trg_sync_accessible_orgs from user_organizations_projection). Permission gated by has_permission('user.role_assign') within the requested scope path.
+$comment$List users in an organization eligible for bulk role assignment to a specific role at a specific scope. Includes current role names per user and an is_already_assigned flag. Membership gated by users.accessible_organizations (the canonical membership oracle, maintained by trg_sync_accessible_orgs from user_organizations_projection). Permission gated by has_effective_permission('user.role_assign', p_scope_path) (verifies the caller holds the permission at a scope that contains the requested path).
 
 @a4c-rpc-shape: read$comment$;
 
@@ -223,20 +200,16 @@ SECURITY DEFINER
 SET search_path TO 'public', 'extensions', 'pg_temp'
 AS $function$
 DECLARE
-  v_user_scope extensions.ltree;
   v_org_id UUID;
 BEGIN
-  -- Get user's scope for permission check
-  v_user_scope := public.get_permission_scope('user.role_assign');
-
-  IF v_user_scope IS NULL THEN
+  -- Permission gate: caller must hold user.role_assign at a scope that
+  -- contains p_scope_path. Uses has_effective_permission (EXISTS over JWT
+  -- effective_permissions) which correctly ORs across multiple matching
+  -- entries — forward-compatible with future cross-tenant grants. See
+  -- header for the DISTINCT ON tripwire that makes the prior two-step
+  -- pattern observationally equivalent today.
+  IF NOT public.has_effective_permission('user.role_assign', p_scope_path) THEN
     RAISE EXCEPTION 'Missing permission: user.role_assign'
-      USING ERRCODE = 'insufficient_privilege';
-  END IF;
-
-  -- Verify requested scope is within user's scope
-  IF NOT (v_user_scope @> p_scope_path) THEN
-    RAISE EXCEPTION 'Requested scope is outside your permission scope'
       USING ERRCODE = 'insufficient_privilege';
   END IF;
 
@@ -296,9 +269,8 @@ BEGIN
 END;
 $function$;
 
--- Author new prose (function previously carried only the bare shape tag).
 COMMENT ON FUNCTION api.list_users_for_role_management(uuid, ltree, text, integer, integer) IS
-$comment$List users in an organization with their assignment status for a specific role at a specific scope. Returns is_assigned flag distinguishing role-bearing users from candidates. Membership gated by users.accessible_organizations (the canonical membership oracle, maintained by trg_sync_accessible_orgs from user_organizations_projection). Permission gated by has_permission('user.role_assign') within the requested scope path. Used by the Roles management UI to enumerate assigned users when reviewing or deleting a role.
+$comment$List users in an organization with their assignment status for a specific role at a specific scope. Returns is_assigned flag distinguishing role-bearing users from candidates. Membership gated by users.accessible_organizations (the canonical membership oracle, maintained by trg_sync_accessible_orgs from user_organizations_projection). Permission gated by has_effective_permission('user.role_assign', p_scope_path) (verifies the caller holds the permission at a scope that contains the requested path). Used by the Roles management UI to enumerate assigned users when reviewing or deleting a role.
 
 @a4c-rpc-shape: read$comment$;
 
@@ -421,8 +393,7 @@ BEGIN
 END;
 $function$;
 
--- Author new prose (function previously carried only the bare shape tag).
 COMMENT ON FUNCTION api.list_users_for_schedule_management(uuid, text, integer, integer) IS
-$comment$List users in an organization with their assignment status for a specific schedule template. Returns is_assigned flag plus current_schedule_id/name when the user is on a DIFFERENT template (helps reviewers see where they'd move from). Membership gated by users.accessible_organizations (the canonical membership oracle, maintained by trg_sync_accessible_orgs from user_organizations_projection). Permission gated by has_effective_permission('user.schedule_manage', <ou_path OR org_path>) where the path derives from the template's org_unit_id (or the org root if the template is org-scoped).
+$comment$List users in an organization with their assignment status for a specific schedule template. Returns is_assigned flag plus current_schedule_id/name when the user is on a DIFFERENT template (helps reviewers see where they'd move from). Membership gated by users.accessible_organizations (the canonical membership oracle, maintained by trg_sync_accessible_orgs from user_organizations_projection). Permission gated by has_effective_permission('user.schedule_manage', <ou_path OR org_path>) (verifies the caller holds the permission at a scope that contains the template's org_unit_id path, or the org root if the template is org-scoped).
 
 @a4c-rpc-shape: read$comment$;


### PR DESCRIPTION
## Summary

Three sister RPCs to \`api.list_users\` carried a different but related smell from PR #66's fix: they gated user-list membership by \`u.current_organization_id = v_org_id\`. \`current_organization_id\` is the user's **active session pointer**, not a membership oracle. Multi-org users were invisible in role-management, bulk-assignment, and schedule-assignment admin UIs unless their session pointer happened to match the target org.

This PR applies PR #66's \`accessible_organizations @> ARRAY[v_org_id]::uuid[]\` convention to all three:

- \`api.list_users_for_role_management\`
- \`api.list_users_for_bulk_assignment\`
- \`api.list_users_for_schedule_management\`

Reuses \`idx_users_accessible_orgs_gin\` from PR #66; no new index needed.

## Architect review

Plan was architect-reviewed before implementation — verdict **APPROVE WITH FINDINGS** (1 must-fix + 4 should-considers + 4 nits, all folded into the plan before execution). See \`dev/active/list-users-sister-functions-membership-gating/tasks.md\` "Architect-review punch list" for the resolution table.

Notably: the architect's must-fix (Phase 3 smoke synthesis was leaking the projection-as-read-model invariant) drove the transactional \`BEGIN; ... ROLLBACK;\` harness used during verification — see "Smoke verification" below.

## Smoke verification (transactional, zero externally observable drift)

Synthesized \`lars.tice+test2@gmail.com\` multi-org membership (testorg → also liveforlife) inside a single Management API SQL transaction with JWT-claim simulation (dakaratekid's effective_permissions shape), ran all three RPCs against liveforlife, then ROLLBACK. Post-rollback verification confirms zero drift.

| Verification | Result |
|---|---|
| In-tx INSERT visible; trigger reconciled \`accessible_organizations\` | \`[testorg, liveforlife]\` ✓ |
| Test subject \`current_organization_id\` unchanged | Still \`testorg\` ✓ |
| \`list_users_for_role_management\` surfaces test subject | ✓ (\`is_assigned: false\`, \`current_roles: []\`) |
| \`list_users_for_bulk_assignment\` surfaces test subject | ✓ (\`is_already_assigned: false\`) |
| \`list_users_for_schedule_management\` surfaces test subject | ✓ (\`is_assigned: false\`) |
| Regression: existing liveforlife members (dakaratekid, rachel, troy) | ✓ all still appear with correct flags |
| Post-ROLLBACK projection state | Identical to pre-flight (0 rows for test2+liveforlife in user_organizations_projection) |

## Migration session search_path note

Parameter type \`ltree\` lives in the \`extensions\` schema. The function-body \`SET search_path TO 'public', 'extensions', 'pg_temp'\` clauses apply INSIDE the function body but NOT during \`CREATE OR REPLACE\`'s parameter type resolution. First push failed with \`type ltree does not exist (SQLSTATE 42704)\`. Fix: added \`SET search_path = public, extensions, pg_temp;\` at the top of the migration so \`ltree\` resolves during parsing. This pattern may be worth noting in the supabase-CLAUDE.md for future ltree-parameter migrations.

## Out of scope (per architect-approved plan)

- **Super_admin invisibility**: super_admins have \`current_organization_id IS NULL\` AND \`accessible_organizations IS NULL\` (note: live state on dev is \`NULL\`, not \`[]\` as the PR #66 close-out memory states — that's a memory-file accuracy note for next groom). Both pre-fix and post-fix predicates exclude them. They have global permissions, not narrow-scope \`role_id\` rows, so this is acceptable.
- **\`COUNT(*) OVER ()\` dedup pattern from PR #66**: intentionally NOT applied here. These three RPCs don't return \`total_count\`; pagination total is a consumer-side concern. Preempts a "you should be consistent" review comment.
- **Reframing \`current_organization_id\` semantics**: stays as the active-session pointer for direct-care use.

## Docs touched (small adjacent edits)

- \`documentation/architecture/authorization/rbac-architecture.md\`: fixed pre-existing signature/return-shape drift on the \`list_users_for_role_management\` entry (was showing 1-of-5 params and 4 wrong return columns) while adjacent to the change. Added cross-reference to the sister functions. Bumped \`last_updated\`.
- \`documentation/infrastructure/reference/database/tables/users.md\`: updated \`idx_users_accessible_orgs_gin\` section to note it's now load-bearing for all four \`list_users*\` RPCs (was 1 post-PR-66). Bumped \`last_updated\`.

## Frontend impact

No code change required — signatures unchanged. \`database.types.ts\` and \`rpc-registry.generated.ts\` byte-identical (verified via \`npm run typecheck && npm run lint && npm run docs:check && npm run build\` — all green).

## Card

\`dev/active/list-users-sister-functions-membership-gating/\` — will be archived on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)