### PR TITLE
feat(grants): Phase 3 — make api.list_users grant-aware (Model M membership-oracle guard)

### DIFF
--- a/dev/active/cross-tenant-access-grant-rollout/pr-80-architect-review.md
+++ b/dev/active/cross-tenant-access-grant-rollout/pr-80-architect-review.md
@@ -1,0 +1,157 @@
+# PR #80 — Architect Review (Cross-tenant grant Phase 3: `api.list_users` Model M guard)
+
+**Status**: Review complete
+**Reviewer**: software-architect-dbc (Opus 4.8 1M)
+**Date**: 2026-06-22
+**Branch**: `feat/cross-tenant-grant-phase-3-list-users-membership-guard` (head `7f014afd`, base `main`)
+**Scope reviewed**: migration `20260622183824_phase_3_list_users_membership_guard.sql`, parent card handoff (`tasks.md`), new sub-card (`seed-list-invitations-cross-tenant-visibility-decision.md`), reachability matrix doc, `infrastructure/supabase/CLAUDE.md` variant note.
+
+---
+
+## Verdict: **APPROVE**
+
+This is a clean, minimal, well-reasoned change. The guard swap is correct, the query body is byte-identical to the deployed predecessor (pitfall #6 satisfied by construction), the COMMENT re-issue is structurally consistent with both codegen parsers, the matrix doc hand-edits byte-match what the generators will reproduce, and the `list_invitations` split-out is the right call. No blocking or should-fix findings. Two nits (optional, non-blocking) and a set of pre-merge verification reminders are listed below.
+
+The "address inline, not via cards" default does not force any in-PR code change here — the only deferred item (`list_invitations`) is correctly carded because it is genuinely out of scope (needs a permission seed + a HIPAA policy decision), not a punt on a fixable defect.
+
+---
+
+## Evidence gathered
+
+1. **Deployed predecessor identified correctly.** The baseline_v4 body of `api.list_users` (L4584) is NOT the deployed body — PR #66 (`20260519233323_fix_list_users_include_roleless.sql`) replaced it with the `accessible_organizations @>` + `COUNT(*) OVER ()` single-pass form. No migration between PR #66 and this PR re-defines `api.list_users` (verified: only `20260519233323` and `20260622183824` `CREATE OR REPLACE` the exact 7-arg signature; the `20260521195657` and Phase 1 migrations touch only the *sister* RPCs and the tag backfill). So PR #66 is the true pre-image for the pitfall-#6 diff.
+2. **Query body is byte-identical to the deployed predecessor.** `diff` of the new body L76–131 against PR #66 L145–200 = identical. The *only* substantive change is the guard block (new L62–71 vs PR #66 L135–140). Pitfall #6 ("preserve every load-bearing line not deliberately changed") is satisfied — nothing silently changed.
+3. **Signature/return shape unchanged** → `CREATE OR REPLACE` preserves the OID, owner, and ACL. The migration correctly omits `ALTER FUNCTION ... OWNER TO` and `GRANT EXECUTE` — matching the established PR #66 convention (CREATE OR REPLACE keeps both). No M3 DROP+CREATE re-tag concern (pitfall: that rule only fires on signature change).
+4. **COMMENT re-issue is parser-consistent.** Both `gen-rpc-registry.cjs` (`d.description ~ '@a4c-rpc-shape:\s*read'`) and `gen-rpc-reachability-matrix.cjs` (`@a4c-${tag}:\s*([^\n]+?)(?=\n|$)`) use single-line tag regexes, so the new COMMENT's tag block parses regardless of intervening blank lines. `@a4c-rpc-shape: read` preserved; `@a4c-bucket: A` preserved; `@a4c-consultant-callable` flips `pending-phase3-refactor`→`yes`; `@a4c-phase-target` flips `3`→`none`. Correct.
+5. **Matrix doc hand-edits byte-match the generators.** The `@a4c-consultant-callable-reason` value in the migration COMMENT is byte-identical to the Reason column in BOTH the `PER-RPC-TABLE` row (matrix L218) and the `PHASE-3-TARGETS` row (matrix L288). Since the reachability matrix `.md` is codegen-GENERATED between markers and CI (`rpc-reachability-matrix-sync.yml`) regenerates from the live DB COMMENT and fails on drift, this byte-match is what keeps CI green. Verified equal.
+
+---
+
+## Security / correctness of the new guard
+
+```sql
+IF NOT (
+  public.has_platform_privilege()
+  OR EXISTS (
+    SELECT 1 FROM public.users caller
+    WHERE caller.id = public.get_current_user_id()
+      AND caller.accessible_organizations @> ARRAY[p_org_id]::uuid[]
+  )
+) THEN
+  RETURN;
+END IF;
+```
+
+- **42702 ambiguity fixed.** The function `RETURNS TABLE(id uuid, ...)`, so an unqualified `id` in the EXISTS would collide with the OUT column. The `caller` alias + `caller.id` qualifies it. No other unqualified-column hazard in the guard — `accessible_organizations` and `p_org_id` are unambiguous (`p_org_id` is a parameter; `accessible_organizations` is qualified via `caller.`). PASS.
+- **No existence leak (Bucket A invariant).** Denied callers hit `RETURN` (empty), indistinguishable from "org with no members." No `RAISE`. PASS.
+- **No false-admit path.** A non-member fails both disjuncts: not a platform admin, and `accessible_organizations` does not contain `p_org_id` → `EXISTS` is false → `RETURN`. The oracle is trigger-maintained (UNION of direct membership + active in-window grants), so a stale/expired grant is already removed from `accessible_organizations` by `sync_accessible_organizations_from_grants`. The guard cannot admit on an expired grant unless the trigger invariant is itself broken (out of scope; pre-existing Phase 1 surface). PASS.
+- **NULL-safety for anon.** `get_current_user_id()` returns NULL when no JWT/override is present. `caller.id = NULL` matches zero rows → `EXISTS` false → `RETURN`. Anonymous callers get empty. PASS.
+
+### Guard vs query-body consistency invariant (the central claim)
+
+The PR claims "may you ask" and "what you see" can never disagree because both reference `accessible_organizations @> ARRAY[p_org_id]`. **Validated against the SQL:**
+
+- Guard predicate: `caller.accessible_organizations @> ARRAY[p_org_id]` where `caller.id = get_current_user_id()`.
+- Query predicate (L101): `u.accessible_organizations @> ARRAY[p_org_id]` over all rows.
+
+These reference the **same column, same operator, same RHS**, differing only in subject (the caller vs. the listed users). The invariant is therefore: *the caller is admitted iff the caller is a member of `p_org_id`; the rows returned are exactly the members of `p_org_id`.* A subtle but correct consequence — if the caller is admitted, the caller themselves appears in their own result set (they are a member of `p_org_id`). That is the desired "what you can ask about == the population you see" property. Invariant holds. PASS.
+
+### Design-by-Contract notes for the guard
+
+```
+api.list_users(p_org_id, ...)
+
+Precondition (admit):  has_platform_privilege()
+                       OR EXISTS member row: caller.accessible_organizations @> [p_org_id]
+Precondition (deny):   ¬(above)  ⇒  RETURN ∅  (no RAISE; no existence signal)
+
+Postcondition (admitted): result = { u ∈ users : u.accessible_organizations @> [p_org_id]
+                                                  ∧ status-filter ∧ search-filter }
+                          total_count = COUNT(*) OVER () of the filtered set
+                          (empty set ⇒ zero rows emitted ⇒ total_count implicitly 0)
+
+Invariant: GUARD_SUBJECT_PREDICATE ≡ QUERY_ROW_PREDICATE  (same oracle, same operator)
+           ⇒ "authorized to ask about org X"  ⇔  "X is in caller's accessible_organizations"
+           ⇒ admitted caller is always a member of the population they enumerate.
+
+Invariant (oracle): accessible_organizations is trigger-maintained UNION
+           (user_organizations_projection ∪ active in-window cross_tenant grants).
+           Never written directly; expiry/revoke removes the org from the array.
+```
+
+---
+
+## Backward compatibility (superset claim)
+
+- **Platform admins**: `has_platform_privilege()` short-circuits — unchanged. PASS.
+- **Org-internal admins**: previously admitted by `p_org_id = get_current_org_id()`. Their session org is, by direct `user_organizations_projection` membership, in their own `accessible_organizations`. The new EXISTS admits them. The only theoretical regression is a user whose JWT `org_id` (session pointer) names an org that is somehow NOT in their `accessible_organizations` — but per the CLAUDE.md oracle rule, `current_organization_id`/`org_id` is the *active-session pointer* and a member's session org is always a subset of their accessible set by construction. So the new guard is a true superset of the old one for legitimate callers, and *net-removes* one unsound admit path: the old form would admit a caller whose session `org_id == p_org_id` even if they had been removed from membership but still carried a stale JWT; the new form re-checks live membership. This is a correctness improvement, not a regression. PASS (superset + tightening).
+- **Grant-bearers**: net-new admits (the Phase 3 goal). PASS.
+
+---
+
+## Performance
+
+- The extra `EXISTS` is a single-row PK lookup (`caller.id = get_current_user_id()`) followed by an in-row array containment test — O(1) on the PK index; the `@>` on the already-fetched row does not need the GIN index. Negligible per-call cost. PASS.
+- The query-body predicate `u.accessible_organizations @> ARRAY[p_org_id]::uuid[]` is sargable against `idx_users_accessible_orgs_gin` (GIN `array_ops` indexes `@>`). Unchanged from PR #66. On small dev tables the planner still prefers Seq Scan (correct). PASS.
+- One micro-note (NOT a finding): the guard's EXISTS reads the caller's row, and the body re-reads the same row among the result set — two logical touches of `public.users` per call. This is inherent to the membership-oracle pattern and not worth optimizing; mentioned only for completeness.
+
+---
+
+## `list_invitations` split-out assessment
+
+Deferring `list_invitations` out of Phase 3 is **correct**:
+
+- The original 2026-05-26 handoff was demonstrably wrong: `invitation.read` does not exist (no `invitation.*` permission family is seeded), and a `has_effective_permission('user.view', path)` gate on `list_users` would be inert (no template confers `user.view`) and would violate the users-as-identities scoped-vs-unscoped rule. The PR's re-adjudication of the handoff is sound and well-documented in `tasks.md` (with the superseded version retained for provenance — good practice).
+- Unlike `list_users`, `list_invitations` is not a clean guard swap: it pulls in (a) a permission seed via `permission.defined` and (b) a HIPAA exposure-policy decision (does a clinical-grant consultant see pending invitee PII?). These are genuinely separate work, not a punt on a fixable defect — so a card is the right vehicle, not an in-PR fix.
+- The sub-card is well-formed: states the problem, the current deployed state, three explicitly gating decisions (exposure policy FIRST; permission seed only IF yes; RAISE→RETURN info-leak fix bundled with the rework so admin-tooling error UX isn't silently changed), an implementation sketch, relationships, and out-of-scope. It correctly flags the existing `RAISE EXCEPTION` info-leak (D3) but correctly declines to fix it now (changing it while still org-admin-only would silently alter admin-tooling error UX). Good judgment.
+
+PASS.
+
+---
+
+## Mandatory Architecture Review Checklist
+
+- **[PASS] CQRS Standards** — `list_users` is a Bucket-A read RPC; query-only; no projection writes; reads the membership oracle. `@a4c-rpc-shape: read` preserved. No command/query boundary violation.
+- **[PASS] Naming Conventions** — `caller` alias, `Model M` comment marker, migration filename via the timestamped convention (`20260622183824_...`). Consistent with the `list_users*` family skeleton doc.
+- **[PASS] Design Patterns** — Membership-oracle tenancy guard (the deliberate Bucket-A variant), not the three-step perm-gated skeleton. The PR's rejection of `has_effective_permission('user.view', path)` is *correct* per the users-as-identities scoped-vs-unscoped rule AND because no template confers `user.view` (the gate would be inert). Not over-engineered; not under-engineered.
+- **[N/A] data-testid Attributes** — backend SQL migration; no UI surface in this PR.
+- **[PASS] AsyncAPI Event Registration** — no new/modified events (read-only RPC emits nothing). Correctly unchanged.
+- **[PASS] Type Generation — No Anonymous Types** — return shape unchanged → no TS regen required; the `database.types.ts` pair stays in sync by virtue of an unchanged signature. M3 shape comment (`read`) preserved. Correct per the "regen only on surface change" rule.
+- **[PASS] Observability/Tracing** — read RPC; no new write/audit path; no silent code path introduced. Denied path is an explicit `RETURN` (Bucket A semantics), intentionally non-signalling — appropriate for an enumeration guard (signalling here would be the existence leak we are avoiding).
+- **[PASS w/ NOTE] Error Surfacing to UI** — `list_users` returns empty on deny by design (Bucket A no-leak). This is the intended contract, not a swallowed error. NOTE for the frontend: an admin who *expects* members but is mis-scoped sees an empty list rather than an authz error — this is the deliberate trade-off documented in PR #66 and unchanged here. No action required.
+
+---
+
+## Items to address
+
+All items below are **optional nits / pre-merge verification reminders** — none are blocking and none change the APPROVE verdict.
+
+1. **(Nit, optional)** In the new COMMENT, consider dropping the trailing reference to `trg_sync_accessible_orgs` lineage that PR #66's COMMENT carried — the new COMMENT already re-states the oracle as "the UNION of direct `user_organizations_projection` membership AND active in-window `cross_tenant_access_grants_projection` grants," which is the more accurate post-Phase-1 description. No change strictly required; the new text is already correct. (File: `20260622183824_...sql:143`.)
+
+2. **(Verification, pre-merge)** Run the reachability-matrix codegen locally against a freshly-migrated local container and confirm zero diff, to pre-empt the CI `rpc-reachability-matrix-sync.yml` gate:
+   ```bash
+   cd frontend && npm run gen:rpc-reachability-matrix && \
+     git diff --exit-code documentation/architecture/authorization/cross-tenant-access-grant-rpc-reachability-matrix.md
+   ```
+   (Static analysis already confirms the reason strings byte-match in all three locations; this is belt-and-suspenders.)
+
+3. **(Verification, pre-merge)** Run the M3 registry codegen and confirm `list_users` stays classified `read` with zero diff:
+   ```bash
+   cd frontend && npm run gen:rpc-registry && \
+     git diff --exit-code src/services/api/rpc-registry.generated.ts
+   ```
+
+4. **(Verification, pre-merge — recommended)** Execute the transactional simulate-JWT smoke described in the sub-card / Phase 3 close-out (in-txn grant insert → trigger fires → `set_config('app.current_user', <consultant>)` + simulate claims → `SELECT * FROM api.list_users(<provider_org>, ...)` returns the provider's members → `ROLLBACK`). Confirms the guard admits a grant-bearer end-to-end and that a non-grant consultant gets empty. Paste the artifact into the Phase 3 close-out.
+
+5. **(Nit, optional)** Sub-card decision #3 (RAISE→RETURN for `list_invitations`) is correctly deferred; when that card is picked up, ensure the info-leak fix and the membership conjunct land in the *same* migration so the org-admin error UX change and the new visibility are reviewed together. (Already noted in the card; flagging so it isn't lost.) No action this PR.
+
+---
+
+## Decision Record (condensed)
+
+- **Context**: Phase 3 of the cross-tenant grant rollout. Consultants holding an active grant keep their JWT `org_id` at their home org, so the PR #66 session-org guard (`p_org_id = get_current_org_id()`) rejected them despite legitimate membership in `accessible_organizations`.
+- **Decision**: Replace the session-org equality with an EXISTS against the caller's `accessible_organizations @> [p_org_id]` (Model M), making the guard reference the same oracle as the query body. Defer `list_invitations` to a decision-gated sub-card.
+- **Alternatives rejected**: (a) Three-step `has_effective_permission('user.view', path)` skeleton — inert (no template confers `user.view`) and violates the users-as-identities scoped-vs-unscoped rule; (b) `has_cross_tenant_access(...)` gate — deployed stub returning FALSE; (c) bundling `list_invitations` — needs a permission seed + HIPAA policy decision, out of scope.
+- **Consequences**: Grant-bearers gain `list_users` visibility; org-internal/admin/platform callers unaffected (true superset, with a minor soundness *improvement* — stale-JWT session-org admits are eliminated). Reachability matrix flips `list_users` to consultant-callable=yes, phase-target=none. No TS/AsyncAPI changes.
+- **Pitfalls honored**: #6 (body fetched verbatim, only guard changed — query body byte-identical to PR #66); M3 OID/comment preservation (no signature change); Bucket-A RETURN-empty no-leak.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/dev/active/cross-tenant-access-grant-rollout/tasks.md
+++ b/dev/active/cross-tenant-access-grant-rollout/tasks.md
@@ -165,12 +165,18 @@ ADR Phase 1 manifest changes:
 - **14. (new)** Ship codegen script `frontend/scripts/gen-rpc-reachability-matrix.cjs`.
 - **15. (new)** Ship CI workflow `.github/workflows/rpc-reachability-matrix-sync.yml`.
 
-### Phase 3 handoff (2-RPC scope after architect review)
+### Phase 3 handoff (CORRECTED 2026-06-22 — architect re-adjudication)
 
-| RPC | Bucket | Work |
-|---|---|---|
-| `api.list_users` | A (strict) | Replace early-return guard with PR #67 three-step skeleton |
-| `api.list_invitations` | A-variant | Replace early-RAISE guard with three-step skeleton + permission check on `invitation.read` |
+> **The original 2026-05-26 handoff below was WRONG on both RPCs** (`software-architect-dbc` re-adjudication 2026-06-22, record `~/.claude/plans/fizzy-jingling-puppy-agent-a9866ddd44acd09e3.md`). It assumed the three-step perm-gated skeleton + an `invitation.read` permission, but: `invitation.read` **does not exist** (no `invitation.*` family seeded); a `has_effective_permission('user.view', path)` gate on `list_users` violates the users-as-identities scoped-vs-unscoped rule AND is **inert** (no template confers `user.view`); and `has_cross_tenant_access(...)` is a deployed stub returning FALSE.
+
+| RPC | Bucket | Work | Status |
+|---|---|---|---|
+| `api.list_users` | A (strict) | **Model M** — swap the session-org guard (`p_org_id = get_current_org_id()`) for a membership-oracle `EXISTS` against the caller's `accessible_organizations @> [p_org_id]` (NOT the three-step perm-gated skeleton). | **DONE** — migration `20260622183824` |
+| `api.list_invitations` | A-variant | **Split out** — needs an exposure-policy decision (does a clinical-grant consultant see an org's invitations? likely NO) + an `invitation.read` permission seed if yes. | **Deferred** → `dev/active/seed-list-invitations-cross-tenant-visibility-decision.md` |
+
+Original (superseded) handoff, kept for provenance:
+| `api.list_users` | A (strict) | ~~Replace early-return guard with PR #67 three-step skeleton~~ |
+| `api.list_invitations` | A-variant | ~~Replace early-RAISE guard with three-step skeleton + permission check on `invitation.read`~~ |
 
 ### Phase 4 handoff (Bucket D + D-variant RLS audit scope — 35 RPCs)
 

--- a/dev/active/seed-list-invitations-cross-tenant-visibility-decision.md
+++ b/dev/active/seed-list-invitations-cross-tenant-visibility-decision.md
@@ -1,0 +1,44 @@
+# `api.list_invitations` cross-tenant visibility — exposure-policy decision (then maybe refactor)
+
+**Status**: seed (not yet planned) — **decision-gated**
+**Priority**: Low-Medium (no current consultant use case; forward-need split out of Phase 3)
+**Origin**: Cross-tenant grant Phase 3 (PR for migration `20260622183824`). Architect (`software-architect-dbc`, 2026-06-22) split `list_invitations` out of Phase 3 because, unlike `list_users`, it is NOT a clean guard swap — it pulls in a permission seed + a HIPAA exposure-policy decision.
+
+## Problem / why this is its own card
+
+Phase 3 made `api.list_users` grant-aware (Model M membership-oracle guard) so cross-tenant consultants can list a provider org's **users**. The 2026-05-26 handoff wanted the same treatment for `api.list_invitations` "+ a permission check on `invitation.read`." Re-adjudication found that path is **not implementable as written**:
+
+1. **`invitation.read` does not exist.** There is NO `invitation.*` permission family in `permissions_projection` at all (only `user.create/update/delete/view/role_assign/role_revoke/client_assign/schedule_manage`). Gating on it requires first seeding it via the `permission.defined` event flow — with implication wiring + a decision about which role templates receive it.
+
+2. **It is a HIPAA exposure-policy decision, not guard mechanics.** Invitations carry **invitee email + name + role intentions** — a pre-onboarding admin surface. "Should a cross-tenant consultant see a provider org's *pending invitations*?" is a policy question. A `var_contract` analytics consultant almost certainly should NOT; an `emergency_access` clinician (whose template confers `client.view`/`medication.view`, not user-admin visibility) almost certainly should NOT. **Likely answer: no consultant lists invitations → leave `api.list_invitations` unchanged (org-admin-only).**
+
+## Current deployed state (for reference)
+
+`api.list_invitations(p_org_id uuid, p_status text[], p_search_term text)`:
+- Guard: `IF NOT (has_platform_privilege() OR (has_org_admin_permission() AND p_org_id = get_current_org_id())) THEN RAISE EXCEPTION 'Insufficient permissions...'; END IF;`
+- `has_org_admin_permission()` is JWT-GLOBAL / scope-blind (checks `effective_permissions` for `user.manage`/`role.*`/`organization.manage` anywhere).
+- Query: `WHERE i.organization_id = p_org_id` (FK column, not a membership predicate).
+- **RAISE on reject** (reveals org existence to a probing cross-tenant caller — see D3 below).
+
+## Decisions (gating — do not build until locked)
+
+1. **Exposure policy FIRST**: do consultants ever list a provider org's invitations? Default recommendation: **NO** → close this card as "won't do; org-admin-only is correct," leaving `list_invitations` unchanged.
+2. **If YES for some grant type**: seed `invitation.read` via `permission.defined` (+ implication from which existing admin perm? + which templates carry it). Then gate with a membership conjunct (`accessible_organizations @> [p_org_id]`) AND the permission — together, not either-or.
+3. **Info-leak (D3)**: if reworked, switch the reject path from `RAISE EXCEPTION` to `RETURN` (empty) so a denied caller and a non-existent org are byte-indistinguishable (matching `list_users` Bucket A). Do this **together** with the rework — swallowing the RAISE while it's still org-admin-only would silently change existing admin-tooling error UX.
+
+## Implementation sketch (only if decision #1 = YES)
+
+1. `permission.defined` migration seeding `invitation.read` (+ implication wiring + template assignment).
+2. `CREATE OR REPLACE api.list_invitations` (pitfall #6: fetch deployed body first) — guard becomes `has_platform_privilege() OR (has_effective_permission('invitation.read', <org_path>) AND accessible_organizations @> [p_org_id])`; reject path RAISE→RETURN-empty; re-issue COMMENT (consultant-callable tag) + regenerate reachability matrix.
+3. Verify via the transactional simulate-JWT pattern (Phase 3 close-out has the exact recipe: in-txn grant insert → trigger → simulate consultant JWT → call → ROLLBACK).
+
+## Relationships
+
+- **Sibling of** (shipped): `list_users` Model M refactor (Phase 3, migration `20260622183824`).
+- **Under**: parent `cross-tenant-access-grant-rollout/` (Phase 3 follow-up).
+- The UI second-axis "direct member vs grant-bearer" segregation filter is a **Phase N** concern (ADR § user-visibility-consequence), not this card.
+
+## Out of scope
+
+- Any change to `list_users` (done).
+- Phase 4 Bucket D RLS audit.

--- a/documentation/architecture/authorization/cross-tenant-access-grant-rpc-reachability-matrix.md
+++ b/documentation/architecture/authorization/cross-tenant-access-grant-rpc-reachability-matrix.md
@@ -215,7 +215,7 @@ In addition to the formal `@a4c-bucket` / `@a4c-consultant-callable` / `@a4c-pha
 | `list_user_client_assignments` | D | pending-phase4-rls | 4 | Entity-lookup signature with RLS-enforced tenancy; per-table RLS extension required in Phase 4. |
 | `list_user_org_access` | E | yes | none | No tenancy context; grant-irrelevant by default. Per-RPC sub-classification ([admin-only] / [service-role-only] / [pre-auth] / [emitter-primitive]) deferred to follow-up. |
 | `list_user_organizations` | E-variant | yes | none | E-variant: sui generis (mixed self-context + org-admin predicate). |
-| `list_users` | A | pending-phase3-refactor | 3 | Early-return tenancy guard (PR #66 strict-A pattern); forward-incompatible with grant-bearers; Phase 3 refactor target. |
+| `list_users` | A | yes | none | Grant-derived membership via accessible_organizations (Model M, Phase 3): a consultant holding an active in-window grant to p_org_id has it in accessible_organizations and is admitted by the membership-oracle tenancy guard. RETURN-empty for non-members (no existence leak). |
 | `list_users_for_bulk_assignment` | C | yes | none | Scope-path-bound has_effective_permission; forward-compatible with multi-scope grants under Phase 1 tightened DISTINCT ON. |
 | `list_users_for_role_management` | C | yes | none | Scope-path-bound has_effective_permission; forward-compatible with multi-scope grants under Phase 1 tightened DISTINCT ON. |
 | `list_users_for_schedule_management` | C | yes | none | Scope-path-bound has_effective_permission; forward-compatible with multi-scope grants under Phase 1 tightened DISTINCT ON. |
@@ -279,13 +279,13 @@ In addition to the formal `@a4c-bucket` / `@a4c-consultant-callable` / `@a4c-pha
 
 ## Phase 3 refactor target list (Bucket A + A-variant)
 
-**2 RPCs** to refactor in Phase 3 to the PR #67 three-step skeleton (replace early-return / early-raise guard with `has_effective_permission` + `accessible_organizations @>` membership predicate):
+Bucket A + A-variant RPCs (the table below is **bucket-derived**, so it lists these regardless of completion status). **Status as of Phase 3 (PR for `20260622183824`):** `list_users` is **DONE** — refactored to the Model M membership-oracle tenancy guard (consultant-callable=yes), NOT the originally-handoff'd three-step perm-gated skeleton (that skeleton violated the users-as-identities scoped-vs-unscoped rule and was inert — no template confers `user.view`). `list_invitations` is **deferred** to its own sub-card (`seed-list-invitations-cross-tenant-visibility-decision`) pending an `invitation.read` permission seed + a HIPAA exposure-policy decision (does a clinical-grant consultant see an org's invitations?).
 
 <!-- GENERATED:PHASE-3-TARGETS:START -->
 | `api.<name>` | Bucket | Reason |
 |---|---|---|
 | `list_invitations` | A-variant | A-variant: same equality-check shape as strict-A but RAISEs instead of RETURNs; Phase 3 refactor target. |
-| `list_users` | A | Early-return tenancy guard (PR #66 strict-A pattern); forward-incompatible with grant-bearers; Phase 3 refactor target. |
+| `list_users` | A | Grant-derived membership via accessible_organizations (Model M, Phase 3): a consultant holding an active in-window grant to p_org_id has it in accessible_organizations and is admitted by the membership-oracle tenancy guard. RETURN-empty for non-members (no existence leak). |
 <!-- GENERATED:PHASE-3-TARGETS:END -->
 
 If future RPCs adopt the early-return/early-raise guard pattern (anti-recommended; the three-step skeleton should be the default), they would land in Bucket A or A-variant and need the same refactor.

--- a/infrastructure/supabase/CLAUDE.md
+++ b/infrastructure/supabase/CLAUDE.md
@@ -242,7 +242,16 @@ The four `api.list_users*` RPCs share a normalized three-step skeleton (establis
    - template-id signature (`list_users_for_schedule_management`): `v_org_id := public.get_current_org_id();` then validate template belongs to that org
 3. **Membership-predicate query**: `WHERE u.accessible_organizations @> ARRAY[v_org_id]::uuid[]` — the canonical membership oracle, GIN-indexed via `idx_users_accessible_orgs_gin`. NEVER use `current_organization_id = v_org_id` (that's the user's active-session pointer, not a membership oracle) and NEVER use `scalar = ANY(accessible_organizations)` (GIN `array_ops` doesn't index that form — the `@>` containment form is required).
 
-**Variant**: `api.list_users` (PR #66) uses an early-return tenancy guard (`IF NOT (has_platform_privilege() OR p_org_id = get_current_org_id()) THEN RETURN; END IF;`) in place of the scope-bound permission gate, because its signature takes an explicit `p_org_id` parameter without a permission name. This guard is correct for the org-internal admin use case but is potentially incompatible with future cross-tenant grants — flagged for future audit when partner-grant work activates.
+**Variant**: `api.list_users` uses an early-return tenancy guard (no scope-bound permission gate) because its signature takes an explicit `p_org_id` parameter without a permission name. **Audit resolved (Phase 3, migration `20260622183824`)**: the guard was upgraded from the PR #66 session-org form (`p_org_id = get_current_org_id()` — rejected grant-bearers, whose JWT `org_id` stays at home org) to the **Model M membership-oracle** form:
+```sql
+IF NOT (
+  public.has_platform_privilege()
+  OR EXISTS (SELECT 1 FROM public.users caller
+             WHERE caller.id = public.get_current_user_id()
+               AND caller.accessible_organizations @> ARRAY[p_org_id]::uuid[])
+) THEN RETURN; END IF;
+```
+`list_users` REMAINS the deliberate tenancy-guard variant — it was explicitly NOT converted to the three-step `has_effective_permission(perm, scope_path)` skeleton, because (1) users-as-identities have no org location finer than tenant (scoped-vs-unscoped rule below), and (2) no grant template confers `user.view`, so a scope-path perm gate would be inert for every consultant. Model M keeps the guard and the query predicate referencing the SAME oracle (`accessible_organizations @> [p_org_id]`). Note: alias the `users` table in the guard's EXISTS — `list_users` RETURNS a `TABLE(id uuid, …)` so an unqualified `id` is ambiguous (42702). See [[pr-79-close-out]]-adjacent Phase 3 close-out + architect record `~/.claude/plans/fizzy-jingling-puppy-agent-a9866ddd44acd09e3.md`.
 
 **Two-step → one-step normalization (PR #67)**: legacy bodies that derived `v_user_scope := public.get_permission_scope(perm)` and then manually checked `v_user_scope @> p_scope_path` should be collapsed to a single `has_effective_permission(perm, p_scope_path)` call. This is strictly more correct under multi-scope JWT entries (cross-tenant grant scenario): `get_permission_scope` does `LIMIT 1`; `has_effective_permission` does `EXISTS`. Today they're observationally equivalent because `compute_effective_permissions` ends in `DISTINCT ON (permission_name)`, but that invariant is one cross-tenant-grant feature away from breaking.
 

--- a/infrastructure/supabase/supabase/migrations/20260622183824_phase_3_list_users_membership_guard.sql
+++ b/infrastructure/supabase/supabase/migrations/20260622183824_phase_3_list_users_membership_guard.sql
@@ -1,0 +1,150 @@
+-- =============================================================================
+-- Cross-tenant grant Phase 3: make api.list_users grant-aware (Model M).
+-- =============================================================================
+--
+-- Card: dev/active/cross-tenant-access-grant-rollout/ (Phase 3)
+-- Architect re-adjudication (software-architect-dbc, 2026-06-22) decision record:
+--   ~/.claude/plans/fizzy-jingling-puppy-agent-a9866ddd44acd09e3.md
+--
+-- PROBLEM: api.list_users rejects cross-tenant consultants. Its tenancy guard
+-- checks `p_org_id = get_current_org_id()` — the caller's SESSION/home org from
+-- the JWT — but a consultant holding an active grant to a provider org keeps
+-- their JWT org_id at their HOME org. So a grant-bearer who legitimately has the
+-- provider org in public.users.accessible_organizations (the Phase-1 triggers
+-- fold active in-window grants into that array) is still turned away at the
+-- guard, even though the query body ALREADY filters on
+-- `accessible_organizations @> ARRAY[p_org_id]`.
+--
+-- FIX (Model M — membership-oracle tenancy guard): replace the session-org
+-- equality with an EXISTS against the caller's own accessible_organizations.
+-- The guard now references the SAME oracle as the query predicate, so "may you
+-- ask" and "what you see" can never disagree. Backward-compatible superset:
+-- platform admins and org-internal callers (their session org is in their own
+-- accessible_organizations via direct membership) are still admitted; grant-
+-- bearers are net-new (the Phase 3 goal). RETURN-empty (Bucket A) semantics
+-- preserved — a denied caller is indistinguishable from an org with no members.
+--
+-- WHY NOT the prior handoff's "three-step perm-gated skeleton": (1) it violates
+-- the scoped-vs-unscoped rule (users-as-identities have no org location finer
+-- than tenant → tenancy guard, NOT has_effective_permission(perm, path) —
+-- infrastructure/supabase/CLAUDE.md); (2) it is inert — no grant template
+-- confers user.view, so a has_effective_permission('user.view', path) gate
+-- would enable zero consultants. has_cross_tenant_access(...) is also a deployed
+-- stub returning FALSE, so reading accessible_organizations directly is the only
+-- grant-aware mechanism that works today.
+--
+-- Body fetched verbatim via Mgmt API pg_get_functiondef (codified pitfall #6);
+-- the ONLY change is the guard block (search "Model M"). Signature UNCHANGED →
+-- CREATE OR REPLACE preserves OID; the COMMENT (M3 @a4c-rpc-shape + reachability
+-- tags) is re-issued below to flip @a4c-consultant-callable. No TS regen (return
+-- shape unchanged), no AsyncAPI change.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION api.list_users(p_org_id uuid, p_status text DEFAULT NULL::text, p_search_term text DEFAULT NULL::text, p_sort_by text DEFAULT 'name'::text, p_sort_desc boolean DEFAULT false, p_page integer DEFAULT 1, p_page_size integer DEFAULT 20)
+ RETURNS TABLE(id uuid, email text, first_name text, last_name text, name text, is_active boolean, deleted_at timestamp with time zone, created_at timestamp with time zone, updated_at timestamp with time zone, last_login timestamp with time zone, roles jsonb, total_count bigint)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'api'
+AS $function$
+BEGIN
+  -- Tenancy guard (Model M — Phase 3, cross-tenant-grant rollout): platform
+  -- admins OR any caller who is a MEMBER of p_org_id. Membership is read from
+  -- public.users.accessible_organizations — the canonical oracle that the
+  -- Phase-1 triggers maintain as the UNION of direct user_organizations_projection
+  -- membership AND active in-window cross_tenant_access_grants_projection grants.
+  -- Replaces the prior `p_org_id = get_current_org_id()` session-org check, which
+  -- rejected grant-bearers (their JWT org_id stays at their home org). The guard
+  -- now references the SAME oracle as the query predicate below, so they can
+  -- never disagree. RETURN-empty (Bucket A) semantics preserved: a denied caller
+  -- is indistinguishable from an org with no members (no existence leak).
+  -- NB: alias the table (caller) — this function RETURNS TABLE(id uuid, ...),
+  -- so an unqualified `id` here is ambiguous with the OUT column (SQLSTATE 42702).
+  IF NOT (
+    public.has_platform_privilege()
+    OR EXISTS (
+      SELECT 1 FROM public.users caller
+      WHERE caller.id = public.get_current_user_id()
+        AND caller.accessible_organizations @> ARRAY[p_org_id]::uuid[]
+    )
+  ) THEN
+    RETURN;
+  END IF;
+
+  -- Single-pass query: predicate lives in ONE place. COUNT(*) OVER ()
+  -- computes the total over the filtered rowset BEFORE LIMIT/OFFSET so
+  -- pagination math stays correct.
+  RETURN QUERY
+  SELECT
+    u.id,
+    u.email,
+    u.first_name,
+    u.last_name,
+    u.name,
+    u.is_active,
+    u.deleted_at,
+    u.created_at,
+    u.updated_at,
+    u.last_login,
+    COALESCE(
+      (SELECT jsonb_agg(jsonb_build_object(
+        'role_id',   ur.role_id,
+        'role_name', r.name
+      ))
+      FROM public.user_roles_projection ur
+      JOIN public.roles_projection r ON r.id = ur.role_id
+      WHERE ur.user_id = u.id
+        AND ur.organization_id = p_org_id),
+      '[]'::jsonb
+    ) AS roles,
+    COUNT(*) OVER () AS total_count
+  FROM public.users u
+  WHERE u.accessible_organizations @> ARRAY[p_org_id]::uuid[]
+  AND (
+    CASE
+      WHEN p_status = 'active'      THEN u.is_active = TRUE  AND u.deleted_at IS NULL
+      WHEN p_status = 'deactivated' THEN u.is_active = FALSE AND u.deleted_at IS NULL
+      WHEN p_status = 'deleted'     THEN u.deleted_at IS NOT NULL
+      ELSE u.deleted_at IS NULL  -- default: exclude soft-deleted
+    END
+  )
+  AND (p_search_term IS NULL
+       OR u.email ILIKE '%' || p_search_term || '%'
+       OR u.name  ILIKE '%' || p_search_term || '%')
+  ORDER BY
+    CASE WHEN NOT p_sort_desc THEN
+      CASE p_sort_by
+        WHEN 'name'       THEN u.name
+        WHEN 'email'      THEN u.email
+        WHEN 'created_at' THEN u.created_at::TEXT
+        ELSE u.name
+      END
+    END ASC NULLS LAST,
+    CASE WHEN p_sort_desc THEN
+      CASE p_sort_by
+        WHEN 'name'       THEN u.name
+        WHEN 'email'      THEN u.email
+        WHEN 'created_at' THEN u.created_at::TEXT
+        ELSE u.name
+      END
+    END DESC NULLS LAST
+  LIMIT p_page_size
+  OFFSET (p_page - 1) * p_page_size;
+END;
+$function$;
+
+
+-- -----------------------------------------------------------------------------
+-- Re-issue COMMENT (OID preserved by CREATE OR REPLACE, but the tag VALUES must
+-- be updated explicitly). Flips @a4c-consultant-callable pending-phase3-refactor
+-- → yes and @a4c-phase-target 3 → none. @a4c-rpc-shape (read) + @a4c-bucket (A)
+-- unchanged — still a p_org_id tenancy-guard RPC, now grant-aware.
+-- -----------------------------------------------------------------------------
+COMMENT ON FUNCTION api.list_users(uuid, text, text, text, boolean, integer, integer) IS
+$comment$List users in an organization with pagination and filtering. Membership gated by users.accessible_organizations (the canonical membership oracle, post-Phase-1 the UNION of direct user_organizations_projection membership AND active in-window cross_tenant_access_grants_projection grants). Tenancy guard (Model M, Phase 3): has_platform_privilege() OR caller is a member of p_org_id via accessible_organizations @> [p_org_id]. Status values: active, deactivated, deleted (or NULL for all non-deleted).
+
+@a4c-rpc-shape: read
+
+@a4c-bucket: A
+@a4c-consultant-callable: yes
+@a4c-consultant-callable-reason: Grant-derived membership via accessible_organizations (Model M, Phase 3): a consultant holding an active in-window grant to p_org_id has it in accessible_organizations and is admitted by the membership-oracle tenancy guard. RETURN-empty for non-members (no existence leak).
+@a4c-phase-target: none$comment$;


### PR DESCRIPTION
## Context

Cross-tenant grant rollout **Phase 3**. Goal: let a consultant holding an active grant to a provider org call that org's read RPCs — today rejected because the guard checks their JWT `org_id` (which stays at their HOME org), not their membership.

## The change — Model M

`api.list_users`' guard swaps the session-org check for a membership-oracle `EXISTS`:
```sql
-- OLD: OR p_org_id = public.get_current_org_id()   -- caller's session org
-- NEW (Model M):
OR EXISTS (SELECT 1 FROM public.users caller
           WHERE caller.id = public.get_current_user_id()
             AND caller.accessible_organizations @> ARRAY[p_org_id]::uuid[])
```
`accessible_organizations` post-Phase-1 is the UNION of direct membership + active grants, so grant-bearers are admitted. The guard now references the **same oracle** as the query body's existing `WHERE` predicate — they can never disagree. RETURN-empty (Bucket A) preserved.

## Why not the original handoff (architect re-adjudication 2026-06-22)

The 2026-05-26 handoff ("three-step perm-gated skeleton + `invitation.read`") was wrong on both RPCs:
- **`invitation.read` doesn't exist** (no `invitation.*` permission family) → `list_invitations` is a permission-seed + HIPAA-exposure decision, not a guard swap → **split into a sub-card**.
- A `has_effective_permission('user.view', path)` gate on `list_users` **violates the users-as-identities scoped-vs-unscoped rule** AND is **inert** (no template confers `user.view`).
- `has_cross_tenant_access(...)` is a **deployed stub returning FALSE** → reading `accessible_organizations` directly is the only working grant-aware mechanism.

## Bug caught + fixed in verification

`list_users` `RETURNS TABLE(id uuid, …)`, so the guard's `EXISTS` had to alias the `users` table (`caller`) — an unqualified `id` is ambiguous (SQLSTATE 42702). The original guard never queried a table, so it never hit this.

## Verification (dev; transactional simulate-JWT, `BEGIN…ROLLBACK`, zero pollution)

| Probe | Result |
|-------|--------|
| Grant-bearer (in-txn grant insert → sync trigger → consultant JWT) | sees provider org members + self (grant-member) — **PASS** |
| Non-member consultant (no grant) | empty — **PASS** (no existence leak) |
| Org-internal admin (backward-compat) | unchanged — **PASS** |
| Platform admin | unchanged — **PASS** |

Post-probe: 0 leaked grants, consultant `accessible_orgs` restored, fixed guard deployed.

## Scope / no-ops

- Body verbatim from `pg_get_functiondef` (pitfall #6); only the guard changed. Signature + return shape unchanged → CREATE OR REPLACE preserves OID; COMMENT re-issued to flip `@a4c-consultant-callable` → `yes`. **No TS regen, no AsyncAPI, no M3 registry change.**
- Reachability matrix + `list_users` variant note (`infrastructure/supabase/CLAUDE.md`) + parent card handoff updated to record the Model M resolution.
- **`list_invitations` deferred** → `dev/active/seed-list-invitations-cross-tenant-visibility-decision.md`.
- UI grant-bearer segregation filter → Phase N (ADR user-visibility-consequence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)