### PR TITLE
chore(ci): bump Node-20-era actions ahead of 2026-06-02 default flip

### DIFF
--- a/.github/workflows/edge-functions-deploy.yml
+++ b/.github/workflows/edge-functions-deploy.yml
@@ -141,7 +141,7 @@ jobs:
           deno-version: v2.x
 
       - name: Setup Supabase CLI
-        uses: supabase/setup-cli@v1
+        uses: supabase/setup-cli@v2
         with:
           version: latest
 

--- a/.github/workflows/rpc-registry-sync.yml
+++ b/.github/workflows/rpc-registry-sync.yml
@@ -33,12 +33,12 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
 
       - name: Install Supabase CLI
-        uses: supabase/setup-cli@v1
+        uses: supabase/setup-cli@v2
         with:
           version: latest
 

--- a/.github/workflows/supabase-edge-functions-test.yml
+++ b/.github/workflows/supabase-edge-functions-test.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Set up Deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@v2
         with:
           deno-version: v1.x
 

--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Supabase CLI
-        uses: supabase/setup-cli@v1
+        uses: supabase/setup-cli@v2
         with:
           version: latest
 
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Supabase CLI
-        uses: supabase/setup-cli@v1
+        uses: supabase/setup-cli@v2
         with:
           version: latest
 


### PR DESCRIPTION
## Summary

GitHub Actions defaults flip to Node 24 on **2026-06-02** (Node-20 hard removal **2026-09-16**, per the [2025-09-19 changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). This PR bumps the five remaining Node-20-era pins in our workflow fleet to current majors.

## Changes

| File | Before | After |
|---|---|---|
| `.github/workflows/supabase-migrations.yml` (×2) | `supabase/setup-cli@v1` | `@v2` |
| `.github/workflows/rpc-registry-sync.yml` | `actions/setup-node@v4` + `supabase/setup-cli@v1` | `@v5` + `@v2` |
| `.github/workflows/edge-functions-deploy.yml` | `supabase/setup-cli@v1` | `@v2` |
| `.github/workflows/supabase-edge-functions-test.yml` | `denoland/setup-deno@v1` | `@v2` |

## Why no usage changes

- **`supabase/setup-cli@v2`**: pure internal refresh (switch to composite action, Bun-based build, version-resolution improvements). Our pattern (`with: version: latest`) is unaffected — the new lockfile-detection behavior only kicks in if `version` is omitted.
- **`actions/setup-node@v5`**: only breaking change is automatic caching when `packageManager` field exists in `package.json`. We verified `frontend/package.json` has no `packageManager` field → no behavior change. Matches the fleet — `frontend-deploy.yml` and `contracts-validation.yml` are already on v5.
- **`denoland/setup-deno@v2`**: already battle-tested in `edge-functions-deploy.yml`. `deno-version: v1.x` is preserved (separate from action's own Node runtime).

## CI coverage

This PR touches CI workflow definitions only. Expected check behavior:
- **`Deploy Edge Functions`**, **`Deploy Database Migrations`** — push-to-main only (no PR trigger). Will exercise the new pins on merge.
- **`RPC Shape Registry Sync`** — should run on this PR but only when migrations/registry change (path-filtered). May not trigger here; will validate on the next migration PR.
- **`Edge Function Deno Tests`** — should run on this PR but only when `functions/**` changes (path-filtered). May not trigger; will validate on the next EF PR.

If the path-filtered workflows don't fire on this PR, the merge-to-main behavior is the smoke test (low risk: pure pin bumps, no API or behavior changes).

## Out of scope

- Bumping minor versions of already-modern actions (`@v5`, `@v6`, `@v7`).
- Pinning to SHAs for supply-chain hardening (separate concern).
- Bumping `deno-version: v1.x` → `v2.x` in the test workflow (the deploy workflow already runs Deno 2; aligning the test runtime is a separate concern, not required to clear the Node-20 deprecation).
- Auditing Temporal worker Docker images for Node 20 (runtime images, not GitHub Actions).

## Source card

`dev/active/github-actions-node-20-deprecation-seed.md` (seeded 2026-05-21 post-PR #67 deprecation annotation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)