### PR TITLE
fix(events): handle_user_deleted cascade-cleans FK-dependent projections

### DIFF
--- a/infrastructure/supabase/contracts/asyncapi-bundled.yaml
+++ b/infrastructure/supabase/contracts/asyncapi-bundled.yaml
@@ -13387,7 +13387,6 @@ channels:
                   type: object
                   required:
                     - grant_id
-                    - revoked_by
                     - revocation_reason
                   properties:
                     grant_id:
@@ -13397,7 +13396,10 @@ channels:
                     revoked_by:
                       type: string
                       format: uuid
-                      description: User who revoked the grant
+                      nullable: true
+                      description: >-
+                        User who revoked the grant; NULL for automated
+                        revocations (e.g. consultant user deleted)
                     revocation_reason:
                       type: string
                       description: Explanation for revocation
@@ -31656,7 +31658,6 @@ channels:
                   type: object
                   required:
                     - grant_id
-                    - revoked_by
                     - revocation_reason
                   properties:
                     grant_id:
@@ -31666,7 +31667,10 @@ channels:
                     revoked_by:
                       type: string
                       format: uuid
-                      description: User who revoked the grant
+                      nullable: true
+                      description: >-
+                        User who revoked the grant; NULL for automated
+                        revocations (e.g. consultant user deleted)
                     revocation_reason:
                       type: string
                       description: Explanation for revocation

--- a/infrastructure/supabase/contracts/asyncapi/domains/access_grant.yaml
+++ b/infrastructure/supabase/contracts/asyncapi/domains/access_grant.yaml
@@ -181,7 +181,6 @@ components:
       type: object
       required:
         - grant_id
-        - revoked_by
         - revocation_reason
       properties:
         grant_id:
@@ -190,7 +189,8 @@ components:
         revoked_by:
           type: string
           format: uuid
