### PR TITLE
feat(users): api.reactivate_user Pattern A v2 + correlation NOT NULL (epic PR 2)

### DIFF
--- a/documentation/architecture/authorization/cross-tenant-access-grant-rpc-reachability-matrix.md
+++ b/documentation/architecture/authorization/cross-tenant-access-grant-rpc-reachability-matrix.md
@@ -52,9 +52,9 @@ last_updated: 2026-06-23
 | C | 31 |
 | D | 36 |
 | D-variant | 1 |
-| E | 45 |
+| E | 46 |
 | E-variant | 1 |
-| **Total** | **179** |
+| **Total** | **180** |
 <!-- GENERATED:PER-BUCKET-COUNTS:END -->
 
 > [!NOTE]
@@ -226,6 +226,7 @@ In addition to the formal `@a4c-bucket` / `@a4c-consultant-callable` / `@a4c-pha
 | `reactivate_organization_unit` | C | yes | none | Scope-path-bound has_effective_permission; forward-compatible with multi-scope grants under Phase 1 tightened DISTINCT ON. |
 | `reactivate_role` | B | no | none | JWT-bound (derives org via get_current_org_id); consultant variant deferred to case-by-case Phase 2+ work. |
 | `reactivate_schedule_template` | C | yes | none | Scope-path-bound has_effective_permission; forward-compatible with multi-scope grants under Phase 1 tightened DISTINCT ON. |
+| `reactivate_user` | E | yes | none | No tenancy context; grant-irrelevant by default. Mirror of api.deactivate_user. |
 | `reactivate_var_partnership` | B | no | none | Provider-admin authority + partnership.manage permission; consultant variant N/A. |
 | `register_client` | B | no | none | JWT-bound (derives org via get_current_org_id); consultant variant deferred to case-by-case Phase 2+ work. |
 | `remove_client_address` | B | no | none | JWT-bound (derives org via get_current_org_id); consultant variant deferred to case-by-case Phase 2+ work. |

--- a/documentation/infrastructure/reference/database/tables/users.md
+++ b/documentation/infrastructure/reference/database/tables/users.md
@@ -48,7 +48,7 @@ The `users` table is a shadow table for Supabase Auth users, used for Row-Level 
 | metadata | jsonb | YES | '{}' | Additional custom user metadata |
 | last_login | timestamptz | YES | - | Timestamp of most recent authentication |
 | is_active | boolean | YES | true | User active status (can be disabled) |
-| correlation_id | uuid | YES | - | Business-scoped correlation_id for the user's identity/membership lifecycle (added 2026-06-23). Anchored at `user.created` and `user.synced_from_auth`, reused by identity/membership emitters. See [event-metadata-schema.md](../../../../workflows/reference/event-metadata-schema.md#events-using-stored-correlation_id). |
+| correlation_id | uuid | NO | gen_random_uuid() | Business-scoped correlation_id for the user's identity/membership lifecycle (added 2026-06-23; `NOT NULL` + `DEFAULT gen_random_uuid()` since 2026-06-23). Anchored at `user.created` and `user.synced_from_auth`, reused by identity/membership emitters. The DEFAULT is a non-chaining safety net (any insert is non-NULL by construction); correct chaining still comes from the anchor handlers writing the signup event's id. See [event-metadata-schema.md](../../../../workflows/reference/event-metadata-schema.md#events-using-stored-correlation_id). |
 | created_at | timestamptz | YES | NOW() | Record creation timestamp |
 | updated_at | timestamptz | YES | NOW() | Record update timestamp |
 

--- a/documentation/infrastructure/reference/edge-functions/manage-user.md
+++ b/documentation/infrastructure/reference/edge-functions/manage-user.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last_updated: 2026-04-24
+last_updated: 2026-06-23
 ---
 
 <!-- TL;DR-START -->
@@ -97,9 +97,12 @@ Reactivates a deactivated user.
 
 **Event Emitted**: `user.reactivated`
 
-**Validation Rules**:
-- Target user must exist in the organization
-- Target user must be deactivated
+**Implementation**: Pattern A v2 via SQL RPC `api.reactivate_user` (retrofitted 2026-06-23, mirroring the `deactivate` path). The RPC performs the tenancy/idempotency checks + event-emit + read-back; the EF then clears the auth ban (`auth.admin.updateUserById({ban_duration: 'none'})`, LB1). Returns the Pattern A v2 envelope (`200` + `{success, error?, eventId?}` — callers check `data.success`, not HTTP status).
+
+**Validation Rules** (now enforced by `api.reactivate_user` as success-false envelopes, not HTTP 4xx):
+- Target user must exist in the caller's organization (else `{success:false, error:'User not found in this organization'}`)
+- Target user must be deactivated (else `'User is already active'`)
+- Target user must not be deleted (else `'User is deleted'`)
 
 ---
 

--- a/frontend/src/services/api/rpc-registry.generated.ts
+++ b/frontend/src/services/api/rpc-registry.generated.ts
@@ -70,6 +70,7 @@ export type EnvelopeRpcs =
   | 'reactivate_organization_unit'
   | 'reactivate_role'
   | 'reactivate_schedule_template'
+  | 'reactivate_user'
   | 'reactivate_var_partnership'
   | 'register_client'
   | 'remove_client_address'

--- a/frontend/src/types/database.types.ts
+++ b/frontend/src/types/database.types.ts
@@ -1295,6 +1295,10 @@ export type Database = {
         Args: { p_template_id: string }
         Returns: Json
       }
+      reactivate_user: {
+        Args: { p_reason?: string; p_user_id: string }
+        Returns: Json
+      }
       reactivate_var_partnership: {
         Args: {
           p_new_contract_end_date?: string
@@ -4469,7 +4473,7 @@ export type Database = {
       users: {
         Row: {
           accessible_organizations: string[] | null
-          correlation_id: string | null
+          correlation_id: string
           created_at: string | null
           current_org_unit_id: string | null
           current_organization_id: string | null
@@ -4487,7 +4491,7 @@ export type Database = {
         }
         Insert: {
           accessible_organizations?: string[] | null
-          correlation_id?: string | null
+          correlation_id?: string
           created_at?: string | null
           current_org_unit_id?: string | null
           current_organization_id?: string | null
@@ -4505,7 +4509,7 @@ export type Database = {
         }
         Update: {
           accessible_organizations?: string[] | null
-          correlation_id?: string | null
+          correlation_id?: string
           created_at?: string | null
           current_org_unit_id?: string | null
           current_organization_id?: string | null

--- a/infrastructure/supabase/supabase/functions/manage-user/index.ts
+++ b/infrastructure/supabase/supabase/functions/manage-user/index.ts
@@ -20,7 +20,7 @@
  *
  * Operations:
  * - deactivate: Deactivate a user within the organization (Pattern A v2 via SQL RPC)
- * - reactivate: Reactivate a deactivated user (legacy emit flow — retrofit deferred to next card)
+ * - reactivate: Reactivate a deactivated user (Pattern A v2 via SQL RPC api.reactivate_user)
  *
  * CQRS-compliant: Emits domain events:
  * - user.deactivated / user.reactivated
@@ -46,10 +46,9 @@ import {
   createSpan,
   endSpan,
 } from '../_shared/tracing-context.ts';
-import { buildEventMetadata } from '../_shared/emit-event.ts';
 
 // Deployment version tracking
-const DEPLOY_VERSION = 'v17-deactivate-sql-rpc-pivot';
+const DEPLOY_VERSION = 'v18-reactivate-sql-rpc-pivot';
 
 // CORS headers for frontend requests
 const corsHeaders = standardCorsHeaders;
@@ -83,34 +82,6 @@ interface ManageUserResponse {
    * in the frontend. Optional — consumers are not required to surface it.
    */
   eventId?: string;
-}
-
-/**
- * Get user details for validation (reactivate path only — the deactivate
- * path now delegates tenancy/idempotency checks to `api.deactivate_user`).
- */
-async function getUserDetails(
-  supabase: AnySchemaSupabaseClient,
-  userId: string,
-  orgId: string
-): Promise<{ exists: boolean; isActive: boolean; email?: string }> {
-  const { data, error } = await supabase
-    .rpc('get_user_org_details', { p_user_id: userId, p_org_id: orgId });
-
-  if (error) {
-    console.error(`[manage-user v${DEPLOY_VERSION}] Error getting user details:`, error);
-    return { exists: false, isActive: false };
-  }
-
-  if (!data?.[0]) {
-    return { exists: false, isActive: false };
-  }
-
-  return {
-    exists: true,
-    isActive: data[0].is_active,
-    email: data[0].email,
-  };
 }
 
 serve(async (req) => {
@@ -283,8 +254,7 @@ serve(async (req) => {
     //   - idempotency (already-inactive, already-deleted)
     //   - emit user.deactivated + Pattern A v2 read-back (BOTH checks per Rule 13)
     //
-    // For reactivate (legacy emit flow): retained as-is. The matching
-    // Pattern A v2 retrofit for the reactivate path is the next card.
+    // For reactivate: now Pattern A v2 via api.reactivate_user (same as deactivate).
 
     // ==========================================================================
     // DEACTIVATE PATH — SQL RPC (Pattern A v2 lives in api.deactivate_user)
@@ -339,56 +309,52 @@ serve(async (req) => {
       console.log(`[manage-user v${DEPLOY_VERSION}] deactivate_user OK, eventId=${eventId}`);
     } else {
       // ==========================================================================
-      // REACTIVATE PATH — LEGACY EMIT FLOW (retrofit deferred to next card)
+      // REACTIVATE PATH — SQL RPC (Pattern A v2 lives in api.reactivate_user)
       // ==========================================================================
-      const userDetails = await getUserDetails(supabaseAdmin, requestData.userId, orgId);
+      // Retrofitted from the legacy direct-emit flow (PR closing
+      // manage-user-reactivate-pattern-a-v2-retrofit). The RPC absorbs the
+      // not-found (404) / already-active (400) / deleted checks as success-false
+      // envelopes, mirrors api.deactivate_user, and adds the Pattern A v2
+      // read-back the legacy emit lacked. Auth unban (below, LB1) is unchanged.
+      console.log(`[manage-user v${DEPLOY_VERSION}] Calling api.reactivate_user RPC...`);
 
-      if (!userDetails.exists) {
-        return new Response(
-          JSON.stringify({ error: 'User not found in this organization' }),
-          { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-        );
-      }
-
-      if (userDetails.isActive) {
-        return new Response(
-          JSON.stringify({ error: 'User is already active' }),
-          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-        );
-      }
-
-      const now = new Date().toISOString();
-      const eventType = 'user.reactivated';
-      const eventData: Record<string, unknown> = {
-        user_id: requestData.userId,
-        org_id: orgId,
-        reactivated_at: now,
-      };
-      if (requestData.reason) {
-        eventData.reason = requestData.reason;
-      }
-
-      console.log(`[manage-user v${DEPLOY_VERSION}] Emitting ${eventType} event...`);
-
-      const { data: emittedEventId, error: eventError } = await supabaseAdmin
-        .rpc('emit_domain_event', {
-          p_stream_id: requestData.userId,
-          p_stream_type: 'user',
-          p_event_type: eventType,
-          p_event_data: eventData,
-          p_event_metadata: buildEventMetadata(tracingContext, eventType, req, {
-            user_id: user.id,
-            reason: requestData.reason || 'Manual reactivate',
-          }),
+      const { data: envelope, error: rpcError } = await supabaseUser
+        .schema('api')
+        .rpc('reactivate_user', {
+          p_user_id: requestData.userId,
+          p_reason: requestData.reason ?? null,
         });
 
-      if (eventError) {
-        console.error(`[manage-user v${DEPLOY_VERSION}] Failed to emit event:`, eventError);
-        return handleRpcError(eventError, correlationId, corsHeaders, 'reactivate user');
+      if (rpcError) {
+        console.error(`[manage-user v${DEPLOY_VERSION}] reactivate_user RPC error:`, rpcError);
+        return handleRpcError(rpcError, correlationId, corsHeaders, 'reactivate user');
       }
 
-      eventId = emittedEventId as string | undefined;
-      console.log(`[manage-user v${DEPLOY_VERSION}] Event emitted: ${eventId}`);
+      // Pattern A v2 envelope: 200 + {success:false, error, eventId?} for all
+      // handler-driven failures (idempotency, tenancy, read-back miss). Caller
+      // parses data.success, not HTTP status (adr-rpc-readback-pattern.md).
+      const env_ = (envelope ?? {}) as {
+        success?: boolean;
+        error?: string;
+        eventId?: string;
+        userId?: string;
+      };
+
+      if (!env_.success) {
+        console.warn(`[manage-user v${DEPLOY_VERSION}] reactivate_user envelope failure:`, env_.error);
+        const errorResponse: ManageUserResponse = {
+          success: false,
+          error: env_.error ?? 'Failed to reactivate user',
+          eventId: env_.eventId,
+        };
+        return new Response(JSON.stringify(errorResponse), {
+          status: 200,
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
+
+      eventId = env_.eventId;
+      console.log(`[manage-user v${DEPLOY_VERSION}] reactivate_user OK, eventId=${eventId}`);
     }
 
     // ==========================================================================

--- a/infrastructure/supabase/supabase/migrations/20260623195528_add_reactivate_user_rpc_and_correlation_not_null.sql
+++ b/infrastructure/supabase/supabase/migrations/20260623195528_add_reactivate_user_rpc_and_correlation_not_null.sql
@@ -1,0 +1,190 @@
+-- =============================================================================
+-- api.reactivate_user (Pattern A v2) + correlation_id constraint-hardening.
+-- =============================================================================
+--
+-- Card: dev/active/invite-user-route-existing-users-to-role-assign/ (epic PR 2);
+-- closes parked dev/archived/manage-user-reactivate-pattern-a-v2-retrofit/.
+-- Architect-reviewed (software-architect-dbc, 2026-06-23, epic plan + PR #83
+-- Finding 4 deferral).
+--
+-- (A) Adds api.reactivate_user — a verbatim mirror of the deployed
+-- api.deactivate_user (post-PR1, incl. the correlation chain), with the
+-- idempotency guards inverted (already-ACTIVE / deleted -> success-false
+-- envelope), event_type user.reactivated, and the read-back predicate
+-- is_active = true. handle_user_reactivated + router arm + AsyncAPI already
+-- exist. The manage-user Edge Function reactivate path is retrofitted (separate
+-- commit) to call this RPC then auth-unban (ban_duration:'none', LB1).
+--
+-- (B) PR #83 Finding 4: harden users.correlation_id from convention to
+-- constraint. DEFAULT gen_random_uuid() makes any insert non-NULL by
+-- construction (safe even for an un-anchored path); SET NOT NULL enforces the
+-- "never NULL / one chain per user" invariant. Safe now: both insert handlers
+-- (handle_user_created, handle_user_synced_from_auth) anchor it, backfill filled
+-- the rest, and 0 NULLs remain. The DEFAULT is a non-chaining safety net only —
+-- correct chaining still comes from the anchor handlers writing the event's id.
+-- =============================================================================
+
+
+-- -----------------------------------------------------------------------------
+-- Section A — api.reactivate_user (Pattern A v2 mirror of api.deactivate_user).
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION api.reactivate_user(p_user_id uuid, p_reason text DEFAULT NULL::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $function$
+DECLARE
+    v_claims jsonb := current_setting('request.jwt.claims', true)::jsonb;
+    v_caller_id uuid := public.get_current_user_id();
+    v_org_id uuid := NULLIF(v_claims ->> 'org_id', '')::uuid;
+    v_access_blocked boolean := COALESCE((v_claims ->> 'access_blocked')::boolean, false);
+    v_target_org_id uuid;
+    v_existing_is_active boolean;
+    v_existing_deleted_at timestamptz;
+    v_corr uuid;  -- correlation
+    v_event_id uuid;
+    v_processing_error text;
+    v_now timestamptz := now();
+BEGIN
+    -- =====================================================================
+    -- PRE-EMIT GUARDS (RAISE EXCEPTION; no audit row yet)
+    -- =====================================================================
+
+    IF v_caller_id IS NULL OR v_org_id IS NULL THEN
+        RAISE EXCEPTION 'Access denied' USING ERRCODE = '42501';
+    END IF;
+
+    IF v_access_blocked THEN
+        RAISE EXCEPTION 'Access blocked: organization is deactivated'
+            USING ERRCODE = '42501';
+    END IF;
+
+    -- Permission: unscoped user.update (mirrors api.deactivate_user — the
+    -- reactivate operation is the inverse and shares its permission per the
+    -- deployed Edge Function check).
+    IF NOT public.has_permission('user.update') THEN
+        RAISE EXCEPTION 'Permission denied' USING ERRCODE = '42501';
+    END IF;
+
+    -- =====================================================================
+    -- TENANCY + IDEMPOTENCY (envelope, not RAISE)
+    -- =====================================================================
+
+    SELECT current_organization_id, is_active, deleted_at, correlation_id  -- correlation
+    INTO v_target_org_id, v_existing_is_active, v_existing_deleted_at, v_corr
+    FROM public.users
+    WHERE id = p_user_id;
+
+    -- Tenancy guard: target must be in caller's tenant. Same envelope shape
+    -- as not-found to avoid leaking user-existence across tenants.
+    IF NOT FOUND OR v_target_org_id IS DISTINCT FROM v_org_id THEN
+        RETURN jsonb_build_object(
+            'success', false,
+            'error', 'User not found in this organization'
+        );
+    END IF;
+
+    -- Idempotency: already-active target returns success-false envelope.
+    IF v_existing_is_active = true THEN
+        RETURN jsonb_build_object(
+            'success', false,
+            'error', 'User is already active'
+        );
+    END IF;
+
+    -- Idempotency: deleted target can't be reactivated.
+    IF v_existing_deleted_at IS NOT NULL THEN
+        RETURN jsonb_build_object(
+            'success', false,
+            'error', 'User is deleted'
+        );
+    END IF;
+
+    -- correlation: chain this op's events to the user's lifecycle id.
+    IF v_corr IS NOT NULL THEN
+        PERFORM set_config('app.correlation_id', v_corr::text, true);
+    END IF;
+
+    -- =====================================================================
+    -- EMIT user.reactivated EVENT
+    -- =====================================================================
+
+    v_event_id := api.emit_domain_event(
+        p_stream_id := p_user_id,
+        p_stream_type := 'user',
+        p_event_type := 'user.reactivated',
+        p_event_data := jsonb_build_object(
+            'user_id', p_user_id,
+            'org_id', v_org_id,
+            'reactivated_at', v_now,
+            'reason', p_reason
+        ),
+        p_event_metadata := jsonb_build_object(
+            'user_id', v_caller_id,
+            'organization_id', v_org_id,
+            'source', 'api.reactivate_user',
+            'reason', COALESCE(p_reason, 'Manual reactivate')
+        )
+    );
+
+    -- =====================================================================
+    -- PATTERN A v2 READ-BACK (BOTH checks per Rule 13)
+    -- =====================================================================
+
+    -- Check 1: IF NOT FOUND on the projection read-back (predicate
+    -- requires is_active = true, so absence means handler didn't update)
+    PERFORM 1
+    FROM public.users
+    WHERE id = p_user_id AND is_active = true;
+
+    IF NOT FOUND THEN
+        SELECT processing_error INTO v_processing_error
+        FROM public.domain_events WHERE id = v_event_id;
+        RETURN jsonb_build_object(
+            'success', false,
+            'error', 'Event processing failed: ' ||
+                COALESCE(v_processing_error, 'projection read-back returned no row'),
+            'eventId', v_event_id
+        );
+    END IF;
+
+    -- Check 2: processing_error on captured event_id (race-safe)
+    SELECT processing_error INTO v_processing_error
+    FROM public.domain_events WHERE id = v_event_id;
+    IF v_processing_error IS NOT NULL THEN
+        RETURN jsonb_build_object(
+            'success', false,
+            'error', 'Event processing failed: ' || v_processing_error,
+            'eventId', v_event_id
+        );
+    END IF;
+
+    RETURN jsonb_build_object(
+        'success', true,
+        'eventId', v_event_id,
+        'userId', p_user_id
+    );
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION api.reactivate_user(uuid, text) TO authenticated;
+
+COMMENT ON FUNCTION api.reactivate_user(uuid, text) IS
+$comment$Reactivates a deactivated user by emitting user.reactivated; handle_user_reactivated sets users.is_active = true. Inverse of api.deactivate_user. Does NOT modify auth.users; the Edge Function calls auth.admin.updateUserById({ban_duration:'none'}) to clear the ban after this RPC succeeds.
+
+@a4c-rpc-shape: envelope
+
+@a4c-bucket: E
+@a4c-consultant-callable: yes
+@a4c-consultant-callable-reason: No tenancy context; grant-irrelevant by default. Mirror of api.deactivate_user.
+@a4c-phase-target: none$comment$;
+
+
+-- -----------------------------------------------------------------------------
+-- Section B — constraint-hardening (PR #83 Finding 4). Pre: 0 NULL correlation_id
+-- (both insert handlers anchor it; backfill filled the rest). DEFAULT makes any
+-- future insert non-NULL by construction; SET NOT NULL enforces the invariant.
+-- -----------------------------------------------------------------------------
+ALTER TABLE public.users ALTER COLUMN correlation_id SET DEFAULT gen_random_uuid();
+ALTER TABLE public.users ALTER COLUMN correlation_id SET NOT NULL;

--- a/infrastructure/supabase/supabase/migrations/20260623195528_add_reactivate_user_rpc_and_correlation_not_null.sql
+++ b/infrastructure/supabase/supabase/migrations/20260623195528_add_reactivate_user_rpc_and_correlation_not_null.sql
@@ -185,6 +185,27 @@ $comment$Reactivates a deactivated user by emitting user.reactivated; handle_use
 -- Section B — constraint-hardening (PR #83 Finding 4). Pre: 0 NULL correlation_id
 -- (both insert handlers anchor it; backfill filled the rest). DEFAULT makes any
 -- future insert non-NULL by construction; SET NOT NULL enforces the invariant.
+--
+-- PR #84 architect review fold-ins (both non-blocking; addressed for clarity):
+--   F2 (VERY LOW): explicit pre-ALTER NULL-count guard. Fails loud with a clear
+--     message + ERRCODE P9099 (pitfall-#8 convention) rather than Postgres's
+--     generic "column \"correlation_id\" contains null values" if a NULL ever
+--     slipped past the backfill. The interpolated value is a row COUNT, not a
+--     tenant identifier — Rule 16 compliant.
+--   F1 (LOW): the two `ALTER ... SET` forms are intentionally NOT IF-NOT-EXISTS
+--     guarded — `SET DEFAULT` / `SET NOT NULL` are naturally idempotent (re-run =
+--     harmless no-op), unlike `ADD COLUMN`. Safe under repair+repush re-application.
 -- -----------------------------------------------------------------------------
+DO $$
+DECLARE
+  v_nulls bigint;
+BEGIN
+  SELECT count(*) INTO v_nulls FROM public.users WHERE correlation_id IS NULL;
+  IF v_nulls > 0 THEN
+    RAISE EXCEPTION 'Cannot harden users.correlation_id: % NULL row(s) remain — backfill incomplete', v_nulls
+      USING ERRCODE = 'P9099';
+  END IF;
+END $$;
+
 ALTER TABLE public.users ALTER COLUMN correlation_id SET DEFAULT gen_random_uuid();
 ALTER TABLE public.users ALTER COLUMN correlation_id SET NOT NULL;

--- a/workflows/src/types/database.types.ts
+++ b/workflows/src/types/database.types.ts
@@ -1295,6 +1295,10 @@ export type Database = {
         Args: { p_template_id: string }
         Returns: Json
       }
+      reactivate_user: {
+        Args: { p_reason?: string; p_user_id: string }
+        Returns: Json
+      }
       reactivate_var_partnership: {
         Args: {
           p_new_contract_end_date?: string
@@ -4469,7 +4473,7 @@ export type Database = {
       users: {
         Row: {
           accessible_organizations: string[] | null
-          correlation_id: string | null
+          correlation_id: string
           created_at: string | null
           current_org_unit_id: string | null
           current_organization_id: string | null
@@ -4487,7 +4491,7 @@ export type Database = {
         }
         Insert: {
           accessible_organizations?: string[] | null
-          correlation_id?: string | null
+          correlation_id?: string
           created_at?: string | null
           current_org_unit_id?: string | null
           current_organization_id?: string | null
@@ -4505,7 +4509,7 @@ export type Database = {
         }
         Update: {
           accessible_organizations?: string[] | null
-          correlation_id?: string | null
+          correlation_id?: string
           created_at?: string | null
           current_org_unit_id?: string | null
           current_organization_id?: string | null


### PR DESCRIPTION
## Why (PR 2 of 3 — invite-user epic)

Closes the long-parked `manage-user-reactivate-pattern-a-v2-retrofit` and folds in PR #83's deferred **Finding 4** (constraint-hardening). Builds on PR 1 (correlation foundation).

## What

- **New `api.reactivate_user`** — verbatim mirror of the deployed `api.deactivate_user` (incl. PR 1's correlation chain) with the idempotency guards **inverted** (already-active / deleted → success-false envelope), `event_type = user.reactivated`, and read-back predicate `is_active = true`. `user.update` permission; `@a4c-rpc-shape: envelope` + bucket-E tags mirroring its sibling. (`handle_user_reactivated` + router arm + AsyncAPI already existed.)
- **manage-user EF retrofit** — replaced the legacy direct-emit reactivate (no read-back) with `.schema('api').rpc('reactivate_user', …)` + the auth-unban (`ban_duration:'none'`, LB1), mirroring the deactivate path. The RPC envelope absorbs the old 404/400 checks. Removed now-dead `getUserDetails` + `buildEventMetadata` import; `DEPLOY_VERSION → v18`.
- **Finding 4** — `users.correlation_id` `DEFAULT gen_random_uuid()` + `SET NOT NULL`: the "never NULL / one chain per user" invariant is now **schema-enforced**, not just convention. Safe (both insert handlers anchor it; 0 NULLs). The `DEFAULT` is a non-chaining safety net; correct chaining still comes from the anchor handlers.

## Verification (dev; transactional, rolled back)

| Check | Result |
|-------|--------|
| deactivate → reactivate | `success:true`, `is_active=true`, event chains to the user's `correlation_id`, no `processing_error` |
| Idempotency | reactivate an active user → `"User is already active"` |
| Constraint | `correlation_id` now `DEFAULT gen_random_uuid()` + `NOT NULL` |
| EF | deployed clean (bundles); uses the **sanctioned `.rpc()`** pattern (not wire-tier `.from()`), so no PR #60/#61 schema-allowlist risk |
| Frontend | typecheck/lint/build green; `reactivateUser` already maps the Pattern A v2 envelope |

TS `database.types.ts` ×2 + `rpc-registry.generated.ts` regenerated (`reactivate_user` envelope RPC; `correlation_id` now non-null). On merge: archive `dev/archived/manage-user-reactivate-pattern-a-v2-retrofit/` is already archived — note its capability is now shipped. Next: epic PR 3 (invite-user routing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)