### PR TITLE
fix(authz): align cross_tenant_access_grants_projection schema with deployed handler

### DIFF
--- a/documentation/architecture/authorization/cross-tenant-access-grant-rpc-reachability-matrix.md
+++ b/documentation/architecture/authorization/cross-tenant-access-grant-rpc-reachability-matrix.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last_updated: 2026-06-09
+last_updated: 2026-06-10
 ---
 
 <!-- TL;DR-START -->

--- a/frontend/src/types/database.types.ts
+++ b/frontend/src/types/database.types.ts
@@ -2926,6 +2926,8 @@ export type Database = {
           consultant_user_id: string | null
           created_at: string | null
           expected_resolution_date: string | null
+          expiration_type: string | null
+          expired_at: string | null
           expires_at: string | null
           granted_at: string
           granted_by: string
@@ -2935,10 +2937,11 @@ export type Database = {
           provider_org_id: string
           reactivated_at: string | null
           reactivated_by: string | null
-          reactivation_notes: string | null
+          resolution_details: string | null
+          revocation_details: string | null
+          revocation_reason: string | null
           revoked_at: string | null
           revoked_by: string | null
-          revoked_reason: string | null
           scope: string
           scope_id: string | null
           status: string | null
@@ -2956,6 +2959,8 @@ export type Database = {
           consultant_user_id?: string | null
           created_at?: string | null
           expected_resolution_date?: string | null
+          expiration_type?: string | null
+          expired_at?: string | null
           expires_at?: string | null
           granted_at: string
           granted_by: string
@@ -2965,10 +2970,11 @@ export type Database = {
           provider_org_id: string
           reactivated_at?: string | null
           reactivated_by?: string | null
-          reactivation_notes?: string | null
+          resolution_details?: string | null
+          revocation_details?: string | null
+          revocation_reason?: string | null
           revoked_at?: string | null
           revoked_by?: string | null
-          revoked_reason?: string | null
           scope: string
           scope_id?: string | null
           status?: string | null
@@ -2986,6 +2992,8 @@ export type Database = {
           consultant_user_id?: string | null
           created_at?: string | null
           expected_resolution_date?: string | null
+          expiration_type?: string | null
+          expired_at?: string | null
           expires_at?: string | null
           granted_at?: string
           granted_by?: string
@@ -2995,10 +3003,11 @@ export type Database = {
           provider_org_id?: string
           reactivated_at?: string | null
           reactivated_by?: string | null
-          reactivation_notes?: string | null
+          resolution_details?: string | null
+          revocation_details?: string | null
+          revocation_reason?: string | null
           revoked_at?: string | null
           revoked_by?: string | null
-          revoked_reason?: string | null
           scope?: string
           scope_id?: string | null
           status?: string | null

--- a/infrastructure/supabase/CLAUDE.md
+++ b/infrastructure/supabase/CLAUDE.md
@@ -200,6 +200,37 @@ The five preconditions above are **load-bearing invariants**, not preferences. A
 
 Originating context: PR #73 Section B (2026-06-09) retired `platform.view_event_details` via direct DELETE. All five preconditions held; migration body L213-226 enumerates them inline. Codified per PR #73 architect N1 fold-in.
 
+### Handler-vs-schema column-name drift: parametric existence assertion at handler-deploy
+
+When a handler `INSERT`s or `UPDATE`s columns on a projection table, those column names are not validated at function-creation time — PL/pgSQL late-binds column references. A handler that writes to a column that doesn't exist on the projection will deploy successfully and only fail at event-process time, where it surfaces as a `processing_error` on `domain_events` (a Pattern A v2 envelope returns `PROCESSING_FAILED` to the caller, but the failure happens AFTER the audit row is durable).
+
+**Forensic example**: 3 of 5 arms of `process_access_grant_event` wrote to columns that did not exist on `cross_tenant_access_grants_projection` from baseline_v4 ship date (2026-02-12) until detection by Phase 2 UAT probe L8 (2026-06-09). Latent for ~4 months because the only path that emitted `access_grant.revoked` at scale was Phase 2's cascade-revoke.
+
+**Defense-in-depth**: any migration that ships or refreshes a handler with new column writes MUST add a fail-loud assertion block at the bottom that enumerates the columns the handler writes and verifies their existence on the target projection:
+
+```sql
+DO $$
+DECLARE
+  v_handler_writes_columns text[] := ARRAY['col_a', 'col_b', '...'];
+  v_col text;
+  v_missing text[] := '{}';
+BEGIN
+  FOREACH v_col IN ARRAY v_handler_writes_columns LOOP
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='<proj>' AND column_name=v_col
+    ) THEN v_missing := array_append(v_missing, v_col); END IF;
+  END LOOP;
+  IF array_length(v_missing, 1) > 0 THEN
+    RAISE EXCEPTION 'Handler writes to non-existent columns: %', v_missing USING ERRCODE='P9099';
+  END IF;
+END $$;
+```
+
+This complements (does NOT replace) the existing `plpgsql_check` CI step, which validates handler bodies at deploy-time. `plpgsql_check` catches *static* column references; `EXECUTE`-driven or dynamic-SQL handlers and column references inside `safe_jsonb_extract_*` wrappers are NOT caught by it. The parametric assertion is the catch-all.
+
+Originating context: PR #74 (2026-06-09) hotfix aligned `cross_tenant_access_grants_projection` to the deployed `process_access_grant_event` handler. Migration body Section 2.1 contains the canonical 5-arm enumeration pattern. Codified per PR #74 architect S1 fold-in.
+
 ### `list_users*` family pattern — three-step skeleton
 
 The four `api.list_users*` RPCs share a normalized three-step skeleton (established across PR #66 and PR #67):

--- a/infrastructure/supabase/supabase/migrations/20260609234958_fix_access_grant_projection_handler_schema_alignment.sql
+++ b/infrastructure/supabase/supabase/migrations/20260609234958_fix_access_grant_projection_handler_schema_alignment.sql
@@ -1,0 +1,200 @@
+-- ============================================================================
+-- HOTFIX: align cross_tenant_access_grants_projection schema with the names
+-- the deployed process_access_grant_event router writes.
+-- ============================================================================
+--
+-- Origin: surfaced during Phase 2 UAT execution 2026-06-09. Probe L8
+-- (api.revoke_access_grant happy path) returned PROCESSING_FAILED with
+-- `column "revocation_reason" of relation "cross_tenant_access_grants_projection"
+-- does not exist`. Audit of all router arms revealed 3 of 5 lifecycle arms
+-- write to columns that don't exist:
+--
+--   revoked arm     — writes `revocation_reason` + `revocation_details`
+--                     schema has `revoked_reason`, no `_details`
+--
+--   expired arm     — writes `expired_at` + `expiration_type`
+--                     schema has neither
+--
+--   reactivated arm — writes `resolution_details`
+--                     schema has `reactivation_notes` (different name,
+--                     same semantic field)
+--
+--   suspended arm   — works (schema + handler aligned)
+--   policy_override — works (only touches `permissions` jsonb)
+--
+-- Defect predates Phase 2 — handler was built against a different schema
+-- shape than what landed in baseline_v4. Surfaced now because Phase 2's
+-- cascade-revoke (terminate_var_partnership Step 13) is the first
+-- production-path that emits access_grant.revoked at scale; PR #73 +
+-- Phase 2 UAT C1 + L8 surfaced it.
+--
+-- Direction (per Phase 2 UAT findings + AsyncAPI contract review):
+-- The handler/AsyncAPI/event_data side all use the `<aggregate>_<noun>`
+-- naming convention (`revocation_reason`, `revocation_details`,
+-- `expiration_type`, `resolution_details`). The PROJECTION SCHEMA is
+-- the outlier. Aligning the schema to the handler is therefore the
+-- minimal-blast-radius fix:
+--   1. No handler / AsyncAPI / event_data changes.
+--   2. No consumer code changes (callers read these columns only via
+--      Pattern A v2 read-back which returns Pattern A envelopes — the
+--      consumer-side field names mirror schema, but post-fix the
+--      schema field names match what consumers already expected from
+--      the event_data side).
+--
+-- Pre-existing PHI / audit invariants preserved: no row-level data
+-- changes; only DDL renames + adds + COMMENT refreshes.
+--
+-- Per codified pitfall #6: the handler body was fetched via Mgmt API
+-- pg_get_functiondef before drafting this fix to verify which columns
+-- it actually writes (not just what reference files say). All 5 missing/
+-- mis-named column references confirmed against the deployed body.
+-- ============================================================================
+
+-- ============================================================================
+-- Section 1 — Idempotent column renames + adds
+-- ============================================================================
+-- Standard PG has no `ALTER TABLE ... RENAME COLUMN IF EXISTS`. Use DO blocks
+-- guarded by information_schema lookups so the migration is safe to re-run.
+
+-- 1.1 — Rename revoked_reason → revocation_reason
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name   = 'cross_tenant_access_grants_projection'
+      AND column_name  = 'revoked_reason'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name   = 'cross_tenant_access_grants_projection'
+      AND column_name  = 'revocation_reason'
+  ) THEN
+    ALTER TABLE public.cross_tenant_access_grants_projection
+      RENAME COLUMN revoked_reason TO revocation_reason;
+    RAISE NOTICE 'Renamed revoked_reason -> revocation_reason';
+  ELSE
+    RAISE NOTICE 'Skipping rename: revoked_reason does not exist OR revocation_reason already present (idempotent)';
+  END IF;
+END $$;
+
+-- 1.2 — Add revocation_details column (idempotent)
+ALTER TABLE public.cross_tenant_access_grants_projection
+  ADD COLUMN IF NOT EXISTS revocation_details text;
+
+-- 1.3 — Add expired_at column (idempotent)
+ALTER TABLE public.cross_tenant_access_grants_projection
+  ADD COLUMN IF NOT EXISTS expired_at timestamptz;
+
+-- 1.4 — Add expiration_type column (idempotent)
+ALTER TABLE public.cross_tenant_access_grants_projection
+  ADD COLUMN IF NOT EXISTS expiration_type text;
+
+-- 1.5 — Rename reactivation_notes → resolution_details
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name   = 'cross_tenant_access_grants_projection'
+      AND column_name  = 'reactivation_notes'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name   = 'cross_tenant_access_grants_projection'
+      AND column_name  = 'resolution_details'
+  ) THEN
+    ALTER TABLE public.cross_tenant_access_grants_projection
+      RENAME COLUMN reactivation_notes TO resolution_details;
+    RAISE NOTICE 'Renamed reactivation_notes -> resolution_details';
+  ELSE
+    RAISE NOTICE 'Skipping rename: reactivation_notes does not exist OR resolution_details already present (idempotent)';
+  END IF;
+END $$;
+
+-- 1.6 — COMMENT refreshes on the renamed/new columns for self-documenting schema
+COMMENT ON COLUMN public.cross_tenant_access_grants_projection.revocation_reason IS
+  'Business reason for the revocation. Matches access_grant.revoked event_data.revocation_reason. Renamed from revoked_reason 2026-06-09 to align with handler + AsyncAPI contract.';
+COMMENT ON COLUMN public.cross_tenant_access_grants_projection.revocation_details IS
+  'Additional context / operator notes for the revocation. Matches access_grant.revoked event_data.revocation_details. Added 2026-06-09 (was missing — caused PROCESSING_FAILED on every revoke since grant ship).';
+COMMENT ON COLUMN public.cross_tenant_access_grants_projection.expired_at IS
+  'When the grant transitioned to expired status. Matches access_grant.expired event_data.expired_at. Added 2026-06-09.';
+COMMENT ON COLUMN public.cross_tenant_access_grants_projection.expiration_type IS
+  'How the grant expired (time_based / contract_based / automatic_cleanup). Matches access_grant.expired event_data.expiration_type. Added 2026-06-09.';
+COMMENT ON COLUMN public.cross_tenant_access_grants_projection.resolution_details IS
+  'How the suspension was resolved. Matches access_grant.reactivated event_data.resolution_details. Renamed from reactivation_notes 2026-06-09 to align with handler + AsyncAPI contract.';
+
+
+-- ============================================================================
+-- Section 2 — Fail-loud assertions
+-- ============================================================================
+-- Every column the deployed process_access_grant_event router writes MUST
+-- exist on the projection. Fail-loud at deploy time so this category of
+-- defect cannot land silently again.
+
+-- 2.1 — Affirmative: all handler-written columns exist
+DO $$
+DECLARE
+  v_handler_writes_columns text[] := ARRAY[
+    -- access_grant.created arm
+    'id', 'consultant_org_id', 'consultant_user_id', 'provider_org_id',
+    'scope', 'scope_id', 'authorization_type', 'authorization_reference',
+    'legal_reference', 'granted_by', 'granted_at', 'expires_at',
+    'permissions', 'terms', 'status', 'created_at', 'updated_at',
+    -- access_grant.revoked arm (post-rename + post-add)
+    'revoked_at', 'revoked_by', 'revocation_reason', 'revocation_details',
+    -- access_grant.expired arm (post-add)
+    'expired_at', 'expiration_type',
+    -- access_grant.suspended arm
+    'suspended_at', 'suspended_by', 'suspension_reason', 'suspension_details',
+    'expected_resolution_date',
+    -- access_grant.reactivated arm (post-rename)
+    'reactivated_at', 'reactivated_by', 'resolution_details'
+  ];
+  v_col text;
+  v_missing text[] := '{}';
+BEGIN
+  FOREACH v_col IN ARRAY v_handler_writes_columns
+  LOOP
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name   = 'cross_tenant_access_grants_projection'
+        AND column_name  = v_col
+    ) THEN
+      v_missing := array_append(v_missing, v_col);
+    END IF;
+  END LOOP;
+
+  IF array_length(v_missing, 1) > 0 THEN
+    RAISE EXCEPTION 'Hotfix assertion failed: handler writes to columns that do not exist post-migration: %', v_missing
+      USING ERRCODE = 'P9099';
+  END IF;
+  RAISE NOTICE 'Hotfix assertion PASS: all % handler-written columns exist on cross_tenant_access_grants_projection', array_length(v_handler_writes_columns, 1);
+END $$;
+
+-- 2.2 — Cross-check: the columns we renamed FROM should no longer exist
+DO $$
+DECLARE
+  v_legacy text[] := ARRAY['revoked_reason', 'reactivation_notes'];
+  v_col text;
+  v_still_present text[] := '{}';
+BEGIN
+  FOREACH v_col IN ARRAY v_legacy
+  LOOP
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name   = 'cross_tenant_access_grants_projection'
+        AND column_name  = v_col
+    ) THEN
+      v_still_present := array_append(v_still_present, v_col);
+    END IF;
+  END LOOP;
+
+  IF array_length(v_still_present, 1) > 0 THEN
+    RAISE EXCEPTION 'Hotfix assertion failed: legacy column names still present (rename did not take): %', v_still_present
+      USING ERRCODE = 'P9099';
+  END IF;
+  RAISE NOTICE 'Hotfix assertion PASS: legacy column names (revoked_reason, reactivation_notes) no longer present';
+END $$;

--- a/workflows/src/types/database.types.ts
+++ b/workflows/src/types/database.types.ts
@@ -2926,6 +2926,8 @@ export type Database = {
           consultant_user_id: string | null
           created_at: string | null
           expected_resolution_date: string | null
+          expiration_type: string | null
+          expired_at: string | null
           expires_at: string | null
           granted_at: string
           granted_by: string
@@ -2935,10 +2937,11 @@ export type Database = {
           provider_org_id: string
           reactivated_at: string | null
           reactivated_by: string | null
-          reactivation_notes: string | null
+          resolution_details: string | null
+          revocation_details: string | null
+          revocation_reason: string | null
           revoked_at: string | null
           revoked_by: string | null
-          revoked_reason: string | null
           scope: string
           scope_id: string | null
           status: string | null
@@ -2956,6 +2959,8 @@ export type Database = {
           consultant_user_id?: string | null
           created_at?: string | null
           expected_resolution_date?: string | null
+          expiration_type?: string | null
+          expired_at?: string | null
           expires_at?: string | null
           granted_at: string
           granted_by: string
@@ -2965,10 +2970,11 @@ export type Database = {
           provider_org_id: string
           reactivated_at?: string | null
           reactivated_by?: string | null
-          reactivation_notes?: string | null
+          resolution_details?: string | null
+          revocation_details?: string | null
+          revocation_reason?: string | null
           revoked_at?: string | null
           revoked_by?: string | null
-          revoked_reason?: string | null
           scope: string
           scope_id?: string | null
           status?: string | null
@@ -2986,6 +2992,8 @@ export type Database = {
           consultant_user_id?: string | null
           created_at?: string | null
           expected_resolution_date?: string | null
+          expiration_type?: string | null
+          expired_at?: string | null
           expires_at?: string | null
           granted_at?: string
           granted_by?: string
@@ -2995,10 +3003,11 @@ export type Database = {
           provider_org_id?: string
           reactivated_at?: string | null
           reactivated_by?: string | null
-          reactivation_notes?: string | null
+          resolution_details?: string | null
+          revocation_details?: string | null
+          revocation_reason?: string | null
           revoked_at?: string | null
           revoked_by?: string | null
-          revoked_reason?: string | null
           scope?: string
           scope_id?: string | null
           status?: string | null


### PR DESCRIPTION
## Summary

Hotfix for a **baseline_v4 schema-vs-handler column-name mismatch defect** surfaced during Phase 2 UAT execution (2026-06-09). Probe L8 (`api.revoke_access_grant` happy path) returned `PROCESSING_FAILED` with `column \"revocation_reason\" of relation \"cross_tenant_access_grants_projection\" does not exist`. Audit of all router arms revealed **3 of 5 grant lifecycle arms write to columns that don't exist** on the projection.

| Arm | Handler writes | Schema had | Status pre-hotfix |
|---|---|---|---|
| `revoked` | `revocation_reason`, `revocation_details` | `revoked_reason`, no `_details` | ❌ every revoke = `PROCESSING_FAILED` |
| `expired` | `expired_at`, `expiration_type` | neither column | ❌ all expirations broken |
| `reactivated` | `resolution_details` | `reactivation_notes` (different name) | ❌ all reactivations broken |
| `suspended` | all 5 cols | ✅ aligned | works |
| `policy_override` | `permissions` jsonb only | ✅ aligned | works |

## Why this surfaced now

Defect predates Phase 2 — handler was built against a different schema shape than what landed in `baseline_v4`. Surfaced now because Phase 2's cascade-revoke (`terminate_var_partnership` Step 13) is the first production path that emits `access_grant.revoked` at scale. Phase 2 architect review focused on the cascade-FIRST HIPAA invariant (preserved correctly) and Pattern A v2 envelope shape (preserved correctly) — neither line of review opens the handler arms' UPDATE column lists against the projection schema.

## Direction chosen

Per AsyncAPI contract + handler review: handler / AsyncAPI / event_data all use `revocation_*` / `expired_*` / `resolution_*` naming. The projection schema is the outlier. **Aligning the schema is the minimal-blast-radius fix**: no handler changes, no AsyncAPI changes, no event_data changes.

## Migration body (~205 lines)

- **1.1**: rename `revoked_reason` → `revocation_reason` (idempotent via `information_schema` lookups; `RENAME COLUMN IF EXISTS` doesn't exist in PG)
- **1.2**: add `revocation_details text` (idempotent)
- **1.3**: add `expired_at timestamptz` (idempotent)
- **1.4**: add `expiration_type text` (idempotent)
- **1.5**: rename `reactivation_notes` → `resolution_details` (idempotent)
- **1.6**: `COMMENT ON COLUMN` refreshes citing handler-side field names + Phase 2 UAT origin
- **2.1**: parametric assertion — all 31 handler-written columns MUST exist on the projection post-migration (fail-loud `P9099`)
- **2.2**: cross-check — legacy column names MUST NOT exist post-rename (fail-loud `P9099`)

## Deploy state (dev applied 2026-06-09)

```
Applying migration 20260609234958_fix_access_grant_projection_handler_schema_alignment.sql...
NOTICE: Renamed revoked_reason -> revocation_reason
NOTICE: Renamed reactivation_notes -> resolution_details
NOTICE: Hotfix assertion PASS: all 31 handler-written columns exist on cross_tenant_access_grants_projection
NOTICE: Hotfix assertion PASS: legacy column names (revoked_reason, reactivation_notes) no longer present
Finished supabase db push.
```

## L8 re-probe after deploy

Same probe that originally failed — now passes end-to-end:

```json
{
  "eventId": "71060c45-1495-4176-aff5-8855be5d3304",
  "grantId": "db590f01-31c3-4511-82fa-5f948bf74425",
  "success": true
}
```

Projection state confirmed:
```json
{
  "id": "db590f01-31c3-4511-82fa-5f948bf74425",
  "status": "revoked",
  "revoked_at": "2026-06-09T23:53:42.858364+00:00",
  "revoked_by": "440df2ae-c620-40d1-ae0a-0655ed68380b",
  "revocation_reason": "L8 rehotfix verification",
  "revocation_details": "Confirming the schema rename fixed PROCESSING_FAILED"
}
```

## database.types.ts regen pulled through

Both consumer copies updated byte-identical (`frontend/src/types/` + `workflows/src/types/`):
- 5 new column entries appear in the `cross_tenant_access_grants_projection` Row / Insert / Update types
- `frontend npm run typecheck` ✅, `workflows npm run build` ✅

## Codified pitfall #6 applied

Per the rule we just established in PR #71 architect Chunk 2 finding (`infrastructure/supabase/CLAUDE.md`): **BEFORE `CREATE OR REPLACE FUNCTION` of a pre-existing function, fetch the deployed body**. Same principle applies to schema-alignment work: fetched the deployed handler body via Mgmt API `pg_get_functiondef` to verify which columns it ACTUALLY writes (not just what reference files say). All 5 missing/mis-named column references confirmed against the deployed body before drafting fixes.

## What this PR does NOT touch

- Handler body — already correct
- AsyncAPI contracts (`access_grant.yaml`) — already correct
- Event_data emit shapes in Phase 2 RPCs — already correct
- Pattern A v2 read-back guards — work as designed (Phase 2 UAT C1 + L8 both surfaced the defect via the envelope, which is exactly what Pattern A v2 promised)

## Test plan

- [x] Migration deployed to dev cleanly with both assertion blocks PASS
- [x] L8 re-probe: `api.revoke_access_grant` returns `success: true`; projection row populates new column names
- [x] Stage Z teardown cleaned the re-probe fixtures
- [x] `database.types.ts` regen byte-identical to dev shape
- [x] Frontend typecheck + workflows build green
- [ ] Architect review (recommended given the "rename a deployed column" architectural decision)
- [ ] CI gates green
- [ ] Post-merge: deploy gates green
- [ ] Phase 2 UAT can now re-run L8 + Batch 3 cascade for full happy-path validation (currently UAT card has C1 as STRUCTURAL PASS only — partial-failure was the only path observable pre-hotfix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)