-          description: User ID of person revoking access
+          nullable: true
+          description: User ID of person revoking access; NULL for automated revocations (e.g. consultant user deleted)
         revocation_reason:
           type: string
           description: Explanation for why access is being revoked (e.g., contract

--- a/infrastructure/supabase/contracts/asyncapi/domains/rbac.yaml
+++ b/infrastructure/supabase/contracts/asyncapi/domains/rbac.yaml
@@ -413,7 +413,6 @@ components:
       type: object
       required:
         - grant_id
-        - revoked_by
         - revocation_reason
       properties:
         grant_id:
@@ -423,7 +422,8 @@ components:
         revoked_by:
           type: string
           format: uuid
-          description: User who revoked the grant
+          nullable: true
+          description: User who revoked the grant; NULL for automated revocations (e.g. consultant user deleted)
         revocation_reason:
           type: string
           description: Explanation for revocation

--- a/infrastructure/supabase/contracts/types/generated-events.ts
+++ b/infrastructure/supabase/contracts/types/generated-events.ts
@@ -2228,7 +2228,7 @@ export interface AccessGrantRevokedEvent {
 
 export interface AccessGrantRevokedData {
   'grant_id': string;
-  'revoked_by': string;
+  'revoked_by'?: string;
   'revocation_reason': string;
   'additionalProperties'?: Map<string, any>;
 }

--- a/infrastructure/supabase/handlers/trigger/emit_grant_revocations_on_user_deleted.sql
+++ b/infrastructure/supabase/handlers/trigger/emit_grant_revocations_on_user_deleted.sql
@@ -1,0 +1,53 @@
+-- AFTER-INSERT trigger fn on public.domain_events WHEN (NEW.event_type = 'user.deleted').
+-- Revokes active cross-tenant grants whose consultant_user_id is the deleted user,
+-- by emitting one access_grant.revoked event per grant. Event-chaining lives in an
+-- AFTER-INSERT trigger (NOT a nested emit from the BEFORE handler handle_user_deleted):
+-- a nested emit would bury an inner failure in the inner event's processing_error,
+-- which api.delete_user's outer Pattern-A-v2 read-back never inspects. Running after
+-- the outer user.deleted row is durable, any inner emit failure surfaces as a normal
+-- retryable processing_error on its own event row. (architect F1, migration 20260622212441)
+--
+-- Trigger DDL (in the migration, not this ref file):
+--   CREATE TRIGGER emit_grant_revocations_on_user_deleted_trigger
+--     AFTER INSERT ON public.domain_events FOR EACH ROW
+--     WHEN (NEW.event_type = 'user.deleted')
+--     EXECUTE FUNCTION public.emit_grant_revocations_on_user_deleted();
+CREATE OR REPLACE FUNCTION public.emit_grant_revocations_on_user_deleted()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $function$
+DECLARE
+    v_grant record;
+BEGIN
+    FOR v_grant IN
+        SELECT id
+        FROM public.cross_tenant_access_grants_projection
+        WHERE consultant_user_id = NEW.stream_id
+          AND status = 'active'
+    LOOP
+        -- Handler process_access_grant_event keys its UPDATE on event_data->>'grant_id'
+        -- (NOT stream_id); set both. revoked_by NULL = automated (AsyncAPI contract
+        -- AccessGrantRevokedData.revoked_by made nullable in the same PR).
+        PERFORM api.emit_domain_event(
+            p_stream_id      := v_grant.id,
+            p_stream_type    := 'access_grant',
+            p_event_type     := 'access_grant.revoked',
+            p_event_data     := jsonb_build_object(
+                'grant_id',           v_grant.id,
+                'revoked_by',         NULL,
+                'revocation_reason',  'consultant_user_deleted',
+                'revocation_details', 'Consultant user was soft-deleted; grant auto-revoked by handle_user_deleted cascade.'
+            ),
+            p_event_metadata := jsonb_build_object(
+                'automated', true,
+                'source',    'handle_user_deleted_cascade',
+                'user_id',   NULL,
+                'reason',    'consultant_user_deleted'
+            )
+        );
+    END LOOP;
+
+    RETURN NULL;  -- AFTER trigger: return value ignored
+END;
+$function$;

--- a/infrastructure/supabase/handlers/trigger/emit_grant_revocations_on_user_deleted.sql
+++ b/infrastructure/supabase/handlers/trigger/emit_grant_revocations_on_user_deleted.sql
@@ -20,6 +20,10 @@ AS $function$
 DECLARE
     v_grant record;
 BEGIN
+    -- INVARIANT: a deleted user can only be a grant *consultant*, never a grant
+    -- *target* (targets are orgs/clients, never users), so consultant_user_id =
+    -- NEW.stream_id is the COMPLETE revoke set. Revisit for Phase N if any
+    -- user-as-target grant type is ever introduced.
     FOR v_grant IN
         SELECT id
         FROM public.cross_tenant_access_grants_projection
@@ -28,7 +32,9 @@ BEGIN
     LOOP
         -- Handler process_access_grant_event keys its UPDATE on event_data->>'grant_id'
         -- (NOT stream_id); set both. revoked_by NULL = automated (AsyncAPI contract
-        -- AccessGrantRevokedData.revoked_by made nullable in the same PR).
+        -- AccessGrantRevokedData.revoked_by made nullable in the same PR). READ-SIDE
+        -- POSTCONDITION: rows revoked via this path carry revoked_by IS NULL —
+        -- consumers must treat revoked_by as nullable.
         PERFORM api.emit_domain_event(
             p_stream_id      := v_grant.id,
             p_stream_type    := 'access_grant',

--- a/infrastructure/supabase/handlers/user/handle_user_deleted.sql
+++ b/infrastructure/supabase/handlers/user/handle_user_deleted.sql
@@ -39,7 +39,10 @@ BEGIN
     DELETE FROM public.schedule_user_assignments_projection     WHERE user_id = p_event.stream_id;
 
     -- contacts_projection: preserve the contact entity, drop only the user
-    -- linkage (user_id nullable; partial UNIQUE index tolerates NULLs).
-    UPDATE public.contacts_projection SET user_id = NULL WHERE user_id = p_event.stream_id;
+    -- linkage (user_id nullable; partial indexes idx_contacts_unique_user_per_org
+    -- and idx_contacts_user_id, both WHERE user_id IS NOT NULL, tolerate NULLs).
+    -- The explicit user_id IS NOT NULL conjunct makes replay a guaranteed no-op.
+    UPDATE public.contacts_projection SET user_id = NULL
+     WHERE user_id = p_event.stream_id AND user_id IS NOT NULL;
 END;
 $function$;

--- a/infrastructure/supabase/handlers/user/handle_user_deleted.sql
+++ b/infrastructure/supabase/handlers/user/handle_user_deleted.sql
@@ -4,8 +4,11 @@ CREATE OR REPLACE FUNCTION public.handle_user_deleted(p_event record)
  SET search_path TO 'public', 'extensions', 'pg_temp'
 AS $function$
 BEGIN
-    -- COALESCE order: existing tombstone wins (replay-safe), then event
-    -- payload's deleted_at, then event creation time as final fallback.
+    -- TOMBSTONE FIRST (load-bearing: must precede the projection DELETEs so the
+    -- accessible_organizations recompute triggered by the user_organizations_
+    -- projection DELETE self-guards on deleted_at IS NULL to a no-op).
+    -- COALESCE order: existing tombstone wins (replay-safe), then event payload's
+    -- deleted_at, then event creation time as final fallback.
     UPDATE public.users
        SET deleted_at = COALESCE(
              deleted_at,
@@ -19,5 +22,24 @@ BEGIN
     IF NOT FOUND THEN
         RAISE EXCEPTION 'User not found' USING ERRCODE = 'P0002';
     END IF;
+
+    -- CASCADE: hard-DELETE membership/identity projections anchored on user_id.
+    -- Derived "membership state" no longer holds once the user is tombstoned;
+    -- domain_events remains the audit trail. Audit-reference columns (assigned_by,
+    -- created_by, granted_by, ...) live on OTHER rows and are untouched.
+    -- Grant-revoke is handled by the AFTER-INSERT trigger
+    -- emit_grant_revocations_on_user_deleted (NOT here — no emit_domain_event in
+    -- this synchronous body; see migration 20260622212441 / architect F1).
+    DELETE FROM public.user_roles_projection                    WHERE user_id = p_event.stream_id;
+    DELETE FROM public.user_organizations_projection            WHERE user_id = p_event.stream_id;
+    DELETE FROM public.user_notification_preferences_projection WHERE user_id = p_event.stream_id;
+    DELETE FROM public.user_addresses                           WHERE user_id = p_event.stream_id;
+    DELETE FROM public.user_phones                              WHERE user_id = p_event.stream_id;
+    DELETE FROM public.user_client_assignments_projection       WHERE user_id = p_event.stream_id;
+    DELETE FROM public.schedule_user_assignments_projection     WHERE user_id = p_event.stream_id;
+
+    -- contacts_projection: preserve the contact entity, drop only the user
+    -- linkage (user_id nullable; partial UNIQUE index tolerates NULLs).
+    UPDATE public.contacts_projection SET user_id = NULL WHERE user_id = p_event.stream_id;
 END;
 $function$;

--- a/infrastructure/supabase/supabase/migrations/20260622212441_handle_user_deleted_cascade_cleanup_projections.sql
+++ b/infrastructure/supabase/supabase/migrations/20260622212441_handle_user_deleted_cascade_cleanup_projections.sql
@@ -1,0 +1,226 @@
+-- =============================================================================
+-- handle_user_deleted: cascade-cleanup FK-dependent membership/identity projections
+-- =============================================================================
+--
+-- Card: dev/active/handle-user-deleted-cascade-cleanup-projections/
+-- Architect verdict (software-architect-dbc, 2026-06-22): APPROVE WITH IN-PR FIXES.
+--   Decision record: ~/.claude/plans/fizzy-jingling-puppy-agent-ad12fa238108e55da.md
+--
+-- PROBLEM: handle_user_deleted only tombstones the user (deleted_at/is_active);
+-- it leaves stale rows in membership/identity projections, so soft-deleted users
+-- still resolve as members (e.g. check_user_org_membership) and consumers must add
+-- ad-hoc deleted_at IS NULL filters. Dev today: 9 stale rows across 2 users.
+--
+-- FIX (two layers, per architect F1):
+--   1. BEFORE handler handle_user_deleted: hard-DELETE the 7 membership/identity
+--      projections + NULL the contacts user-linkage. Order is LOAD-BEARING — the
+--      tombstone UPDATE runs FIRST so the recompute_user_accessible_organizations
+--      that fires on user_organizations_projection DELETE self-guards
+--      (WHERE deleted_at IS NULL) to a clean no-op. Audit-reference columns
+--      (*_by/created_by/...) are preserved everywhere.
+--   2. Grant-revoke is an AFTER-INSERT trigger (NOT a nested emit from the BEFORE
+--      handler): a nested emit_domain_event buries an inner failure in the INNER
+--      event's processing_error, which api.delete_user's outer Pattern-A-v2
+--      read-back never inspects -> a failed revoke would return {success:true}
+--      silently. The AFTER-INSERT trigger emits access_grant.revoked per active
+--      grant; any failure surfaces as a normal retryable processing_error.
+--
+-- Pitfall #6: deployed handle_user_deleted body (COALESCE tombstone + IF NOT FOUND
+-- RAISE P0002) is preserved verbatim; the cascade is appended. Pitfall #4 N/A
+-- (no INSERTs here). Pitfall #8 column-existence assertion included (Section 3).
+-- Idempotent/replay-safe: DELETE/NULL are no-ops on re-processing.
+-- =============================================================================
+
+
+-- -----------------------------------------------------------------------------
+-- Section 1 — handle_user_deleted: tombstone (preserved) + cascade DELETEs.
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.handle_user_deleted(p_event record)
+ RETURNS void
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $function$
+BEGIN
+    -- TOMBSTONE FIRST (load-bearing: must precede the projection DELETEs so the
+    -- accessible_organizations recompute triggered by the user_organizations_
+    -- projection DELETE self-guards on deleted_at IS NULL to a no-op).
+    -- COALESCE order: existing tombstone wins (replay-safe), then event payload's
+    -- deleted_at, then event creation time as final fallback.
+    UPDATE public.users
+       SET deleted_at = COALESCE(
+             deleted_at,
+             (p_event.event_data->>'deleted_at')::timestamptz,
+             p_event.created_at
+           ),
+           is_active = false,
+           updated_at = p_event.created_at
+     WHERE id = p_event.stream_id;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'User not found' USING ERRCODE = 'P0002';
+    END IF;
+
+    -- CASCADE: hard-DELETE membership/identity projections anchored on user_id.
+    -- These are derived "membership state" facts that no longer hold once the
+    -- user is tombstoned; reversibility on undelete is via re-onboarding. The
+    -- domain_events stream remains the audit trail. Audit-reference columns
+    -- (assigned_by, created_by, granted_by, ...) live on OTHER rows and are
+    -- untouched. NOTE: grant-revoke is handled by the AFTER-INSERT trigger in
+    -- Section 2, NOT here (no emit_domain_event in this synchronous body).
+    DELETE FROM public.user_roles_projection                    WHERE user_id = p_event.stream_id;
+    DELETE FROM public.user_organizations_projection            WHERE user_id = p_event.stream_id;
+    DELETE FROM public.user_notification_preferences_projection WHERE user_id = p_event.stream_id;
+    DELETE FROM public.user_addresses                           WHERE user_id = p_event.stream_id;
+    DELETE FROM public.user_phones                              WHERE user_id = p_event.stream_id;
+    DELETE FROM public.user_client_assignments_projection       WHERE user_id = p_event.stream_id;
+    DELETE FROM public.schedule_user_assignments_projection     WHERE user_id = p_event.stream_id;
+
+    -- contacts_projection: preserve the contact entity (it may be referenced by
+    -- other domain entities), drop only the user linkage. user_id is nullable;
+    -- the partial UNIQUE index idx_contacts_unique_user_id WHERE user_id IS NOT
+    -- NULL tolerates NULLs.
+    UPDATE public.contacts_projection SET user_id = NULL WHERE user_id = p_event.stream_id;
+END;
+$function$;
+
+
+-- -----------------------------------------------------------------------------
+-- Section 2 — AFTER-INSERT trigger: revoke active grants whose consultant_user_id
+-- is the deleted user. Event-chaining via AFTER-INSERT (sanctioned carve-out;
+-- mirrors enqueue_workflow_from_bootstrap_event / bootstrap_workflow_trigger).
+-- Runs after the outer user.deleted row is durable, so an inner emit failure
+-- surfaces as processing_error on its OWN event row (retryable), not swallowed.
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.emit_grant_revocations_on_user_deleted()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $function$
+DECLARE
+    v_grant record;
+BEGIN
+    FOR v_grant IN
+        SELECT id
+        FROM public.cross_tenant_access_grants_projection
+        WHERE consultant_user_id = NEW.stream_id
+          AND status = 'active'
+    LOOP
+        -- Handler process_access_grant_event keys its UPDATE on event_data->>'grant_id'
+        -- (NOT stream_id); set both. revoked_by NULL = automated (contract made
+        -- nullable in this PR's AsyncAPI change).
+        PERFORM api.emit_domain_event(
+            p_stream_id      := v_grant.id,
+            p_stream_type    := 'access_grant',
+            p_event_type     := 'access_grant.revoked',
+            p_event_data     := jsonb_build_object(
+                'grant_id',           v_grant.id,
+                'revoked_by',         NULL,
+                'revocation_reason',  'consultant_user_deleted',
+                'revocation_details', 'Consultant user was soft-deleted; grant auto-revoked by handle_user_deleted cascade.'
+            ),
+            p_event_metadata := jsonb_build_object(
+                'automated', true,
+                'source',    'handle_user_deleted_cascade',
+                'user_id',   NULL,
+                'reason',    'consultant_user_deleted'
+            )
+        );
+    END LOOP;
+
+    RETURN NULL;  -- AFTER trigger: return value ignored
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS emit_grant_revocations_on_user_deleted_trigger ON public.domain_events;
+CREATE TRIGGER emit_grant_revocations_on_user_deleted_trigger
+    AFTER INSERT ON public.domain_events
+    FOR EACH ROW
+    WHEN (NEW.event_type = 'user.deleted')
+    EXECUTE FUNCTION public.emit_grant_revocations_on_user_deleted();
+
+
+-- -----------------------------------------------------------------------------
+-- Section 3 — pitfall #8 fail-loud assertion: every column the cascade writes
+-- must exist on its target table, else the handler would deploy and only fail
+-- when a user.deleted event arrives.
+-- -----------------------------------------------------------------------------
+DO $$
+DECLARE
+    v_targets text[][] := ARRAY[
+        ARRAY['user_roles_projection','user_id'],
+        ARRAY['user_organizations_projection','user_id'],
+        ARRAY['user_notification_preferences_projection','user_id'],
+        ARRAY['user_addresses','user_id'],
+        ARRAY['user_phones','user_id'],
+        ARRAY['user_client_assignments_projection','user_id'],
+        ARRAY['schedule_user_assignments_projection','user_id'],
+        ARRAY['contacts_projection','user_id'],
+        ARRAY['cross_tenant_access_grants_projection','consultant_user_id'],
+        ARRAY['cross_tenant_access_grants_projection','status']
+    ];
+    v_row text[];
+    v_missing text[] := '{}';
+BEGIN
+    FOREACH v_row SLICE 1 IN ARRAY v_targets LOOP
+        IF NOT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = v_row[1]
+              AND column_name = v_row[2]
+        ) THEN
+            v_missing := array_append(v_missing, v_row[1] || '.' || v_row[2]);
+        END IF;
+    END LOOP;
+    IF array_length(v_missing, 1) > 0 THEN
+        RAISE EXCEPTION 'Cascade references non-existent columns: %', v_missing
+            USING ERRCODE = 'P9099';
+    END IF;
+END $$;
+
+
+-- -----------------------------------------------------------------------------
+-- Section 4 — backfill: clean already-tombstoned users so projection state
+-- matches the historical user.deleted events. Direct DELETEs (the user.deleted
+-- event already exists; re-emitting would add audit noise). Covers all 3 arms.
+-- Migration context (not a trigger) -> emit_domain_event for grant-revoke is
+-- safe here. Dev targets today: 9 membership rows, 0 contacts, 0 active grants.
+-- -----------------------------------------------------------------------------
+DO $$
+DECLARE
+    v_user record;
+    v_grant record;
+BEGIN
+    FOR v_user IN SELECT id FROM public.users WHERE deleted_at IS NOT NULL LOOP
+        DELETE FROM public.user_roles_projection                    WHERE user_id = v_user.id;
+        DELETE FROM public.user_organizations_projection            WHERE user_id = v_user.id;
+        DELETE FROM public.user_notification_preferences_projection WHERE user_id = v_user.id;
+        DELETE FROM public.user_addresses                           WHERE user_id = v_user.id;
+        DELETE FROM public.user_phones                              WHERE user_id = v_user.id;
+        DELETE FROM public.user_client_assignments_projection       WHERE user_id = v_user.id;
+        DELETE FROM public.schedule_user_assignments_projection     WHERE user_id = v_user.id;
+        UPDATE public.contacts_projection SET user_id = NULL        WHERE user_id = v_user.id;
+
+        FOR v_grant IN
+            SELECT id FROM public.cross_tenant_access_grants_projection
+            WHERE consultant_user_id = v_user.id AND status = 'active'
+        LOOP
+            PERFORM api.emit_domain_event(
+                p_stream_id      := v_grant.id,
+                p_stream_type    := 'access_grant',
+                p_event_type     := 'access_grant.revoked',
+                p_event_data     := jsonb_build_object(
+                    'grant_id',           v_grant.id,
+                    'revoked_by',         NULL,
+                    'revocation_reason',  'consultant_user_deleted',
+                    'revocation_details', 'Backfill: consultant user already soft-deleted; grant auto-revoked.'
+                ),
+                p_event_metadata := jsonb_build_object(
+                    'automated', true,
+                    'source',    'handle_user_deleted_cascade_backfill',
+                    'user_id',   NULL,
+                    'reason',    'consultant_user_deleted'
+                )
+            );
+        END LOOP;
+    END LOOP;
+END $$;

--- a/infrastructure/supabase/supabase/migrations/20260622212441_handle_user_deleted_cascade_cleanup_projections.sql
+++ b/infrastructure/supabase/supabase/migrations/20260622212441_handle_user_deleted_cascade_cleanup_projections.sql
@@ -77,9 +77,13 @@ BEGIN
 
     -- contacts_projection: preserve the contact entity (it may be referenced by
     -- other domain entities), drop only the user linkage. user_id is nullable;
-    -- the partial UNIQUE index idx_contacts_unique_user_id WHERE user_id IS NOT
-    -- NULL tolerates NULLs.
-    UPDATE public.contacts_projection SET user_id = NULL WHERE user_id = p_event.stream_id;
+    -- the partial indexes idx_contacts_unique_user_per_org (organization_id,
+    -- user_id) and idx_contacts_user_id — both WHERE user_id IS NOT NULL — tolerate
+    -- NULLs. The explicit user_id IS NOT NULL conjunct mirrors those index
+    -- predicates and makes replay a guaranteed no-op (no write against rows already
+    -- unlinked on a prior pass).
+    UPDATE public.contacts_projection SET user_id = NULL
+     WHERE user_id = p_event.stream_id AND user_id IS NOT NULL;
 END;
 $function$;
 
@@ -99,6 +103,12 @@ AS $function$
 DECLARE
     v_grant record;
 BEGIN
+    -- INVARIANT: a deleted user can only ever be a grant *consultant*, never a
+    -- grant *target* — grant targets are orgs/clients (provider_org_id / client
+    -- scope), never users. So filtering on consultant_user_id = NEW.stream_id is
+    -- the COMPLETE set of grants to revoke for this user. (Boundary doc for Phase N
+    -- user-targeted grant types: revisit this assumption if a user-as-target grant
+    -- type is ever introduced.)
     FOR v_grant IN
         SELECT id
         FROM public.cross_tenant_access_grants_projection
@@ -107,7 +117,9 @@ BEGIN
     LOOP
         -- Handler process_access_grant_event keys its UPDATE on event_data->>'grant_id'
         -- (NOT stream_id); set both. revoked_by NULL = automated (contract made
-        -- nullable in this PR's AsyncAPI change).
+        -- nullable in this PR's AsyncAPI change). READ-SIDE POSTCONDITION: revoked
+        -- grant rows produced by this path carry revoked_by IS NULL — consumers
+        -- (read RPCs / frontend grant types) must treat revoked_by as nullable.
         PERFORM api.emit_domain_event(
             p_stream_id      := v_grant.id,
             p_stream_type    := 'access_grant',
@@ -183,13 +195,33 @@ END $$;
 -- matches the historical user.deleted events. Direct DELETEs (the user.deleted
 -- event already exists; re-emitting would add audit noise). Covers all 3 arms.
 -- Migration context (not a trigger) -> emit_domain_event for grant-revoke is
--- safe here. Dev targets today: 9 membership rows, 0 contacts, 0 active grants.
+-- safe here.
+--
+-- BLAST RADIUS: scope is env-dependent — the loop runs over EVERY tombstoned user
+-- in the TARGET environment (not just dev's), and each active grant found drives a
+-- synchronous grant-revoke (emit -> handler -> accessible_organizations recompute)
+-- inside this single migration transaction. It is idempotent / re-run-safe
+-- (DELETE/NULL no-op; grant-revoke filters status='active' so a re-applied
+-- migration emits 0 duplicates). The RAISE NOTICE below records the actual counts
+-- in the deploy log so the blast radius is observable per environment. Dev targets
+-- at authoring time: 9 membership rows across 2 users, 0 contacts, 0 active grants.
 -- -----------------------------------------------------------------------------
 DO $$
 DECLARE
     v_user record;
     v_grant record;
+    v_tombstoned_users bigint;
+    v_active_grants     bigint;
 BEGIN
+    SELECT count(*) INTO v_tombstoned_users
+      FROM public.users WHERE deleted_at IS NOT NULL;
+    SELECT count(*) INTO v_active_grants
+      FROM public.cross_tenant_access_grants_projection g
+      JOIN public.users u ON u.id = g.consultant_user_id
+     WHERE u.deleted_at IS NOT NULL AND g.status = 'active';
+    RAISE NOTICE 'handle_user_deleted backfill blast radius: % tombstoned user(s), % active grant(s) to revoke',
+                 v_tombstoned_users, v_active_grants;
+
     FOR v_user IN SELECT id FROM public.users WHERE deleted_at IS NOT NULL LOOP
         DELETE FROM public.user_roles_projection                    WHERE user_id = v_user.id;
         DELETE FROM public.user_organizations_projection            WHERE user_id = v_user.id;
@@ -198,7 +230,7 @@ BEGIN
         DELETE FROM public.user_phones                              WHERE user_id = v_user.id;
         DELETE FROM public.user_client_assignments_projection       WHERE user_id = v_user.id;
         DELETE FROM public.schedule_user_assignments_projection     WHERE user_id = v_user.id;
-        UPDATE public.contacts_projection SET user_id = NULL        WHERE user_id = v_user.id;
+        UPDATE public.contacts_projection SET user_id = NULL        WHERE user_id = v_user.id AND user_id IS NOT NULL;
 
         FOR v_grant IN
             SELECT id FROM public.cross_tenant_access_grants_projection

--- a/workflows/src/shared/types/generated/events.ts
+++ b/workflows/src/shared/types/generated/events.ts
@@ -10,7 +10,7 @@
  * 2. cd infrastructure/supabase/contracts && npm run generate:types
  * 3. cd workflows && npm run sync-schemas
  *
- * Last synced: 2026-06-09T19:04:00.578Z
+ * Last synced: 2026-06-22T21:53:58.523Z
  */
 
 // =============================================================================
@@ -2231,7 +2231,7 @@ export interface AccessGrantRevokedEvent {
 
 export interface AccessGrantRevokedData {
   'grant_id': string;
-  'revoked_by': string;
+  'revoked_by'?: string;
   'revocation_reason': string;
   'additionalProperties'?: Map<string, any>;
 }


### PR DESCRIPTION
## Problem

`handle_user_deleted` only tombstoned the user (`deleted_at`/`is_active`); it left stale rows in membership/identity projections. Soft-deleted users still resolved as members (e.g. `check_user_org_membership`), and consumer RPCs needed ad-hoc `WHERE deleted_at IS NULL` filters. Dev had **9 stale rows** across 2 users — this blocked PR #64 UAT T4.

## Fix (two layers — architect-reviewed, APPROVE WITH IN-PR FIXES)

1. **BEFORE handler** `handle_user_deleted` — after the preserved COALESCE tombstone + `IF NOT FOUND` guard, hard-DELETE the 7 membership/identity projections + NULL the `contacts_projection` user-linkage. **Order is load-bearing**: tombstone first, so the `accessible_organizations` recompute that fires on `user_organizations_projection` DELETE self-guards (`deleted_at IS NULL`) to a no-op. Audit-reference columns preserved.
2. **AFTER-INSERT trigger** `emit_grant_revocations_on_user_deleted` — emits `access_grant.revoked` per active grant of the deleted consultant. This is the architect's **F1** fix: keeping it out of the BEFORE handler means a failed revoke surfaces as a retryable `processing_error` instead of being buried in the inner event and returning a silent `{success:true}` to `api.delete_user`'s outer read-back.

**Decisions**: revoke (not transfer); no `auth.admin.deleteUser` cascade; contacts NULL-link only (no PII clear); backfill via direct DELETEs (all 3 arms); keep consumer filters (defense-in-depth).

**F2**: automated revoke emits `revoked_by=NULL` → made `AccessGrantRevokedData.revoked_by` nullable. Note: `rbac.yaml` is the **wired** source (its `AccessGrantRevoked` message is what `asyncapi.yaml` references); `access_grant.yaml` carries a parallel **unwired** duplicate of the schema, aligned here — consolidating the two is a separate cleanup.

Pitfall #6 (deployed body preserved verbatim), #8 (column-existence assertion), #4 N/A. Replay-safe (DELETE/NULL idempotent).

## Verification (dev; transactional simulate-JWT, `BEGIN…ROLLBACK`, zero pollution)

| Check | Result |
|-------|--------|
| Backfill | 9 stale rows → **0** |
| Handler cascade | all 7 projections cleaned + contacts NULL + tombstone, no `processing_error` |
| Grant-revoke arm (synthesized) | `status=revoked`, `revoked_by IS NULL`, reason correct, **1 event, no `processing_error`** |
| Replay | 2nd `user.deleted` is a clean no-op (0 errors) |
| Cleanliness | 0 leaked grants, real user rows intact (all rolled back) |

PR #64 UAT T4 is now runnable as designed (soft-deleted user → `check_user_org_membership` 0 → … → `not_found`).

## Scope

No `database.types.ts` regen (handler + trigger bodies only). `generated-events.ts` regenerated for the contract change (contracts copy committed; frontend copy is gitignored, regenerated by the build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)