### PR TITLE
docs(card): UAT setup detail + REAL DEFECT seed (grant.* not seeded into provider_admin)

### DIFF
--- a/dev/active/phase-2-uat-var-partnership-lifecycle-seed.md
+++ b/dev/active/phase-2-uat-var-partnership-lifecycle-seed.md
@@ -24,9 +24,75 @@ Plus the architect's **N2** finding (PR #71 review): Step 8 `api.create_access_g
 
 ### Setup (one-time per environment)
 
-1. Seed a test `provider_partner` org via the standard partner-org bootstrap (or direct SQL fixture if bootstrap is too heavy for UAT — document either way).
-2. Seed a provider-admin user holding `partnership.manage` at the provider org path AND `grant.create` / `grant.revoke`.
-3. Capture both orgs + the provider-admin user UUIDs for the test harness.
+**Fixture requirements**:
+- A provider org (one already exists on dev: `2d0829ae-224b-4a79-ac3a-726b00d6c172` "TestOrg-20260329", and `43ede501-5d88-44b5-a84b-53edeec0781f` "Live for Life").
+- A `provider_partner` org (NONE exist on dev as of 2026-06-09).
+- A user with permission to call the 3 RPCs under test (`create_var_partnership`, `create_access_grant`, `revoke_access_grant`, etc.). See "Permission gate fork" below.
+
+#### Step 1 — Seed a `provider_partner` org
+
+Two equivalent paths exist (the create-path is fully supported; nobody has just exercised it on dev yet):
+
+**Path A (canonical)** — Run the existing Temporal `organization-bootstrap` workflow with `type='provider_partner'` + `partner_type='var'`. Trigger example: `workflows/src/examples/trigger-workflow.ts:34`. From a worker-connected shell:
+
+```bash
+cd workflows
+TEMPORAL_ADDRESS=localhost:7233 npx ts-node src/examples/trigger-workflow.ts
+# Edit the example or pass org args to set type='provider_partner' + partner_type='var'
+# Workflow handles DNS provisioning (if is_subdomain_required(type, partner_type) returns true),
+# auth-admin minting, and the organization.created event emission.
+```
+
+**Path B (pragmatic)** — Bypass the workflow and emit `organization.created` directly via `api.emit_domain_event` (event-sourced shortcut; the projection handler does the rest). Faster than Path A for write-side RPC UAT because we don't need DNS or auth-admin minting:
+
+```sql
+SELECT api.emit_domain_event(
+  p_stream_id   := gen_random_uuid(),
+  p_stream_type := 'organization',
+  p_event_type  := 'organization.created',
+  p_event_data  := jsonb_build_object(
+    'name',                'UAT-Partner-' || to_char(now(), 'YYYYMMDD-HH24MI'),
+    'type',                'provider_partner',
+    'partner_type',        'var',
+    'parent_id',           NULL,  -- partner orgs are tenancy-root in their own subtree
+    'created_by',          (current_setting('request.jwt.claims', true)::jsonb ->> 'sub')::uuid
+  ),
+  p_event_metadata := jsonb_build_object(
+    'user_id',         (current_setting('request.jwt.claims', true)::jsonb ->> 'sub')::uuid,
+    'organization_id', (current_setting('request.jwt.claims', true)::jsonb ->> 'org_id')::uuid,
+    'reason',          'Phase 2 UAT fixture seed'
+  )
+);
+```
+
+Then `SELECT id FROM organizations_projection WHERE name LIKE 'UAT-Partner-%' ORDER BY created_at DESC LIMIT 1;` to capture the partner_org_id.
+
+**Teardown for Path B**: emit `organization.deleted` for the partner_org_id at the end of UAT, or soft-delete via `api.deactivate_organization` if a non-destructive trail is preferred.
+
+#### Step 2 — Identify a calling user (permission gate fork)
+
+The 3 grant-tier RPCs and the 5 VAR-partnership RPCs are gated as:
+
+| RPC | Gate |
+|---|---|
+| `api.create_var_partnership` (+ 4 sister RPCs: update/terminate/suspend/reactivate) | `has_platform_privilege() OR has_effective_permission('partnership.manage', v_provider_path)` |
+| `api.create_access_grant` | `has_platform_privilege() OR has_effective_permission('grant.create', v_provider_path)` |
+| `api.revoke_access_grant` | `has_platform_privilege() OR has_effective_permission('grant.revoke', v_provider_path)` |
+| `api.revoke_permission_across_grants` | **platform-only** (`has_platform_privilege()`; no provider fallback) |
+
+**Sub-decision (UAT path)**: use a **platform-admin user** for the entire UAT — the `has_platform_privilege()` short-circuit covers every RPC, including the platform-only `revoke_permission_across_grants`. Dev already has the Phase 1 baseline reference user `093c0e7b-5ace-49df-9632-d49858d54ef5` (which is platform-privileged per the latency benchmark history); reuse it. No additional permission seeding required to run UAT.
+
+**Production-readiness gap discovered during this UAT planning** (NOT a UAT blocker, but a real defect): per dev probe 2026-06-09, `provider_admin` role template has only `partnership.manage` granted; **`grant.create`, `grant.revoke`, `grant.view` are NOT granted to any role**. The reachability matrix entries for these RPCs say "Provider-admin authority" but no provider_admin can actually invoke them today — only the platform-privilege fallback path works. Tracked in a separate seed card: `seed-grant-create-grant-revoke-into-provider-admin-role-seed.md`. Phase 1 (PR #70) defined the 3 grant.* permissions in `permissions_projection` but did not extend `role_permission_templates`; Phase 2 (PR #71) extended only `partnership.manage`. Decide whether to fold the role-template seed into the UAT migration prep or treat as a separate ship.
+
+#### Step 3 — Capture fixture identifiers
+
+```sql
+-- Capture for test harness
+SELECT
+  (SELECT id FROM organizations_projection WHERE type='provider' AND name='TestOrg-20260329') AS provider_org_id,
+  (SELECT id FROM organizations_projection WHERE type='provider_partner' ORDER BY created_at DESC LIMIT 1) AS partner_org_id,
+  '093c0e7b-5ace-49df-9632-d49858d54ef5'::uuid AS calling_user_id;
+```
 
 ### Batch 2 — VAR partnership + access grant lifecycle (8 probes)
 

--- a/dev/active/phase-2-uat-var-partnership-lifecycle-seed.md
+++ b/dev/active/phase-2-uat-var-partnership-lifecycle-seed.md
@@ -43,26 +43,40 @@ TEMPORAL_ADDRESS=localhost:7233 npx ts-node src/examples/trigger-workflow.ts
 # auth-admin minting, and the organization.created event emission.
 ```
 
-**Path B (pragmatic)** — Bypass the workflow and emit `organization.created` directly via `api.emit_domain_event` (event-sourced shortcut; the projection handler does the rest). Faster than Path A for write-side RPC UAT because we don't need DNS or auth-admin minting:
+**Path B (pragmatic)** — Bypass the workflow and emit `organization.created` directly via `api.emit_domain_event` (event-sourced shortcut; the projection handler does the rest). Faster than Path A for write-side RPC UAT because we don't need DNS or auth-admin minting. **Path B caveats** (S3 architect fold-in 2026-06-09):
+
+1. **`event_data` MUST include `slug` + `path` + `parent_path`** — `handle_organization_created` reads these fields and the projection columns may have NOT NULL constraints / UNIQUE indexes (`slug` in particular). Defaulting to the stream_id-as-string for `path`/`parent_path` is sane for a tenancy-root partner org.
+2. **Path B bypasses Temporal workflow auth-admin minting** — no `organization_admin` user is created for the seeded partner org. Acceptable for Phase 2's UAT scope (provider-admin-initiated grant ops AGAINST the partner_org, where the calling user lives at the provider org side, not the partner). NOT acceptable if a future UAT probe needs a user-as-tenant test against the partner org (e.g., consultant-callability probe at the partner subtree); use Path A for that.
 
 ```sql
+WITH partner AS (
+  SELECT
+    gen_random_uuid() AS stream_id,
+    'UAT-Partner-' || to_char(now(), 'YYYYMMDD-HH24MI') AS partner_name,
+    lower(replace('uat-partner-' || to_char(now(), 'YYYYMMDD-HH24MI'), ' ', '-')) AS partner_slug
+)
 SELECT api.emit_domain_event(
-  p_stream_id   := gen_random_uuid(),
+  p_stream_id   := partner.stream_id,
   p_stream_type := 'organization',
   p_event_type  := 'organization.created',
   p_event_data  := jsonb_build_object(
-    'name',                'UAT-Partner-' || to_char(now(), 'YYYYMMDD-HH24MI'),
+    'name',                partner.partner_name,
+    'slug',                partner.partner_slug,                   -- S3 fold-in: required by handler
     'type',                'provider_partner',
     'partner_type',        'var',
-    'parent_id',           NULL,  -- partner orgs are tenancy-root in their own subtree
+    'path',                partner.stream_id::text,                -- S3 fold-in: tenancy-root partner; path = stream_id
+    'parent_path',         partner.stream_id::text,                -- S3 fold-in: ditto (self-parent for tenancy-root)
+    'parent_id',           NULL,                                   -- partner orgs are tenancy-root in their own subtree
+    'subdomain_status',    'skipped',                              -- Path B doesn't provision DNS
     'created_by',          (current_setting('request.jwt.claims', true)::jsonb ->> 'sub')::uuid
   ),
   p_event_metadata := jsonb_build_object(
     'user_id',         (current_setting('request.jwt.claims', true)::jsonb ->> 'sub')::uuid,
     'organization_id', (current_setting('request.jwt.claims', true)::jsonb ->> 'org_id')::uuid,
-    'reason',          'Phase 2 UAT fixture seed'
+    'reason',          'Phase 2 UAT fixture seed (Path B — direct emit; no DNS / no auth-admin minting)'
   )
-);
+)
+FROM partner;
 ```
 
 Then `SELECT id FROM organizations_projection WHERE name LIKE 'UAT-Partner-%' ORDER BY created_at DESC LIMIT 1;` to capture the partner_org_id.

--- a/dev/active/seed-grant-create-grant-revoke-into-provider-admin-role-seed.md
+++ b/dev/active/seed-grant-create-grant-revoke-into-provider-admin-role-seed.md
@@ -1,0 +1,92 @@
+# Seed `grant.create` + `grant.revoke` + `grant.view` into `provider_admin` role template
+
+**Status**: seed (not yet planned)
+**Priority**: High (production defect; the entire Phase 2 grant write-side is unreachable by the intended `provider_admin` role — only platform-privilege fallback works)
+**Origin**: Phase 2 UAT planning probe 2026-06-09 (post-PR-#71-merge dev verification by claude during UAT card update)
+
+## Problem
+
+Phase 1 (PR #70) seeded 3 new permissions into `permissions_projection` via `permission.defined` events: `grant.create`, `grant.revoke`, `grant.view` (all `scope_type='global'`). Phase 2 (PR #71) added a 4th permission `partnership.manage` AND extended the `provider_admin` `role_permission_templates` to grant it (Step 7b: template addition + backfill to existing role instances).
+
+**But neither phase ever extended the `provider_admin` role template (or any other role template) with the 3 `grant.*` permissions.**
+
+Dev probe results (2026-06-09 18:35Z, just post-PR-#71-merge):
+
+```
+permissions_projection: grant.create, grant.revoke, grant.view, partnership.manage  (4 rows ✓)
+role_permission_templates for provider_admin (matching): partnership.manage         (1 row)
+role_permissions_projection for provider_admin instances + partnership.manage: 2/2  (backfill OK)
+role_permissions_projection for provider_admin instances + grant.*:          0/2   (UNGRANTED)
+permission_implications involving grant.* or partnership.manage:             none   (no transitive path)
+ANY role_permission_template row with permission_name LIKE 'grant.%':        ZERO
+```
+
+The 3 new RPCs Phase 2 ships all have the same gate shape: `has_platform_privilege() OR has_effective_permission('grant.<x>', v_provider_path)`. Today only the `has_platform_privilege()` short-circuit succeeds for any caller — provider admins (the **intended authority** per ADR Decision C.1 + the reachability-matrix entries that explicitly say "Provider-admin authority") cannot call `api.create_access_grant` or `api.revoke_access_grant`.
+
+The reachability matrix at `documentation/architecture/authorization/cross-tenant-access-grant-rpc-reachability-matrix.md` declares (as of PR #71 merge):
+
+| RPC | Bucket | Notes |
+|---|---|---|
+| `create_access_grant` | B | Provider-admin authority (HIPAA gate at provider org path via `has_effective_permission('grant.create', v_provider_path)`) |
+| `revoke_access_grant` | B | Provider-admin authority (HIPAA gate at provider org path via `has_effective_permission('grant.revoke', v_provider_path)`) |
+
+The descriptions are aspirational; the runtime gate-effect today is "platform-privilege fallback only."
+
+## Why this matters
+
+1. **Production-functional gap**: provider admins are the role the architecture says SHOULD manage their cross-tenant grants. Today they CAN'T. Platform admins can but that's not the long-term design.
+2. **UAT blast radius**: any UAT that wants to verify the "real" provider-admin user-journey path (vs the platform-privilege fallback) is forced to manually grant the permissions to a test user first. Adds friction; makes the test non-repeatable across environments without cleanup.
+3. **Architect-cohesion-review miss**: the PR #71 final-PR architect review verified that `partnership.manage` was seeded (Step 7b) but did not flag the missing parallel seed for the 3 `grant.*` permissions. The cohesion review checklist should grow a probe like: "every RPC whose gate is `has_effective_permission('<perm>', ...)` has `<perm>` granted in at least one role template via a `permission.granted_to_role` (or equivalent) audit-trail event."
+4. **Phase 0.4 Decision C.1 cross-check**: the ADR locks "provider-admin authority" for grant emit — but the implementation is half-done. The ADR doesn't directly speak to role-template seeding, so this is an ADR ⇄ implementation cohesion gap.
+
+## Options
+
+### Option A — Seed via `role_permission_templates` + backfill to existing role instances (mirrors PR #71 Step 7b for `partnership.manage`)
+
+Add a migration that:
+1. Inserts 3 rows into `role_permission_templates` for `('provider_admin', 'grant.create', true)`, `('provider_admin', 'grant.revoke', true)`, `('provider_admin', 'grant.view', true)`.
+2. Backfills `role_permissions_projection` for every existing `provider_admin` role instance via `role.permission.granted` events (the same pattern PR #71 Step 7b uses for `partnership.manage`).
+
+**Pro**: matches the existing convention; backfill keeps existing assignments consistent without manual ops.
+**Con**: 3 new permissions get globally granted to every `provider_admin`. This is correct semantically (the ADR says provider admins should have grant authority) but worth a privacy/compliance second-look before shipping.
+
+### Option B — Implication chain: `partnership.manage → grant.{create,revoke,view}`
+
+Add 3 rows to `permission_implications` so any user holding `partnership.manage` automatically derives `grant.*` via `compute_effective_permissions`.
+
+**Pro**: zero backfill; takes effect on next token refresh.
+**Con**: conceptually weird — `partnership.manage` is about the business relationship, not the per-user data grant. Conflates two concerns the ADR deliberately separated (Decision C.3 explicitly states "partnership.manage authorizes the BUSINESS RELATIONSHIP; grant.create authorizes PHI release against it"). The migration's own L825-867 docblock for `partnership.manage` calls this out: distinct from `grant.create`.
+
+### Option C — Separate `grant_admin` sub-role within `provider_admin` hierarchy
+
+Create a new `grant_admin` role that exists alongside `provider_admin`, with `grant.*` granted. Manage assignments separately so not every `provider_admin` gets grant authority.
+
+**Pro**: principle of least privilege at the role level.
+**Con**: new role surface; larger migration; raises governance questions (who provisions `grant_admin`?). Likely overkill for v1.
+
+### Recommendation
+
+**Option A**, with the privacy/compliance second-look done as part of the migration PR (architect review). This matches the existing seed convention (PR #71 Step 7b precedent) and keeps the "Provider-admin authority" matrix descriptions semantically accurate at runtime.
+
+## Steps (Option A)
+
+1. **Create migration**: `supabase migration new seed_grant_perms_into_provider_admin_role`. Migration body:
+   - `INSERT INTO public.role_permission_templates (role_name, permission_name, is_active) VALUES ('provider_admin', 'grant.create', true), ('provider_admin', 'grant.revoke', true), ('provider_admin', 'grant.view', true) ON CONFLICT (role_name, permission_name) DO NOTHING;` (idempotent).
+   - Backfill DO block: for each existing `provider_admin` role instance (`SELECT id FROM roles_projection WHERE name='provider_admin'`), emit 3 `role.permission.granted` events via `api.emit_domain_event` with `event_data = {role_id, permission_name, granted_at}` + `event_metadata = {user_id: '00...00', reason: 'Backfill: seed grant.* into provider_admin (Phase 2 PR #71 follow-up)'}`. Handler at `handle_rbac_role_permission_granted` projects to `role_permissions_projection` idempotently (codified pitfall #4 `IF NOT EXISTS` precondition).
+2. **Stage E probe**: re-run the 2026-06-09 probe — expect provider_admin template with 4 permissions (`grant.create, grant.revoke, grant.view, partnership.manage`) and role_permissions_projection with 8 rows across 2 existing provider_admin instances (4 perms × 2 instances).
+3. **UAT validation**: re-run Phase 2 UAT lifecycle E2E using a provider_admin user (NOT a platform-admin) to prove the "intended authority" path works end-to-end.
+4. **Reachability matrix update**: the matrix entries don't change (bucket B + "Provider-admin authority"), but the implementation now matches the description.
+
+## Out of scope
+
+- Phase 3/4/N rollout work (parent card `cross-tenant-access-grant-rollout/`).
+- Frontend integration UI for grant management (separate concern; the RPCs work — the gate just needs the permission).
+- Seeding `grant.*` for other role templates (e.g., `super_admin` already has `has_platform_privilege()` so the OR fallback covers them).
+
+## Files involved
+
+- `infrastructure/supabase/supabase/migrations/20260601174841_cross_tenant_grant_phase_1_jwt_shape.sql` — Phase 1 originating migration that seeded the 3 `grant.*` permissions in `permissions_projection` but stopped there
+- `infrastructure/supabase/supabase/migrations/20260604210910_cross_tenant_grant_phase_2_write_side.sql` § Step 7b (L820-880) — precedent pattern for "seed permission + grant to role template + backfill" that this seed card mirrors
+- `documentation/architecture/authorization/cross-tenant-access-grant-rpc-reachability-matrix.md` — entries for `create_access_grant`, `revoke_access_grant`, `revoke_permission_across_grants` (the third is platform-only by design; the first two are the ones with the gap)
+- `documentation/architecture/decisions/adr-cross-tenant-access-grant-jwt-shape.md` § Decision C.1 — declares "provider-admin authority" for grant emit
+- `dev/active/phase-2-uat-var-partnership-lifecycle-seed.md` — UAT card that calls this out as a "production-readiness gap discovered during UAT planning"

--- a/dev/active/seed-grant-create-grant-revoke-into-provider-admin-role-seed.md
+++ b/dev/active/seed-grant-create-grant-revoke-into-provider-admin-role-seed.md
@@ -36,7 +36,45 @@ The descriptions are aspirational; the runtime gate-effect today is "platform-pr
 
 1. **Production-functional gap**: provider admins are the role the architecture says SHOULD manage their cross-tenant grants. Today they CAN'T. Platform admins can but that's not the long-term design.
 2. **UAT blast radius**: any UAT that wants to verify the "real" provider-admin user-journey path (vs the platform-privilege fallback) is forced to manually grant the permissions to a test user first. Adds friction; makes the test non-repeatable across environments without cleanup.
-3. **Architect-cohesion-review miss**: the PR #71 final-PR architect review verified that `partnership.manage` was seeded (Step 7b) but did not flag the missing parallel seed for the 3 `grant.*` permissions. The cohesion review checklist should grow a probe like: "every RPC whose gate is `has_effective_permission('<perm>', ...)` has `<perm>` granted in at least one role template via a `permission.granted_to_role` (or equivalent) audit-trail event."
+3. **Architect-cohesion-review miss**: the PR #71 final-PR architect review verified that `partnership.manage` was seeded (Step 7b) but did not flag the missing parallel seed for the 3 `grant.*` permissions. The cohesion review checklist should grow the following probe (S2 architect fold-in 2026-06-09 — strengthened from the original draft to cover three structural edge cases):
+
+   > **Permission-gate-vs-role-template cohesion probe (cross-aggregate authz invariant)**
+   >
+   > For every `api.*` RPC whose body references a permission via `has_effective_permission('<perm>', <scope_path>)` **OR `has_permission('<perm>')`**, that `<perm>` MUST be granted in at least one row of `role_permission_templates` (or, equivalently, have an active `permission_implications` chain leading from another role-granted permission).
+   >
+   > **Carve-outs**:
+   >
+   > 1. **Intentionally platform-only RPCs** — if the gate is `has_platform_privilege()` with NO `OR has_effective_permission/has_permission` clause (e.g., `api.revoke_permission_across_grants`), the RPC is platform-admin-only by design and should NOT have a corresponding role-template entry. The probe MUST recognize this shape and skip those RPCs.
+   >
+   > 2. **`scope_type` catalog ⇄ runtime gate divergence** — if the permission's `permissions_projection.scope_type` is `'global'` but the gating RPC uses the scope-typed form `has_effective_permission(perm, <ltree_path>)`, this is a catalog/runtime divergence (works today because `compute_effective_permissions` derives scope from `user_roles_projection.scope_path`, but the conceptual mismatch is real). Either reclassify the catalog `scope_type` to `org`/`org_unit`, or document the structural rationale for why a global-typed permission is being scope-checked at runtime. The Phase 1 `grant.*` permissions match this divergent shape and warrant the explicit documentation (the gate's scope-typed check enforces tenancy at the provider org path even though the permission is catalog-global).
+   >
+   > **Audit query** (parametric for future architect-cohesion reviews):
+   >
+   > ```sql
+   > WITH gate_refs AS (
+   >   -- regex-extract has_effective_permission('<perm>', ...) AND has_permission('<perm>') from api.* bodies
+   >   SELECT p.proname AS rpc,
+   >          (regexp_matches(pg_get_functiondef(p.oid),
+   >                          'has_(?:effective_)?permission\s*\(\s*''([^'']+)''', 'g'))[1] AS perm,
+   >          CASE WHEN pg_get_functiondef(p.oid) ~ 'has_effective_permission\s*\(\s*''([^'']+)'''
+   >               THEN 'has_effective_permission' ELSE 'has_permission' END AS gate_kind
+   >   FROM pg_proc p JOIN pg_namespace n ON p.pronamespace=n.oid
+   >   WHERE n.nspname='api'
+   > ),
+   > platform_only AS (
+   >   SELECT p.proname AS rpc FROM pg_proc p JOIN pg_namespace n ON p.pronamespace=n.oid
+   >   WHERE n.nspname='api'
+   >     AND pg_get_functiondef(p.oid) ~ 'has_platform_privilege\s*\(\)'
+   >     AND pg_get_functiondef(p.oid) !~ 'OR\s+has_(?:effective_)?permission'
+   > )
+   > SELECT g.rpc, g.perm, g.gate_kind, pp.scope_type AS catalog_scope_type
+   > FROM gate_refs g
+   > LEFT JOIN public.permissions_projection pp ON pp.name = g.perm
+   > WHERE NOT EXISTS (SELECT 1 FROM public.role_permission_templates rpt
+   >                   WHERE rpt.is_active=true AND rpt.permission_name = g.perm)
+   >   AND NOT EXISTS (SELECT 1 FROM platform_only po WHERE po.rpc = g.rpc);
+   > -- Every result row is a candidate defect (gate-perm in zero templates AND RPC isn't platform-only).
+   > ```
 4. **Phase 0.4 Decision C.1 cross-check**: the ADR locks "provider-admin authority" for grant emit — but the implementation is half-done. The ADR doesn't directly speak to role-template seeding, so this is an ADR ⇄ implementation cohesion gap.
 
 ## Options
@@ -70,11 +108,33 @@ Create a new `grant_admin` role that exists alongside `provider_admin`, with `gr
 
 ## Steps (Option A)
 
-1. **Create migration**: `supabase migration new seed_grant_perms_into_provider_admin_role`. Migration body:
-   - `INSERT INTO public.role_permission_templates (role_name, permission_name, is_active) VALUES ('provider_admin', 'grant.create', true), ('provider_admin', 'grant.revoke', true), ('provider_admin', 'grant.view', true) ON CONFLICT (role_name, permission_name) DO NOTHING;` (idempotent).
-   - Backfill DO block: for each existing `provider_admin` role instance (`SELECT id FROM roles_projection WHERE name='provider_admin'`), emit 3 `role.permission.granted` events via `api.emit_domain_event` with `event_data = {role_id, permission_name, granted_at}` + `event_metadata = {user_id: '00...00', reason: 'Backfill: seed grant.* into provider_admin (Phase 2 PR #71 follow-up)'}`. Handler at `handle_rbac_role_permission_granted` projects to `role_permissions_projection` idempotently (codified pitfall #4 `IF NOT EXISTS` precondition).
-2. **Stage E probe**: re-run the 2026-06-09 probe — expect provider_admin template with 4 permissions (`grant.create, grant.revoke, grant.view, partnership.manage`) and role_permissions_projection with 8 rows across 2 existing provider_admin instances (4 perms × 2 instances).
+1. **Create migration**: `supabase migration new seed_grant_perms_into_provider_admin_role`. Migration body mirrors PR #71 Step 7b precedent **verbatim** (S1 architect fold-in 2026-06-09 — the prior draft incorrectly proposed event-emit backfill; precedent uses direct INSERT). Step 7b reference: migration `20260604210910...sql:879-894`.
+
+   ```sql
+   -- 1a — Extend the template (idempotent)
+   INSERT INTO public.role_permission_templates (role_name, permission_name, is_active)
+   VALUES
+     ('provider_admin', 'grant.create', true),
+     ('provider_admin', 'grant.revoke', true),
+     ('provider_admin', 'grant.view',   true)
+   ON CONFLICT (role_name, permission_name) DO NOTHING;
+
+   -- 1b — Backfill: direct INSERT into role_permissions_projection (NOT event-emit).
+   -- Mirrors PR #71 Step 7b L879-894 precedent. Audit trail is the migration commit
+   -- itself; events are the wrong layer for this kind of bulk-template-extension.
+   INSERT INTO public.role_permissions_projection (role_id, permission_id, granted_at)
+   SELECT rp.id AS role_id, pp.id AS permission_id, now() AS granted_at
+   FROM public.roles_projection rp
+   CROSS JOIN public.permissions_projection pp
+   WHERE rp.name = 'provider_admin' AND rp.deleted_at IS NULL
+     AND pp.applet = 'grant' AND pp.action IN ('create', 'revoke', 'view')
+   ON CONFLICT (role_id, permission_id) DO NOTHING;
+   ```
+
+2. **Stage E probe** (parametric per N2 fold-in 2026-06-09): assert `expected_rows = (perm_count_in_template × provider_admin_instance_count)`. Snapshot of dev 2026-06-09: 2 provider_admin instances pre-migration with 2 rows (`partnership.manage` × 2); Option A adds 6 new rows (3 perms × 2 instances); total post-migration 8 rows. Production may have different instance counts — write the probe as the parametric assertion above, not the snapshot count. Idempotency: re-running the migration produces zero new rows.
+
 3. **UAT validation**: re-run Phase 2 UAT lifecycle E2E using a provider_admin user (NOT a platform-admin) to prove the "intended authority" path works end-to-end.
+
 4. **Reachability matrix update**: the matrix entries don't change (bucket B + "Provider-admin authority"), but the implementation now matches the description.
 
 ## Out of scope
@@ -82,6 +142,7 @@ Create a new `grant_admin` role that exists alongside `provider_admin`, with `gr
 - Phase 3/4/N rollout work (parent card `cross-tenant-access-grant-rollout/`).
 - Frontend integration UI for grant management (separate concern; the RPCs work — the gate just needs the permission).
 - Seeding `grant.*` for other role templates (e.g., `super_admin` already has `has_platform_privilege()` so the OR fallback covers them).
+- **Sibling defect with the same shape** (N1 architect fold-in 2026-06-09): `api.get_failed_events_with_detail` (PR #43-era) gates on `has_permission('platform.view_event_details')`. That permission exists in `permissions_projection` (`scope_type='global'`) but is in zero role templates, AND the gate has no `has_platform_privilege()` fallback — so the RPC is currently **uncallable by any caller, including platform admins**. Likely intended grant: `platform_admin` or `super_admin` role template. **Defer to a parallel seed card** (`seed-platform-view-event-details-into-platform-admin-role-seed.md` or similar — see `dev/active/seed-platform-view-event-details-permission-seed.md` for prior seeding work that landed the permission but not the role-template extension). Not folded here because this card's scope is `grant.*` × `provider_admin`; the sibling defect's role-template target is a different role.
 
 ## Files involved
 


### PR DESCRIPTION
## Summary

Docs-only follow-up from PR #71 (Phase 2 cross-tenant grant write-side). Two card updates:

1. **`phase-2-uat-var-partnership-lifecycle-seed.md`** — spell out concrete fixture-seed paths instead of leaving "needs fixtures" as a vague blocker.
2. **`seed-grant-create-grant-revoke-into-provider-admin-role-seed.md`** (NEW) — REAL DEFECT discovered while validating UAT prerequisites: Phase 1 + 2 never seeded `grant.create` / `grant.revoke` / `grant.view` into any role template. The reachability matrix entries for `create_access_grant` + `revoke_access_grant` say "Provider-admin authority" but no `provider_admin` can actually invoke them today — only the `has_platform_privilege()` OR fallback works.

## The defect — dev probe results (2026-06-09, post-PR-#71-merge)

| What | Result |
|---|---|
| `partnership.manage` in `provider_admin` template | ✅ (Phase 2 Step 7b) |
| `partnership.manage` granted to existing `provider_admin` role instances | ✅ 2/2 (backfill OK) |
| `grant.create` / `grant.revoke` / `grant.view` in `provider_admin` template | ❌ NOT GRANTED |
| `grant.*` granted to existing `provider_admin` role instances | ❌ 0/2 |
| Any role template carrying any `grant.*` permission | ❌ ZERO |
| Implication chain `partnership.manage → grant.*` | ❌ none |

Phase 1 (PR #70) defined the 3 `grant.*` permissions in `permissions_projection` (`scope_type='global'`) but stopped there. Phase 2 (PR #71) extended `role_permission_templates` only for the 4th permission `partnership.manage` (Step 7b: template addition + backfill to existing role instances). The 3 grant permissions were never extended to any role.

The migration-body comment for `partnership.manage` at L820-867 of the Phase 2 migration explicitly distinguishes the two concerns: `partnership.manage` authorizes the BUSINESS RELATIONSHIP; `grant.create` authorizes PHI release against it. They're orthogonal, so implication-chain (`partnership.manage → grant.*`) would conflate them — the seed card recommends explicit role-template seeding instead (Option A).

## Process gap

The PR #71 final-PR architect-cohesion review verified that Step 7b extended `role_permission_templates` for `partnership.manage` AND backfilled to existing role instances — but did NOT check the parallel for the 3 `grant.*` permissions. Recommended checklist addition (codified in the seed card):

> Every RPC whose gate is `has_effective_permission('<perm>', ...)` MUST have `<perm>` granted in at least one role template via a documented `permission.granted_to_role` (or equivalent) audit-trail event.

## Recommended fix (in a follow-up implementation PR)

Per the seed card, **Option A** — mirror PR #71 Step 7b precedent:

1. Migration `seed_grant_perms_into_provider_admin_role`:
   - `INSERT INTO role_permission_templates VALUES ('provider_admin', 'grant.create', true), ('provider_admin', 'grant.revoke', true), ('provider_admin', 'grant.view', true) ON CONFLICT (role_name, permission_name) DO NOTHING;`
   - Backfill DO block: for each existing `provider_admin` role instance, emit 3 `role.permission.granted` events with `api.emit_domain_event`.
2. Stage E re-probe: expect provider_admin template with 4 permissions; `role_permissions_projection` rows = 4 × N (N = existing `provider_admin` instances).
3. UAT re-validation: re-run Phase 2 UAT lifecycle E2E using a `provider_admin` user (NOT a platform-admin) to prove the intended-authority path works end-to-end.

## Carry-over to UAT card

UAT itself is NOT blocked by this defect because `has_platform_privilege()` short-circuits all 8 RPCs (including the platform-only `revoke_permission_across_grants`). UAT card now documents the platform-admin path as the canonical execution path; running UAT with a `provider_admin` user becomes the verification step in the seeded follow-up.

## Test plan

- [ ] Confirm both cards merge cleanly
- [ ] Stage the follow-up implementation work per the seed card (Option A migration + Stage E re-probe + UAT re-validation with `provider_admin`)
- [ ] Verify the cohesion-review-checklist addition gets picked up by the next authz architect review

🤖 Generated with [Claude Code](https://claude.com/claude-code)