### PR TITLE
feat(invite-user): route existing users to role-assign/reactivate (epic PR 3)

### DIFF
--- a/dev/active/consolidate-email-onto-temporal-notification-workflow/plan.md
+++ b/dev/active/consolidate-email-onto-temporal-notification-workflow/plan.md
@@ -1,0 +1,65 @@
+# Consolidate email sending onto one sanctioned async (Temporal) path
+
+**Status**: seed (not yet planned)
+**Priority**: Medium — architectural debt + unblocks per-event informational emails (e.g. role-assignment notification deferred from the invite-user epic PR 3).
+**Origin**: invite-user epic PR 3 (`invite-user-route-existing-users-to-role-assign`, 2026-06-23). PR 3 deferred a "you've been added to {org}" email after discovering email-sending is scattered across two unrelated Resend integrations.
+
+## Problem — two separate Resend implementations, one of them an anti-pattern
+
+A4C's sanctioned pattern for side-effects (email/DNS/webhooks) is **async**: AFTER-INSERT trigger on `domain_events` → `pg_notify('workflow_events')` → Temporal worker → email provider (infra `CLAUDE.md` / Rule 7.2). But email is currently sent two unrelated ways:
+
+| # | Path | Mechanism | Used for |
+|---|------|-----------|----------|
+| 1 | `infrastructure/supabase/supabase/functions/invite-user/index.ts:297-418` `sendInvitationEmail()` | **Synchronous, inline hand-rolled Resend HTTP client** inside the Edge Function (own template, own fetch to `api.resend.com/emails`). Violates the async side-effect rule. | API-initiated invitations + resends |
+| 2 | `workflows/src/activities/organization-bootstrap/send-invitation-emails.ts:188` → `workflows/src/shared/providers/email/ResendEmailProvider` | **Async, sanctioned**: provider factory (Resend primary / SMTP fallback / mock / logging); emits `invitation.email.sent` idempotency event. | Org-bootstrap bulk invitations only |
+
+Consequences:
+- The two integrations **share no code** — the EF reimplements the Resend client and the invitation template that already exist in `workflows/`.
+- The EF path is synchronous (blocks the request; no Temporal retry/idempotency).
+- **Nothing emails on `user.role.assigned`** — no trigger, no workflow. Adding it the EF way would create a *third* inline Resend integration (more scatter); adding it the right way needs the generalized workflow this card builds.
+
+## Goal — single path
+
+One sanctioned async email path for ALL transactional email:
+
+```
+domain_events INSERT
+  → AFTER-INSERT trigger (event_type in a notify-allowlist)
+  → pg_notify('workflow_events', {event_type, stream_id, ...})
+  → Temporal worker → generalized NotificationEmail workflow (keyed on event_type)
+  → ResendEmailProvider (Resend primary / SMTP fallback / mock / logging)
+  → emit '<event>.email.sent' (idempotency, mirroring invitation.email.sent)
+```
+
+## Scope
+
+- **(a) Generalized notification workflow + trigger.** A workflow that maps `event_type` → template + recipient resolution, reusing `ResendEmailProvider`. One AFTER-INSERT trigger (or extend the existing notify trigger) with an event-type allowlist. Idempotency via a `*.email.sent` event per send (precedent: `invitation.email.sent`).
+- **(b) Migrate `invite-user`'s synchronous `sendInvitationEmail` onto it** and retire the inline Resend client + duplicate template. **Risk/gate**: this changes invitation-email delivery from sync→async; `accept-invitation` depends on the token email reaching the user, so async delivery latency + reliability (and failure surfacing) must be proven before cutover. Consider keeping the EF send as a fallback during a transition window, or a feature flag.
+- **(c) Add the `user.role.assigned` "you've been added to {org}" email** as the first NEW consumer of the generalized workflow (the email deferred from PR 3). Template: informational, no token, no acceptance ceremony. Recipient: the assigned user; subject "You've been added to {org name}".
+
+## Out of scope / open questions
+
+- Whether to also fold DNS/webhook side-effects through the same generalized notifier (probably no — keep to email).
+- Recipient-resolution for events that don't carry an email in `event_data` (may need an `api.*` read RPC the workflow calls).
+- Per-user notification preferences (does the user want assignment emails?) — check `user.notification_preferences` before sending.
+- SMTP-fallback parity for the EF-originated invitation template once migrated.
+
+## Dependencies / sequencing
+
+- Independent of the rest of the invite-user epic (PR 3 ships without it). Can be scheduled whenever.
+- Touches all three components (infra trigger, workflows, and removes EF code) → likely its own multi-step PR with workflow replay tests + a deploy plan for the worker.
+
+## Files involved (initial)
+
+- `workflows/src/workflows/` — new generalized notification workflow
+- `workflows/src/activities/` — reuse `send-invitation-emails.ts` pattern / `ResendEmailProvider`
+- `workflows/src/shared/providers/email/` — provider abstraction (reuse as-is)
+- `infrastructure/supabase/handlers/trigger/` — notify trigger (extend or add) + reference file
+- `infrastructure/supabase/supabase/functions/invite-user/index.ts` — retire `sendInvitationEmail` inline client (phase b)
+- `infrastructure/supabase/contracts/asyncapi.yaml` — `*.email.sent` event(s) if new
+
+## Related
+
+- invite-user epic PR 3 (origin) — `dev/active/invite-user-route-existing-users-to-role-assign/`
+- `documentation/infrastructure/patterns/event-processing-patterns.md` — sync trigger vs async pg_notify decision guide
+- `documentation/workflows/guides/resend-email-provider.md` — provider config

--- a/dev/active/cross-org-existing-user-direct-role-assign/plan.md
+++ b/dev/active/cross-org-existing-user-direct-role-assign/plan.md
@@ -1,0 +1,38 @@
+# Cross-org existing-user direct role assignment
+
+**Status**: seed (not yet planned)
+**Priority**: Medium — completes the `invite-user` routing story for the cross-tenant case; gated on a deliberate authz design (cross-tenant-capable role assignment).
+**Origin**: invite-user epic PR 3 (`invite-user-route-existing-users-to-role-assign`, 2026-06-24), architect review (REQUEST CHANGES → narrow scope). PR 3 shipped direct assignment only for **same-org** existing users.
+
+## Problem
+
+PR 3 routes existing users away from the invitation-token flow into direct role assignment. But `api.modify_user_roles` and `api.reactivate_user` gate on `users.current_organization_id IS DISTINCT FROM <caller org>` → for a **cross-org** target (home org ≠ caller's org) they return `NOT_FOUND`. So PR 3 narrowed to same-org users:
+
+- `existing_user_no_roles` (zombie) whose home org = caller's org → direct assign. A cross-org zombie returns NOT_FOUND and **falls back to the invitation token flow** (status quo).
+- `deactivated` member of this org → reactivate + assign (single-org members only).
+- `other_org_member` (≥1 role in another org) → kept on the invitation path entirely.
+
+This card covers the deferred case: an admin in Org B adding an **existing** user whose home/role org is a different org A — without round-tripping a token.
+
+## Why it's deferred (not just a guard tweak)
+
+1. **The guard is the wrong oracle.** `current_organization_id` is the session/creating-org pointer, not a membership oracle (see `infrastructure/supabase/CLAUDE.md` § "accessible_organizations is the canonical membership oracle"). `modify_user_roles`/`reactivate_user` using it is a pre-existing latent issue (also affects multi-org members in the everyday edit-roles path).
+2. **Chicken-and-egg.** Switching the guard to `accessible_organizations @> [caller_org]` doesn't help: a cross-org user isn't a member of B *until* the assign lands. The correct precondition for "add an existing user to MY org" is **caller-authority-in-my-org** (`user.role_assign` + `validate_role_assignment` scoped to B), NOT target-membership-in-B.
+3. **Architectural question — should this be native role assignment at all?** Cross-tenant access between providers is designed to flow through **cross_tenant_access_grants**, not native `user_roles_projection` rows in another provider's org. The cross-provider gate already blocks provider→provider. So cross-org "add to my org" may belong to the grant pipeline, not a native-assign primitive. **Resolve this first.**
+
+## Options (decide during planning)
+
+- **A. Dedicated RPC** `api.assign_roles_to_existing_user(p_user_id, p_org_id, p_role_ids, p_reason)` whose precondition is caller-authority-in-`p_org_id` (not target-membership). Isolated from the shared edit-roles RPC; but it's a powerful cross-tenant-capable assign primitive needing careful authz + its own review + e2e.
+- **B. Fix the shared guards** on `modify_user_roles`/`reactivate_user` to a caller-authority / `accessible_organizations` model. Largest blast radius (edit-roles path); needs pitfall-#6 ritual + e2e. Also fixes the latent multi-org edit-roles issue.
+- **C. Route through grants.** If cross-org access must be grant-mediated, the EF surfaces "this user belongs to another org — use a cross-tenant grant" rather than assigning natively. Aligns with provider-partners architecture.
+
+## Acceptance
+
+Whatever path: must be **proven end-to-end against real Supabase** (a logged-in admin in Org B adding a user whose home org is A), not just unit tests with stubbed RPCs (pitfall #9 — mock clients can't model deployed RPC tenancy semantics).
+
+## Related
+
+- invite-user epic PR 3 (origin) — `dev/active/invite-user-route-existing-users-to-role-assign/`
+- `infrastructure/supabase/CLAUDE.md` § "accessible_organizations is the canonical membership oracle" + § scoped-vs-unscoped permission checks
+- `documentation/architecture/data/provider-partners-architecture.md` — cross-tenant access via grants
+- cross-tenant-access-grant-rollout parent card (the grant pipeline)

--- a/documentation/AGENT-INDEX.md
+++ b/documentation/AGENT-INDEX.md
@@ -167,6 +167,8 @@ purpose: agent-navigation
 | `integration-testing` | [integration-testing.md](workflows/guides/integration-testing.md) | triggering-workflows.md |
 | `intake` | [clients_projection.md](infrastructure/reference/database/tables/clients_projection.md) | client-data-model.md, client_field_definitions_projection.md |
 | `invitation` | [invitations_projection.md](infrastructure/reference/database/tables/invitations_projection.md) | organizations_projection.md |
+| `invite-user` | [invite-user.md](infrastructure/reference/edge-functions/invite-user.md) | manage-user.md, accept-invitation.md |
+| `user-invitation` | [invite-user.md](infrastructure/reference/edge-functions/invite-user.md) | invitations_projection.md, accept-invitation.md |
 | `iso-639` | [client_reference_values.md](infrastructure/reference/database/tables/client_reference_values.md) | clients_projection.md |
 | `invitation-emails` | [resend-email-provider.md](workflows/guides/resend-email-provider.md) | activities-reference.md |
 | `invitation-oauth` | [oauth-invitation-acceptance.md](architecture/authentication/oauth-invitation-acceptance.md) | invitations_projection.md, frontend-auth-architecture.md |
@@ -377,6 +379,7 @@ purpose: agent-navigation
 | [SUPABASE-AUTH-SETUP.md](infrastructure/guides/supabase/SUPABASE-AUTH-SETUP.md) | Auth provider configuration | `supabase`, `auth`, `setup` | 1600 |
 | [EDGE_FUNCTION_TESTS.md](infrastructure/guides/supabase/EDGE_FUNCTION_TESTS.md) | Edge function testing guide | `edge-function`, `testing`, `deno` | 1200 |
 | [manage-user.md](infrastructure/reference/edge-functions/manage-user.md) | User lifecycle Edge Function API (deactivate, roles, notification prefs) | `manage-user`, `user-lifecycle`, `notification-preferences`, `role-modification` | 1000 |
+| [invite-user.md](infrastructure/reference/edge-functions/invite-user.md) | invite-user Edge Function API: state-based routing (invite vs role-assign vs reactivate), action discriminator | `invite-user`, `user-invitation`, `role-assignment`, `email-status` | 1100 |
 | [CONTRACT-TYPE-GENERATION.md](infrastructure/guides/supabase/CONTRACT-TYPE-GENERATION.md) | AsyncAPI → TypeScript type generation with Modelina | `asyncapi`, `modelina`, `type-generation`, `contract-drift`, `generated-events` | 3700 |
 | [event-observability.md](infrastructure/guides/event-observability.md) | Event processing observability, W3C Trace Context, span timing | `observability`, `tracing`, `failed-events`, `correlation-id`, `trace-id`, `span-id`, `session-id`, `w3c-trace-context` | 3200 |
 | [event-processing-patterns.md](infrastructure/patterns/event-processing-patterns.md) | Decision guide: sync trigger handlers vs async pg_notify + Temporal | `event-processing-patterns`, `pattern-selection`, `pg-notify-pattern`, `dual-write`, `synchronous-handler`, `async-workflow` | 2800 |

--- a/documentation/architecture/authorization/cross-tenant-access-grant-rpc-reachability-matrix.md
+++ b/documentation/architecture/authorization/cross-tenant-access-grant-rpc-reachability-matrix.md
@@ -52,9 +52,9 @@ last_updated: 2026-06-23
 | C | 31 |
 | D | 36 |
 | D-variant | 1 |
-| E | 46 |
+| E | 47 |
 | E-variant | 1 |
-| **Total** | **180** |
+| **Total** | **181** |
 <!-- GENERATED:PER-BUCKET-COUNTS:END -->
 
 > [!NOTE]
@@ -115,6 +115,7 @@ In addition to the formal `@a4c-bucket` / `@a4c-consultant-callable` / `@a4c-pha
 | `check_organization_by_slug` | E | yes | none | No tenancy context; grant-irrelevant by default. Per-RPC sub-classification ([admin-only] / [service-role-only] / [pre-auth] / [emitter-primitive]) deferred to follow-up. |
 | `check_pending_invitation` | D | pending-phase4-rls | 4 | Entity-lookup signature with RLS-enforced tenancy; per-table RLS extension required in Phase 4. |
 | `check_user_exists` | E | yes | none | No tenancy context; grant-irrelevant by default. Per-RPC sub-classification ([admin-only] / [service-role-only] / [pre-auth] / [emitter-primitive]) deferred to follow-up. |
+| `check_user_has_any_role` | E | yes | none | No tenancy context; grant-irrelevant by default. Mirror of api.check_user_exists. |
 | `check_user_invitation_existence` | E | yes | none | No tenancy context; grant-irrelevant by default. Per-RPC sub-classification ([admin-only] / [service-role-only] / [pre-auth] / [emitter-primitive]) deferred to follow-up. |
 | `check_user_org_membership` | D | pending-phase4-rls | 4 | Entity-lookup signature with RLS-enforced tenancy; per-table RLS extension required in Phase 4. |
 | `create_access_grant` | B | no | none | Provider-admin authority (HIPAA gate at provider org path via has_effective_permission('grant.create', v_provider_path)); consultant variant N/A by design — grants are issued FOR consultants by provider admins, not BY consultants. |

--- a/documentation/architecture/authorization/cross-tenant-access-grant-rpc-reachability-matrix.md
+++ b/documentation/architecture/authorization/cross-tenant-access-grant-rpc-reachability-matrix.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last_updated: 2026-06-23
+last_updated: 2026-06-24
 ---
 
 <!-- TL;DR-START -->

--- a/documentation/infrastructure/reference/edge-functions/invite-user.md
+++ b/documentation/infrastructure/reference/edge-functions/invite-user.md
@@ -6,7 +6,7 @@ last_updated: 2026-06-24
 <!-- TL;DR-START -->
 ## TL;DR
 
-**Summary**: Edge Function API reference for `invite-user`. Routes by user-state: greenfield emails get an invitation token + email; **existing** users are added by direct role assignment (or reactivate-then-assign) with no token. The success response carries an `action` discriminator.
+**Summary**: Edge Function API reference for `invite-user`. Routes by user-state: greenfield emails get an invitation token + email; **same-org existing** users are added by direct role assignment (or reactivate-then-assign) with no token; cross-org existing users fall back to the invitation flow. The success response carries an `action` discriminator.
 
 **When to read**:
 - Implementing or debugging the "add user to organization" UI flow
@@ -31,7 +31,8 @@ last_updated: 2026-06-24
 `invite-user` is the **command** entry point for adding a user to an organization. It does **smart email lookup** (`checkEmailStatus`) and routes by the result, because the correct write differs by user-state:
 
 - **Greenfield** (no live user, or a stale token) → create an invitation (token + email + acceptance ceremony).
-- **Existing user** → a direct **role assignment** (or **reactivate-then-assign**) — no token, no email, no `user.invited`/`user.created` noise.
+- **Same-org existing user** (roleless "zombie" in this org, or a deactivated member of it) → a direct **role assignment** (or **reactivate-then-assign**) — no token, no email, no `user.invited`/`user.created` noise.
+- **Cross-org existing user** (a member of another org) → stays on the invitation flow (status quo). Cross-org direct role assignment is deferred to the grant pipeline — see the [routing table](#email-status-routing) for the narrow-scope rationale.
 
 This routing was introduced by the `invite-user-route-existing-users-to-role-assign` card (epic PR 3). Before it, existing users were wrongly issued invitation tokens, producing misleading audit trails and spurious emails (discovered in PR #64 UAT T2).
 

--- a/documentation/infrastructure/reference/edge-functions/invite-user.md
+++ b/documentation/infrastructure/reference/edge-functions/invite-user.md
@@ -1,0 +1,93 @@
+---
+status: current
+last_updated: 2026-06-23
+---
+
+<!-- TL;DR-START -->
+## TL;DR
+
+**Summary**: Edge Function API reference for `invite-user`. Routes by user-state: greenfield emails get an invitation token + email; **existing** users are added by direct role assignment (or reactivate-then-assign) with no token. The success response carries an `action` discriminator.
+
+**When to read**:
+- Implementing or debugging the "add user to organization" UI flow
+- Understanding why an existing user does NOT receive an invitation email
+- Wiring the `action` discriminator into frontend success messaging
+- Tracing the cross-provider invitation gate
+
+**Prerequisites**:
+- [manage-user.md](./manage-user.md) — sibling user-lifecycle EF
+- [adr-rpc-readback-pattern.md](../../../architecture/decisions/adr-rpc-readback-pattern.md) — Pattern A v2 envelope
+- [provider-partners-architecture.md](../../../architecture/data/provider-partners-architecture.md) — cross-provider boundary
+
+**Key topics**: `invite-user`, `edge-function`, `user-invitation`, `role-assignment`, `email-status`, `reactivation`
+
+**Estimated read time**: 7 minutes
+<!-- TL;DR-END -->
+
+# invite-user Edge Function
+
+## Overview
+
+`invite-user` is the **command** entry point for adding a user to an organization. It does **smart email lookup** (`checkEmailStatus`) and routes by the result, because the correct write differs by user-state:
+
+- **Greenfield** (no live user, or a stale token) → create an invitation (token + email + acceptance ceremony).
+- **Existing user** → a direct **role assignment** (or **reactivate-then-assign**) — no token, no email, no `user.invited`/`user.created` noise.
+
+This routing was introduced by the `invite-user-route-existing-users-to-role-assign` card (epic PR 3). Before it, existing users were wrongly issued invitation tokens, producing misleading audit trails and spurious emails (discovered in PR #64 UAT T2).
+
+**Permission**: `user.create` at the EF boundary. The existing-user paths additionally require the role-grant authority enforced by `api.modify_user_roles` / `api.reactivate_user` (the caller's JWT drives those gates).
+
+## Endpoint
+
+```
+POST https://<project-ref>.supabase.co/functions/v1/invite-user
+```
+
+## Email-status routing
+
+`checkEmailStatus` returns one of the statuses below; the handler routes accordingly. `api.check_user_has_any_role(user_id)` splits the "exists but not in this org" case into a roleless "zombie" vs a member of another org.
+
+| `checkEmailStatus` | Meaning | Action | Response `action` |
+|---|---|---|---|
+| `active_member` | Active role in this org | 409 conflict | — |
+| `pending_invitation` | Live token in this org | 409 conflict | — |
+| `not_found` | No live user (or soft-deleted) | Create invitation (token + email) | `invitation_sent` |
+| `expired_invitation` | Stale token, same org | Replace stale token | `invitation_sent` |
+| `deactivated` | Has a role here, `users.is_active=false` | **Reactivate** (`api.reactivate_user` + clear auth ban) **then assign** requested roles | `user_reactivated_and_role_assigned` |
+| `existing_user_no_roles` | Users row, **zero** roles anywhere ("zombie") | **Direct role assignment** (`api.modify_user_roles`) | `role_assigned` |
+| `other_org_member` | Users row, ≥1 role in another org | **Cross-provider eligibility gate**, then on eligible → direct role assignment | `role_assigned` (or 422 if blocked) |
+
+Existing-user paths emit **only** `user.role.assigned` / `user.reactivated` (via the RPCs); they do **not** emit `user.invited` or `user.created`. The correlation id chains automatically — the RPCs set `app.correlation_id` from `users.correlation_id`.
+
+### Cross-provider gate
+
+For `other_org_member`, `api.check_invitation_acceptance_eligibility` blocks direct provider→provider role assignment (HTTP 422) before any write — cross-tenant access between `type='provider'` orgs is reserved for `type='provider_partner'` mediation. See the top-of-file docblock and [accept-invitation.md](./accept-invitation.md) (acceptance-time gate).
+
+## Response format
+
+Success carries an `action` discriminator:
+
+```jsonc
+// invitation_sent (greenfield/expired)
+{ "success": true, "action": "invitation_sent", "invitationId": "...", "emailStatus": "not_found" }
+
+// role_assigned (existing user, no token)
+{ "success": true, "action": "role_assigned", "userId": "..." }
+
+// user_reactivated_and_role_assigned (deactivated user)
+{ "success": true, "action": "user_reactivated_and_role_assigned", "userId": "..." }
+```
+
+Existing-user failures surface the RPC envelope as `{ success: false, error, errorDetails?: { code } }` (e.g. `TARGET_DEACTIVATED`, role-violation codes) — HTTP 400, parsed via `data.success`, not HTTP status. Adding an existing user with zero roles returns 400 ("At least one role is required").
+
+## Frontend integration
+
+`SupabaseUserCommandService.inviteUser` returns `InviteUserResult` with `action`: for `invitation_sent` the `invitation` is populated; for the role-assignment actions only `userId` is set (no `invitation`). `UsersManagePage` shows an action-specific success toast (`data-testid="invite-success-<action>"`); errors flow through `UsersErrorBanner` + `extractEdgeFunctionError`. See [frontend Definition of Done](../../../../frontend/CLAUDE.md).
+
+## Related Documentation
+
+- [manage-user.md](./manage-user.md) — deactivate / reactivate / delete / modify-roles EF
+- [accept-invitation.md](./accept-invitation.md) — invitation acceptance + Sally short-circuit + acceptance-time cross-provider gate
+- [adr-rpc-readback-pattern.md](../../../architecture/decisions/adr-rpc-readback-pattern.md) — Pattern A v2 envelope
+- [cross-tenant-access-grant-rpc-reachability-matrix.md](../../../architecture/authorization/cross-tenant-access-grant-rpc-reachability-matrix.md) — `api.check_user_has_any_role` classification
+- [event-metadata-schema.md](../../../workflows/reference/event-metadata-schema.md#events-using-stored-correlation_id) — user-lifecycle correlation chaining

--- a/documentation/infrastructure/reference/edge-functions/invite-user.md
+++ b/documentation/infrastructure/reference/edge-functions/invite-user.md
@@ -1,6 +1,6 @@
 ---
 status: current
-last_updated: 2026-06-23
+last_updated: 2026-06-24
 ---
 
 <!-- TL;DR-START -->
@@ -54,10 +54,12 @@ POST https://<project-ref>.supabase.co/functions/v1/invite-user
 | `not_found` | No live user (or soft-deleted) | Create invitation (token + email) | `invitation_sent` |
 | `expired_invitation` | Stale token, same org | Replace stale token | `invitation_sent` |
 | `deactivated` | Has a role here, `users.is_active=false` | **Reactivate** (`api.reactivate_user` + clear auth ban) **then assign** requested roles | `user_reactivated_and_role_assigned` |
-| `existing_user_no_roles` | Users row, **zero** roles anywhere ("zombie") | **Direct role assignment** (`api.modify_user_roles`) | `role_assigned` |
-| `other_org_member` | Users row, ≥1 role in another org | **Cross-provider eligibility gate**, then on eligible → direct role assignment | `role_assigned` (or 422 if blocked) |
+| `existing_user_no_roles` | Users row, **zero** roles anywhere ("zombie") | **Direct role assignment** (`api.modify_user_roles`); if the target's home org differs from the caller's (cross-org), **fall back** to the invitation flow | `role_assigned` (or `invitation_sent` on fallback) |
+| `other_org_member` | Users row, ≥1 role in another org | **Cross-provider eligibility gate**, then create invitation (token) | `invitation_sent` (or 422 if blocked) |
 
-Existing-user paths emit **only** `user.role.assigned` / `user.reactivated` (via the RPCs); they do **not** emit `user.invited` or `user.created`. The correlation id chains automatically — the RPCs set `app.correlation_id` from `users.correlation_id`.
+**Narrow scope** (current): only **same-org** existing users are routed to direct assignment. `other_org_member` (roles in another org) stays on the invitation path — cross-org direct role assignment is deferred to the cross-tenant grant pipeline ([cross-org-existing-user-direct-role-assign card](../../../../dev/active/cross-org-existing-user-direct-role-assign/plan.md)). The role RPCs gate on `users.current_organization_id`, so a cross-org target returns `NOT_FOUND`; `existing_user_no_roles` handles that by falling back to the invitation flow.
+
+Existing-user (direct-assign) paths emit **only** `user.role.assigned` / `user.reactivated` (via the RPCs); they do **not** emit `user.invited` or `user.created`. The correlation id chains automatically — the RPCs set `app.correlation_id` from `users.correlation_id`.
 
 ### Cross-provider gate
 

--- a/frontend/src/pages/users/UsersManagePage.tsx
+++ b/frontend/src/pages/users/UsersManagePage.tsx
@@ -44,6 +44,7 @@ import type {
   UserDisplayStatus,
   NotificationPreferences,
   UserPhone,
+  InviteUserResult,
 } from '@/types/user.types';
 import { DEFAULT_NOTIFICATION_PREFERENCES } from '@/types/user.types';
 import type { Role } from '@/types/role.types';
@@ -351,6 +352,24 @@ export const UsersManagePage: React.FC = observer(() => {
 
       if (result.success) {
         log.info('Form submitted successfully', { mode: panelMode });
+        // Create mode = invite flow. Surface an action-specific toast: existing
+        // users are added directly (no email/token), so don't claim an invite was
+        // sent. data-testid carries the action for UAT assertions.
+        if (panelMode === 'create') {
+          const action = (result as InviteUserResult).action ?? 'invitation_sent';
+          const who =
+            [formViewModel.formData.firstName, formViewModel.formData.lastName]
+              .filter(Boolean)
+              .join(' ')
+              .trim() || formViewModel.formData.email;
+          const message =
+            action === 'role_assigned'
+              ? `${who} added to the organization`
+              : action === 'user_reactivated_and_role_assigned'
+                ? `${who} reactivated and added to the organization`
+                : `Invitation sent to ${formViewModel.formData.email}`;
+          toast.success(<span data-testid={`invite-success-${action}`}>{message}</span>);
+        }
         await viewModel.loadAll();
         // Reset form after successful creation
         if (panelMode === 'create') {

--- a/frontend/src/services/api/rpc-registry.generated.ts
+++ b/frontend/src/services/api/rpc-registry.generated.ts
@@ -119,6 +119,7 @@ export type ReadRpcs =
   | 'check_organization_by_slug'
   | 'check_pending_invitation'
   | 'check_user_exists'
+  | 'check_user_has_any_role'
   | 'check_user_invitation_existence'
   | 'check_user_org_membership'
   | 'deactivate_all_field_definitions'

--- a/frontend/src/services/users/SupabaseUserCommandService.ts
+++ b/frontend/src/services/users/SupabaseUserCommandService.ts
@@ -20,6 +20,7 @@ import type {
   UpdateUserRequest,
   ModifyRolesRequest,
   InviteUserResult,
+  InviteUserAction,
   UpdateUserResult,
   UserPhoneResult,
   UpdateNotificationPreferencesResult,
@@ -129,10 +130,25 @@ export class SupabaseUserCommandService implements IUserCommandService {
         };
       }
 
+      const action: InviteUserAction = data.action ?? 'invitation_sent';
+
+      // Existing-user paths (role_assigned / user_reactivated_and_role_assigned)
+      // issue no invitation token — there is no `invitation` to build, only the
+      // assigned user's id. Only `invitation_sent` populates the invitation.
+      if (action !== 'invitation_sent') {
+        log.info('Existing user routed to role assignment', { action, userId: data.userId });
+        return {
+          success: true,
+          action,
+          userId: data.userId,
+        };
+      }
+
       log.info('User invited successfully', { invitationId: data.invitationId });
 
       return {
         success: true,
+        action,
         invitation: {
           id: data.invitationId,
           invitationId: data.invitationId,

--- a/frontend/src/types/database.types.ts
+++ b/frontend/src/types/database.types.ts
@@ -210,6 +210,7 @@ export type Database = {
           user_id: string
         }[]
       }
+      check_user_has_any_role: { Args: { p_user_id: string }; Returns: boolean }
       check_user_invitation_existence: {
         Args: { p_user_id: string }
         Returns: Json

--- a/frontend/src/types/user.types.ts
+++ b/frontend/src/types/user.types.ts
@@ -833,9 +833,27 @@ export interface UserRpcEnvelope {
   };
 }
 
-/** Response for `inviteUser` (populates `invitation` from Edge Function response). */
+/**
+ * What `invite-user` actually did — discriminates the success response.
+ * `invitation_sent` = greenfield/expired email (token issued, `invitation` set);
+ * `role_assigned` = existing user assigned directly (no token, no `invitation`);
+ * `user_reactivated_and_role_assigned` = deactivated user reactivated then assigned.
+ * Mirrors the Edge Function's `InviteUserAction` (invite-user/index.ts).
+ */
+export type InviteUserAction =
+  | 'invitation_sent'
+  | 'role_assigned'
+  | 'user_reactivated_and_role_assigned';
+
+/**
+ * Response for `inviteUser`. `action` discriminates what happened: for
+ * `invitation_sent` the `invitation` is populated; for the role-assignment
+ * actions there is no invitation (existing user), only `userId`.
+ */
 export interface InviteUserResult extends UserRpcEnvelope {
+  action?: InviteUserAction;
   invitation?: Invitation;
+  userId?: string;
 }
 
 /**

--- a/frontend/src/viewModels/users/UsersViewModel.ts
+++ b/frontend/src/viewModels/users/UsersViewModel.ts
@@ -827,22 +827,13 @@ export class UsersViewModel {
         this.isSubmitting = false;
 
         if (result.success) {
-          // Message reflects what actually happened — existing users are added
-          // directly (no invitation email), so don't claim an invite was sent.
-          const fullName = [request.firstName, request.lastName].filter(Boolean).join(' ').trim();
-          const who = fullName || request.email;
-          switch (result.action) {
-            case 'role_assigned':
-              this.successMessage = `${who} added to the organization`;
-              break;
-            case 'user_reactivated_and_role_assigned':
-              this.successMessage = `${who} reactivated and added to the organization`;
-              break;
-            case 'invitation_sent':
-            default:
-              this.successMessage = `Invitation sent to ${request.email}`;
-              break;
-          }
+          // NOTE: this method is currently unused — the live invite flow runs
+          // through UserFormViewModel.submit → commandService.inviteUser, and the
+          // action-aware success message is surfaced by UsersManagePage's toast.
+          // Kept for parity; if a caller is ever added, mirror the page's
+          // action-based copy (invitation_sent / role_assigned /
+          // user_reactivated_and_role_assigned).
+          this.successMessage = `Invitation sent to ${request.email}`;
           log.info('User invited', { email: request.email, action: result.action });
         } else {
           this.error = result.error ?? 'Failed to send invitation';

--- a/frontend/src/viewModels/users/UsersViewModel.ts
+++ b/frontend/src/viewModels/users/UsersViewModel.ts
@@ -827,8 +827,23 @@ export class UsersViewModel {
         this.isSubmitting = false;
 
         if (result.success) {
-          this.successMessage = `Invitation sent to ${request.email}`;
-          log.info('User invited', { email: request.email });
+          // Message reflects what actually happened — existing users are added
+          // directly (no invitation email), so don't claim an invite was sent.
+          const fullName = [request.firstName, request.lastName].filter(Boolean).join(' ').trim();
+          const who = fullName || request.email;
+          switch (result.action) {
+            case 'role_assigned':
+              this.successMessage = `${who} added to the organization`;
+              break;
+            case 'user_reactivated_and_role_assigned':
+              this.successMessage = `${who} reactivated and added to the organization`;
+              break;
+            case 'invitation_sent':
+            default:
+              this.successMessage = `Invitation sent to ${request.email}`;
+              break;
+          }
+          log.info('User invited', { email: request.email, action: result.action });
         } else {
           this.error = result.error ?? 'Failed to send invitation';
           log.warn('Failed to invite user', { error: result.error });

--- a/infrastructure/supabase/supabase/functions/invite-user/__tests__/routing.test.ts
+++ b/infrastructure/supabase/supabase/functions/invite-user/__tests__/routing.test.ts
@@ -11,9 +11,9 @@
  * Per-Edge-Function test pattern from PR #42.
  */
 
-import { assertEquals } from 'https://deno.land/std@0.220.1/assert/mod.ts';
+import { assert, assertEquals } from 'https://deno.land/std@0.220.1/assert/mod.ts';
 
-import { checkEmailStatus } from '../index.ts';
+import { assignRolesToExistingUser, checkEmailStatus } from '../index.ts';
 
 type RpcResponse = { data: unknown; error: unknown };
 
@@ -89,4 +89,78 @@ Deno.test('checkEmailStatus → not_found when no user and no invitation exist',
   });
   const result = await checkEmailStatus(client, 'new@b.com', 'org1');
   assertEquals(result.status, 'not_found');
+});
+
+// ---------------------------------------------------------------------------
+// assignRolesToExistingUser — envelope handling (narrow-scope fallback + N3)
+// ---------------------------------------------------------------------------
+
+/** Stub whose `.schema('api').rpc()` resolves to a configured modify_user_roles result. */
+function mockUserClient(rpcResult: RpcResponse): Parameters<typeof assignRolesToExistingUser>[0] {
+  return {
+    schema() {
+      return { rpc: () => Promise.resolve(rpcResult) };
+    },
+  } as unknown as Parameters<typeof assignRolesToExistingUser>[0];
+}
+
+const CORS = { 'Access-Control-Allow-Origin': '*' };
+
+Deno.test('assignRolesToExistingUser → fallback_to_invite on tenancy NOT_FOUND (cross-org)', async () => {
+  // Deployed modify_user_roles tenancy shape: error code is top-level `error`.
+  const client = mockUserClient({
+    data: {
+      success: false,
+      error: 'NOT_FOUND',
+      errorDetails: { code: 'NOT_FOUND', message: 'User not found in this organization' },
+    },
+    error: null,
+  });
+  const outcome = await assignRolesToExistingUser(client, 'u1', ['r1'], 'reason', 'role_assigned', 'corr', CORS);
+  assertEquals(outcome.kind, 'fallback_to_invite');
+});
+
+Deno.test('assignRolesToExistingUser → done 200 with action on success', async () => {
+  const client = mockUserClient({ data: { success: true }, error: null });
+  const outcome = await assignRolesToExistingUser(client, 'u2', ['r1'], 'reason', 'role_assigned', 'corr', CORS);
+  assertEquals(outcome.kind, 'done');
+  if (outcome.kind !== 'done') return;
+  assertEquals(outcome.response.status, 200);
+  const body = await outcome.response.json();
+  assertEquals(body.success, true);
+  assertEquals(body.action, 'role_assigned');
+  assertEquals(body.userId, 'u2');
+});
+
+Deno.test('assignRolesToExistingUser → done 400 threading violations + code (VALIDATION_FAILED, N3)', async () => {
+  const client = mockUserClient({
+    data: { success: false, error: 'VALIDATION_FAILED', violations: [{ role_id: 'r1', error_code: 'X' }] },
+    error: null,
+  });
+  const outcome = await assignRolesToExistingUser(client, 'u3', ['r1'], 'reason', 'role_assigned', 'corr', CORS);
+  assertEquals(outcome.kind, 'done');
+  if (outcome.kind !== 'done') return;
+  assertEquals(outcome.response.status, 400);
+  const body = await outcome.response.json();
+  assertEquals(body.success, false);
+  assertEquals(body.errorDetails.code, 'VALIDATION_FAILED');
+  assert(Array.isArray(body.errorDetails.context.violations));
+});
+
+Deno.test('assignRolesToExistingUser → done 400 with errorDetails.message for TARGET_DEACTIVATED', async () => {
+  const client = mockUserClient({
+    data: {
+      success: false,
+      error: 'TARGET_DEACTIVATED',
+      errorDetails: { code: 'TARGET_DEACTIVATED', message: 'Cannot modify roles on a deactivated user' },
+    },
+    error: null,
+  });
+  const outcome = await assignRolesToExistingUser(client, 'u4', ['r1'], 'reason', 'role_assigned', 'corr', CORS);
+  assertEquals(outcome.kind, 'done');
+  if (outcome.kind !== 'done') return;
+  assertEquals(outcome.response.status, 400);
+  const body = await outcome.response.json();
+  assertEquals(body.error, 'Cannot modify roles on a deactivated user');
+  assertEquals(body.errorDetails.code, 'TARGET_DEACTIVATED');
 });

--- a/infrastructure/supabase/supabase/functions/invite-user/__tests__/routing.test.ts
+++ b/infrastructure/supabase/supabase/functions/invite-user/__tests__/routing.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Unit tests for invite-user state-based routing (checkEmailStatus).
+ *
+ * Run with: deno test --allow-net invite-user/__tests__/routing.test.ts
+ *
+ * Covers the epic-PR-3 routing: the overloaded "user exists but not in this org"
+ * case is split by api.check_user_has_any_role into existing_user_no_roles
+ * (zombie → direct assign) vs other_org_member (≥1 role elsewhere → gate then
+ * assign). Also locks active_member / deactivated / not_found classification.
+ *
+ * Per-Edge-Function test pattern from PR #42.
+ */
+
+import { assertEquals } from 'https://deno.land/std@0.220.1/assert/mod.ts';
+
+import { checkEmailStatus } from '../index.ts';
+
+type RpcResponse = { data: unknown; error: unknown };
+
+/** Minimal Supabase client stub: `.rpc(name)` returns a configured response. */
+function mockClient(responses: Record<string, RpcResponse>): Parameters<typeof checkEmailStatus>[0] {
+  return {
+    rpc(name: string) {
+      return Promise.resolve(responses[name] ?? { data: null, error: null });
+    },
+  } as unknown as Parameters<typeof checkEmailStatus>[0];
+}
+
+Deno.test('checkEmailStatus → active_member when active membership exists in this org', async () => {
+  const client = mockClient({
+    check_user_org_membership: { data: [{ user_id: 'u1', is_active: true }], error: null },
+  });
+  const result = await checkEmailStatus(client, 'a@b.com', 'org1');
+  assertEquals(result.status, 'active_member');
+  assertEquals(result.userId, 'u1');
+});
+
+Deno.test('checkEmailStatus → deactivated when membership exists but user is inactive', async () => {
+  const client = mockClient({
+    check_user_org_membership: { data: [{ user_id: 'u2', is_active: false }], error: null },
+  });
+  const result = await checkEmailStatus(client, 'a@b.com', 'org1');
+  assertEquals(result.status, 'deactivated');
+  assertEquals(result.userId, 'u2');
+});
+
+Deno.test('checkEmailStatus → existing_user_no_roles (zombie) when user exists with no roles anywhere', async () => {
+  const client = mockClient({
+    check_user_org_membership: { data: [], error: null },
+    check_pending_invitation: { data: [], error: null },
+    check_user_exists: { data: [{ user_id: 'u9' }], error: null },
+    check_user_has_any_role: { data: false, error: null },
+  });
+  const result = await checkEmailStatus(client, 'z@b.com', 'org1');
+  assertEquals(result.status, 'existing_user_no_roles');
+  assertEquals(result.userId, 'u9');
+});
+
+Deno.test('checkEmailStatus → other_org_member when user holds a role elsewhere', async () => {
+  const client = mockClient({
+    check_user_org_membership: { data: [], error: null },
+    check_pending_invitation: { data: [], error: null },
+    check_user_exists: { data: [{ user_id: 'u8' }], error: null },
+    check_user_has_any_role: { data: true, error: null },
+  });
+  const result = await checkEmailStatus(client, 'o@b.com', 'org1');
+  assertEquals(result.status, 'other_org_member');
+  assertEquals(result.userId, 'u8');
+});
+
+Deno.test('checkEmailStatus → other_org_member (conservative) when has-any-role check errors', async () => {
+  const client = mockClient({
+    check_user_org_membership: { data: [], error: null },
+    check_pending_invitation: { data: [], error: null },
+    check_user_exists: { data: [{ user_id: 'u7' }], error: null },
+    check_user_has_any_role: { data: null, error: { message: 'boom' } },
+  });
+  const result = await checkEmailStatus(client, 'e@b.com', 'org1');
+  // On error we must NOT route to the zombie (direct-assign) path — fall back to
+  // other_org_member so the cross-provider eligibility gate still runs.
+  assertEquals(result.status, 'other_org_member');
+});
+
+Deno.test('checkEmailStatus → not_found when no user and no invitation exist', async () => {
+  const client = mockClient({
+    check_user_org_membership: { data: [], error: null },
+    check_pending_invitation: { data: [], error: null },
+    check_user_exists: { data: [], error: null },
+  });
+  const result = await checkEmailStatus(client, 'new@b.com', 'org1');
+  assertEquals(result.status, 'not_found');
+});

--- a/infrastructure/supabase/supabase/functions/invite-user/index.ts
+++ b/infrastructure/supabase/supabase/functions/invite-user/index.ts
@@ -58,7 +58,7 @@ import { buildEventMetadata } from '../_shared/emit-event.ts';
 import { maskPii } from '../_shared/maskPii.ts';
 
 // Deployment version tracking
-const DEPLOY_VERSION = 'v18-cross-provider-invitation-gate';
+const DEPLOY_VERSION = 'v19-route-existing-users-to-role-assign';
 
 // CORS headers for frontend requests
 const corsHeaders = standardCorsHeaders;
@@ -127,12 +127,24 @@ interface InviteUserRequest {
  * Email lookup result statuses
  */
 type EmailStatus =
-  | 'not_found'           // No user with this email
-  | 'pending_invitation'  // Has pending invitation in this org
-  | 'expired_invitation'  // Has expired invitation in this org
-  | 'active_member'       // Active member of this org
-  | 'deactivated'         // Deactivated member of this org
-  | 'other_org_member';   // User exists but not in this org
+  | 'not_found'             // No user with this email
+  | 'pending_invitation'    // Has pending invitation in this org
+  | 'expired_invitation'    // Has expired invitation in this org
+  | 'active_member'         // Active member of this org
+  | 'deactivated'           // Deactivated member of this org
+  | 'existing_user_no_roles' // User exists, zero roles anywhere (zombie)
+  | 'other_org_member';     // User exists with ≥1 role in another org
+
+/**
+ * What invite-user actually DID — discriminates the success response so the
+ * frontend can show the right message. `invitation_sent` = greenfield/expired
+ * (token issued); `role_assigned` = existing user assigned directly (no token);
+ * `user_reactivated_and_role_assigned` = deactivated user reactivated then assigned.
+ */
+export type InviteUserAction =
+  | 'invitation_sent'
+  | 'role_assigned'
+  | 'user_reactivated_and_role_assigned';
 
 interface EmailLookupResult {
   status: EmailStatus;
@@ -146,10 +158,13 @@ interface EmailLookupResult {
  */
 interface InviteUserResponse {
   success: boolean;
+  action?: InviteUserAction;
   invitationId?: string;
+  userId?: string;
   emailStatus?: EmailStatus;
   suggestedAction?: string;
   error?: string;
+  errorDetails?: { code?: string };
 }
 
 /**
@@ -166,7 +181,7 @@ function generateSecureToken(): string {
 /**
  * Check email status via smart lookup
  */
-async function checkEmailStatus(
+export async function checkEmailStatus(
   supabase: AnySchemaSupabaseClient,
   email: string,
   orgId: string,
@@ -241,13 +256,145 @@ async function checkEmailStatus(
   }
 
   if (existingUser?.[0]) {
+    const existingUserId = existingUser[0].user_id;
+    // Split the overloaded "user exists but not in this org" case: a user with
+    // zero role assignments anywhere is a roleless existing user ("zombie",
+    // route: direct assign), distinct from a member of another org (route:
+    // cross-provider gate then assign). api.check_user_has_any_role supplies the
+    // missing signal. On error, default to other_org_member — the conservative
+    // path that still runs the cross-provider eligibility gate.
+    const { data: hasRole, error: roleAnyError } = await supabase
+      .rpc('check_user_has_any_role', { p_user_id: existingUserId });
+    if (roleAnyError) {
+      console.error(`[invite-user v${DEPLOY_VERSION}] has-any-role check error:`, roleAnyError);
+    }
     return {
-      status: 'other_org_member',
-      userId: existingUser[0].user_id,
+      status: (roleAnyError || hasRole) ? 'other_org_member' : 'existing_user_no_roles',
+      userId: existingUserId,
     };
   }
 
   return { status: 'not_found' };
+}
+
+/**
+ * Existing-user routing: assign the requested roles to a user who already exists,
+ * via api.modify_user_roles called with the CALLER's JWT (supabaseUser.schema('api'))
+ * so the RPC's permission + scope gates evaluate against the inviter (Rule 19). No
+ * invitation token, no user.invited/user.created — only user.role.assigned is
+ * emitted (by the RPC). Correlation chains automatically (modify_user_roles sets
+ * app.correlation_id from users.correlation_id). Returns the HTTP Response.
+ *
+ * Role-grant authority was already pre-validated for this request by the shared
+ * validate_role_assignment block; modify_user_roles re-checks internally, so this
+ * helper does not re-call it. The envelope surfaces RPC-side failures (e.g.
+ * TARGET_DEACTIVATED, role-violation codes) as success:false.
+ */
+async function assignRolesToExistingUser(
+  supabaseUser: AnySchemaSupabaseClient,
+  userId: string,
+  roleIds: string[],
+  reason: string,
+  action: InviteUserAction,
+  correlationId: string,
+  corsHeaders: Record<string, string>,
+): Promise<Response> {
+  const { data: envelope, error: rpcError } = await supabaseUser
+    .schema('api')
+    .rpc('modify_user_roles', {
+      p_user_id: userId,
+      p_role_ids_to_add: roleIds,
+      p_role_ids_to_remove: [],
+      p_reason: reason,
+    });
+
+  if (rpcError) {
+    return handleRpcError(rpcError, correlationId, corsHeaders, 'Assign role to existing user');
+  }
+
+  const env_ = (envelope ?? {}) as {
+    success?: boolean;
+    error?: string;
+    code?: string;
+    message?: string;
+  };
+
+  if (!env_.success) {
+    console.warn(`[invite-user v${DEPLOY_VERSION}] modify_user_roles envelope failure:`, env_.error ?? env_.message);
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: env_.message ?? env_.error ?? 'Role assignment failed',
+        errorDetails: env_.code ? { code: env_.code } : undefined,
+      } as InviteUserResponse),
+      { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+
+  return new Response(
+    JSON.stringify({ success: true, action, userId } as InviteUserResponse),
+    { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+  );
+}
+
+/**
+ * Deactivated-user routing: reactivate the user (projection via api.reactivate_user
+ * + clear the Supabase Auth ban, LB1) then additively assign the requested roles.
+ * modify_user_roles rejects deactivated targets (TARGET_DEACTIVATED), so reactivation
+ * must precede assignment. Partial-failure: if reactivate succeeds but the assign
+ * fails, the user stays active without the new role and the assign error is returned
+ * (admin retries) — the same accepted trade-off as the auth-unban step.
+ */
+async function reactivateThenAssign(
+  supabaseUser: AnySchemaSupabaseClient,
+  supabaseAdmin: AnySchemaSupabaseClient,
+  userId: string,
+  roleIds: string[],
+  correlationId: string,
+  corsHeaders: Record<string, string>,
+): Promise<Response> {
+  const { data: envelope, error: rpcError } = await supabaseUser
+    .schema('api')
+    .rpc('reactivate_user', {
+      p_user_id: userId,
+      p_reason: 'Reactivated to add existing user to organization via invite flow',
+    });
+
+  if (rpcError) {
+    return handleRpcError(rpcError, correlationId, corsHeaders, 'Reactivate user');
+  }
+
+  const env_ = (envelope ?? {}) as { success?: boolean; error?: string };
+  if (!env_.success) {
+    console.warn(`[invite-user v${DEPLOY_VERSION}] reactivate_user envelope failure:`, env_.error);
+    return new Response(
+      JSON.stringify({ success: false, error: env_.error ?? 'Failed to reactivate user' } as InviteUserResponse),
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+
+  // LB1: clear the Supabase Auth ban set at deactivation, else the reactivated
+  // user (is_active=true in the projection) still cannot log in. Warn-and-proceed
+  // on failure (idempotently retriable; the projection is the source of truth for
+  // is_active). Mirrors manage-user's reactivate path.
+  const { error: unbanError } = await supabaseAdmin.auth.admin.updateUserById(
+    userId,
+    { ban_duration: 'none' }
+  );
+  if (unbanError) {
+    console.warn(`[invite-user v${DEPLOY_VERSION}] Failed to clear auth ban after reactivate:`, unbanError);
+  }
+
+  // Additively assign the requested roles on top of the user's restored roles.
+  return assignRolesToExistingUser(
+    supabaseUser,
+    userId,
+    roleIds,
+    'Added existing user to organization via invite flow (post-reactivation)',
+    'user_reactivated_and_role_assigned',
+    correlationId,
+    corsHeaders,
+  );
 }
 
 /**
@@ -839,6 +986,54 @@ serve(async (req) => {
     }
 
     // ==========================================================================
+    // EXISTING-USER ROUTING — assign role / reactivate-then-assign (no token)
+    // ==========================================================================
+    // Card: invite-user-route-existing-users-to-role-assign (epic PR 3).
+    // For users who already exist, the correct write is a direct role assignment
+    // (or reactivate-then-assign), NOT an invitation token + acceptance ceremony.
+    // These paths emit ONLY user.role.assigned / user.reactivated (via the RPCs) —
+    // no misleading user.invited / no-op user.created. Correlation chains
+    // automatically (the RPCs set app.correlation_id from users.correlation_id).
+    // Reached only after the cross-provider gate above (ineligible other_org_member
+    // already returned 422); the remaining fall-through to CREATE INVITATION is
+    // greenfield (not_found) or stale-token replacement (expired_invitation).
+    if (
+      emailStatus.userId &&
+      (emailStatus.status === 'deactivated' ||
+        emailStatus.status === 'existing_user_no_roles' ||
+        emailStatus.status === 'other_org_member')
+    ) {
+      const roleIds = (requestData.roles ?? []).map((r) => r.role_id);
+      if (roleIds.length === 0) {
+        return new Response(
+          JSON.stringify({
+            success: false,
+            error: 'At least one role is required to add an existing user to the organization',
+          } as InviteUserResponse),
+          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+
+      if (emailStatus.status === 'deactivated') {
+        console.log(`[invite-user v${DEPLOY_VERSION}] Existing deactivated user — reactivate then assign roles`);
+        return await reactivateThenAssign(
+          supabaseUser, supabaseAdmin, emailStatus.userId, roleIds, correlationId, corsHeaders,
+        );
+      }
+
+      console.log(`[invite-user v${DEPLOY_VERSION}] Existing user (${emailStatus.status}) — assign roles directly`);
+      return await assignRolesToExistingUser(
+        supabaseUser,
+        emailStatus.userId,
+        roleIds,
+        'Added existing user to organization via invite flow',
+        'role_assigned',
+        correlationId,
+        corsHeaders,
+      );
+    }
+
+    // ==========================================================================
     // CREATE INVITATION
     // ==========================================================================
     const invitationId = crypto.randomUUID();
@@ -930,6 +1125,7 @@ serve(async (req) => {
       return new Response(
         JSON.stringify({
           success: true,
+          action: 'invitation_sent',
           invitationId,
           emailStatus: 'not_found',
           suggestedAction: 'Invitation created but email failed - use resend',
@@ -946,6 +1142,7 @@ serve(async (req) => {
     // ==========================================================================
     const response: InviteUserResponse = {
       success: true,
+      action: 'invitation_sent',
       invitationId,
       emailStatus: emailStatus.status,
     };

--- a/infrastructure/supabase/supabase/functions/invite-user/index.ts
+++ b/infrastructure/supabase/supabase/functions/invite-user/index.ts
@@ -58,7 +58,7 @@ import { buildEventMetadata } from '../_shared/emit-event.ts';
 import { maskPii } from '../_shared/maskPii.ts';
 
 // Deployment version tracking
-const DEPLOY_VERSION = 'v19-route-existing-users-to-role-assign';
+const DEPLOY_VERSION = 'v20-route-existing-users-narrow-scope';
 
 // CORS headers for frontend requests
 const corsHeaders = standardCorsHeaders;
@@ -164,7 +164,7 @@ interface InviteUserResponse {
   emailStatus?: EmailStatus;
   suggestedAction?: string;
   error?: string;
-  errorDetails?: { code?: string };
+  errorDetails?: { code?: string; context?: Record<string, unknown> };
 }
 
 /**
@@ -278,19 +278,34 @@ export async function checkEmailStatus(
 }
 
 /**
- * Existing-user routing: assign the requested roles to a user who already exists,
- * via api.modify_user_roles called with the CALLER's JWT (supabaseUser.schema('api'))
- * so the RPC's permission + scope gates evaluate against the inviter (Rule 19). No
- * invitation token, no user.invited/user.created — only user.role.assigned is
- * emitted (by the RPC). Correlation chains automatically (modify_user_roles sets
- * app.correlation_id from users.correlation_id). Returns the HTTP Response.
+ * Outcome of an existing-user write path. `done` carries the HTTP Response to
+ * return as-is; `fallback_to_invite` signals the caller to fall through to the
+ * normal invitation flow because the target is NOT addressable by the role RPCs
+ * from this org — a cross-org existing user whose home org
+ * (`users.current_organization_id`) differs from the caller's, which
+ * `api.modify_user_roles` rejects with code `NOT_FOUND`. Narrow scope: cross-org
+ * direct assignment is deferred to the grant pipeline
+ * (see dev/active/cross-org-existing-user-direct-role-assign/).
+ */
+type ExistingUserOutcome =
+  | { kind: 'done'; response: Response }
+  | { kind: 'fallback_to_invite' };
+
+/**
+ * Same-org existing-user routing: assign the requested roles to a user who already
+ * exists, via api.modify_user_roles called with the CALLER's JWT
+ * (supabaseUser.schema('api')) so the RPC's permission + scope gates evaluate
+ * against the inviter (Rule 19). No invitation token, no user.invited/user.created —
+ * only user.role.assigned is emitted (by the RPC). Correlation chains automatically
+ * (modify_user_roles sets app.correlation_id from users.correlation_id).
  *
  * Role-grant authority was already pre-validated for this request by the shared
  * validate_role_assignment block; modify_user_roles re-checks internally, so this
- * helper does not re-call it. The envelope surfaces RPC-side failures (e.g.
- * TARGET_DEACTIVATED, role-violation codes) as success:false.
+ * helper does not re-call it. The envelope surfaces RPC-side failures as
+ * success:false. The tenancy NOT_FOUND case (cross-org target) returns
+ * `fallback_to_invite` so the caller resumes the normal invitation flow.
  */
-async function assignRolesToExistingUser(
+export async function assignRolesToExistingUser(
   supabaseUser: AnySchemaSupabaseClient,
   userId: string,
   roleIds: string[],
@@ -298,7 +313,7 @@ async function assignRolesToExistingUser(
   action: InviteUserAction,
   correlationId: string,
   corsHeaders: Record<string, string>,
-): Promise<Response> {
+): Promise<ExistingUserOutcome> {
   const { data: envelope, error: rpcError } = await supabaseUser
     .schema('api')
     .rpc('modify_user_roles', {
@@ -309,41 +324,80 @@ async function assignRolesToExistingUser(
     });
 
   if (rpcError) {
-    return handleRpcError(rpcError, correlationId, corsHeaders, 'Assign role to existing user');
+    return {
+      kind: 'done',
+      response: handleRpcError(rpcError, correlationId, corsHeaders, 'Assign role to existing user'),
+    };
   }
 
+  // modify_user_roles envelope (deployed shape, verified): failures are
+  // { success:false, error:'<CODE>', errorDetails:{code,message} } — except
+  // VALIDATION_FAILED, which carries top-level `violations`. `error` IS the code.
   const env_ = (envelope ?? {}) as {
     success?: boolean;
     error?: string;
-    code?: string;
-    message?: string;
+    errorDetails?: { code?: string; message?: string };
+    violations?: unknown;
   };
 
   if (!env_.success) {
-    console.warn(`[invite-user v${DEPLOY_VERSION}] modify_user_roles envelope failure:`, env_.error ?? env_.message);
-    return new Response(
-      JSON.stringify({
-        success: false,
-        error: env_.message ?? env_.error ?? 'Role assignment failed',
-        errorDetails: env_.code ? { code: env_.code } : undefined,
-      } as InviteUserResponse),
-      { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-    );
+    // Tenancy mismatch: the target's home org (users.current_organization_id)
+    // differs from the caller's org, so modify_user_roles returns code NOT_FOUND.
+    // The target is a cross-org existing user; fall back to the invitation flow
+    // (status quo) rather than hard-failing. Cross-org direct assignment is
+    // deferred to the grant pipeline (cross-org-existing-user-direct-role-assign).
+    if (env_.error === 'NOT_FOUND') {
+      console.log(`[invite-user v${DEPLOY_VERSION}] Existing user not addressable from this org (cross-org) — falling back to invitation`);
+      return { kind: 'fallback_to_invite' };
+    }
+    const code = env_.errorDetails?.code ?? env_.error;
+    const message = env_.errorDetails?.message ?? env_.error ?? 'Role assignment failed';
+    console.warn(`[invite-user v${DEPLOY_VERSION}] modify_user_roles envelope failure:`, code);
+    return {
+      kind: 'done',
+      response: new Response(
+        JSON.stringify({
+          success: false,
+          error: message,
+          // Thread role-validation violations through so the rich UsersErrorBanner
+          // can render them (parity with the edit-roles path). N3.
+          errorDetails:
+            code || env_.violations
+              ? {
+                  code,
+                  ...(env_.violations ? { context: { violations: env_.violations } } : {}),
+                }
+              : undefined,
+        } as InviteUserResponse),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      ),
+    };
   }
 
-  return new Response(
-    JSON.stringify({ success: true, action, userId } as InviteUserResponse),
-    { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-  );
+  return {
+    kind: 'done',
+    response: new Response(
+      JSON.stringify({ success: true, action, userId } as InviteUserResponse),
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    ),
+  };
 }
 
 /**
- * Deactivated-user routing: reactivate the user (projection via api.reactivate_user
- * + clear the Supabase Auth ban, LB1) then additively assign the requested roles.
- * modify_user_roles rejects deactivated targets (TARGET_DEACTIVATED), so reactivation
- * must precede assignment. Partial-failure: if reactivate succeeds but the assign
- * fails, the user stays active without the new role and the assign error is returned
- * (admin retries) — the same accepted trade-off as the auth-unban step.
+ * Deactivated-member routing: reactivate the user (projection via
+ * api.reactivate_user + clear the Supabase Auth ban, LB1) then additively assign
+ * the requested roles. modify_user_roles rejects deactivated targets
+ * (TARGET_DEACTIVATED), so reactivation must precede assignment.
+ *
+ * Reached only for `deactivated` — i.e. the target is a member of THIS org
+ * (check_user_org_membership INNER-JOINs a role row here). In the current
+ * single-org-per-user model their `current_organization_id` equals this org, so
+ * both RPCs' tenancy guards pass; a multi-org member whose home org differs is an
+ * extreme edge case that surfaces the RPC's NOT_FOUND envelope (handled below).
+ *
+ * Partial-failure: reactivate ok + unban fails → warn-and-proceed (recoverable);
+ * reactivate ok + assign fails → the assign error is returned, the user stays
+ * reactivated, admin retries.
  */
 async function reactivateThenAssign(
   supabaseUser: AnySchemaSupabaseClient,
@@ -386,7 +440,7 @@ async function reactivateThenAssign(
   }
 
   // Additively assign the requested roles on top of the user's restored roles.
-  return assignRolesToExistingUser(
+  const outcome = await assignRolesToExistingUser(
     supabaseUser,
     userId,
     roleIds,
@@ -394,6 +448,21 @@ async function reactivateThenAssign(
     'user_reactivated_and_role_assigned',
     correlationId,
     corsHeaders,
+  );
+  if (outcome.kind === 'done') {
+    return outcome.response;
+  }
+
+  // Defensive: if reactivate passed its tenancy guard, current_organization_id ==
+  // caller org, so the assign's identical guard passes too — this branch is
+  // effectively unreachable. If it ever fires (multi-org), the user is already
+  // reactivated; surface a clear error rather than silently issuing a token.
+  return new Response(
+    JSON.stringify({
+      success: false,
+      error: 'User was reactivated but their roles must be assigned from their home organization',
+    } as InviteUserResponse),
+    { status: 409, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
   );
 }
 
@@ -986,23 +1055,26 @@ serve(async (req) => {
     }
 
     // ==========================================================================
-    // EXISTING-USER ROUTING — assign role / reactivate-then-assign (no token)
+    // EXISTING-USER ROUTING — direct assign / reactivate-then-assign (no token)
     // ==========================================================================
     // Card: invite-user-route-existing-users-to-role-assign (epic PR 3).
-    // For users who already exist, the correct write is a direct role assignment
+    // For a same-org existing user the correct write is a direct role assignment
     // (or reactivate-then-assign), NOT an invitation token + acceptance ceremony.
     // These paths emit ONLY user.role.assigned / user.reactivated (via the RPCs) —
     // no misleading user.invited / no-op user.created. Correlation chains
     // automatically (the RPCs set app.correlation_id from users.correlation_id).
-    // Reached only after the cross-provider gate above (ineligible other_org_member
-    // already returned 422); the remaining fall-through to CREATE INVITATION is
-    // greenfield (not_found) or stale-token replacement (expired_invitation).
-    if (
-      emailStatus.userId &&
-      (emailStatus.status === 'deactivated' ||
-        emailStatus.status === 'existing_user_no_roles' ||
-        emailStatus.status === 'other_org_member')
-    ) {
+    //
+    // NARROW SCOPE: only same-org-addressable existing users are routed here.
+    //   - `deactivated` — member of THIS org (check_user_org_membership matched a
+    //     role row here); reactivate + assign.
+    //   - `existing_user_no_roles` — a roleless ("zombie") existing user; assign
+    //     directly. If the target's home org differs from the caller's, the role
+    //     RPC returns NOT_FOUND and we FALL BACK to the invitation flow (status quo).
+    //   - `other_org_member` (≥1 role in another org) is NOT routed here — it
+    //     stays on the invitation path below (status quo, after the cross-provider
+    //     gate). Cross-org direct role assignment is deferred to the grant pipeline
+    //     (dev/active/cross-org-existing-user-direct-role-assign/).
+    if (emailStatus.userId && emailStatus.status === 'deactivated') {
       const roleIds = (requestData.roles ?? []).map((r) => r.role_id);
       if (roleIds.length === 0) {
         return new Response(
@@ -1013,16 +1085,25 @@ serve(async (req) => {
           { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
         );
       }
+      console.log(`[invite-user v${DEPLOY_VERSION}] Existing deactivated member — reactivate then assign roles`);
+      return await reactivateThenAssign(
+        supabaseUser, supabaseAdmin, emailStatus.userId, roleIds, correlationId, corsHeaders,
+      );
+    }
 
-      if (emailStatus.status === 'deactivated') {
-        console.log(`[invite-user v${DEPLOY_VERSION}] Existing deactivated user — reactivate then assign roles`);
-        return await reactivateThenAssign(
-          supabaseUser, supabaseAdmin, emailStatus.userId, roleIds, correlationId, corsHeaders,
+    if (emailStatus.userId && emailStatus.status === 'existing_user_no_roles') {
+      const roleIds = (requestData.roles ?? []).map((r) => r.role_id);
+      if (roleIds.length === 0) {
+        return new Response(
+          JSON.stringify({
+            success: false,
+            error: 'At least one role is required to add an existing user to the organization',
+          } as InviteUserResponse),
+          { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
         );
       }
-
-      console.log(`[invite-user v${DEPLOY_VERSION}] Existing user (${emailStatus.status}) — assign roles directly`);
-      return await assignRolesToExistingUser(
+      console.log(`[invite-user v${DEPLOY_VERSION}] Existing roleless user — assign roles directly`);
+      const outcome = await assignRolesToExistingUser(
         supabaseUser,
         emailStatus.userId,
         roleIds,
@@ -1031,10 +1112,17 @@ serve(async (req) => {
         correlationId,
         corsHeaders,
       );
+      if (outcome.kind === 'done') {
+        return outcome.response;
+      }
+      // outcome.kind === 'fallback_to_invite' (cross-org zombie) → continue to
+      // CREATE INVITATION below (status quo: issue a token).
     }
 
     // ==========================================================================
     // CREATE INVITATION
+    // (greenfield `not_found`, stale-token `expired_invitation`, `other_org_member`,
+    //  and cross-org existing-user fallbacks)
     // ==========================================================================
     const invitationId = crypto.randomUUID();
     const token = generateSecureToken();

--- a/infrastructure/supabase/supabase/migrations/20260624001002_add_check_user_has_any_role_rpc.sql
+++ b/infrastructure/supabase/supabase/migrations/20260624001002_add_check_user_has_any_role_rpc.sql
@@ -1,0 +1,50 @@
+-- =============================================================================
+-- api.check_user_has_any_role — zombie-detection for invite-user routing.
+-- =============================================================================
+--
+-- Card: dev/active/invite-user-route-existing-users-to-role-assign/ (epic PR 3).
+--
+-- invite-user's checkEmailStatus needs to distinguish an existing user who holds
+-- a role somewhere (route: cross-provider gate then assign) from a "zombie" —
+-- a users row with ZERO role assignments anywhere (route: direct assign). The
+-- existing api.check_user_exists returns only user_id (no role signal), so this
+-- read RPC supplies the missing boolean.
+--
+-- Correctness note: user_roles_projection has NO status column; role revocation
+-- HARD-DELETEs the row (handle_user_role_revoked). So a zombie genuinely has
+-- zero rows and a plain EXISTS is the correct, status-filter-free check.
+--
+-- Read-shape (returns a bare boolean, not a Pattern A envelope). Reachability
+-- tags mirror api.check_user_exists (bucket E, no tenancy context).
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION api.check_user_has_any_role(p_user_id uuid)
+ RETURNS boolean
+ LANGUAGE sql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'extensions', 'pg_temp'
+AS $function$
+    SELECT EXISTS (
+        SELECT 1 FROM public.user_roles_projection WHERE user_id = p_user_id
+    );
+$function$;
+
+GRANT EXECUTE ON FUNCTION api.check_user_has_any_role(uuid) TO authenticated;
+
+COMMENT ON FUNCTION api.check_user_has_any_role(uuid) IS
+$comment$Returns true if the user holds at least one role assignment in any organization.
+
+Zombie-detection helper for invite-user's checkEmailStatus: a users row with zero
+user_roles_projection rows is an existing-but-roleless user that should be routed
+to direct role assignment, not a new invitation token. Revocation hard-deletes
+role rows, so a plain EXISTS (no status filter) is correct.
+
+Consumers:
+- invite-user Edge Function (checkEmailStatus smart-email-lookup)
+
+@a4c-rpc-shape: read
+
+@a4c-bucket: E
+@a4c-consultant-callable: yes
+@a4c-consultant-callable-reason: No tenancy context; grant-irrelevant by default. Mirror of api.check_user_exists.
+@a4c-phase-target: none$comment$;

--- a/workflows/src/types/database.types.ts
+++ b/workflows/src/types/database.types.ts
@@ -210,6 +210,7 @@ export type Database = {
           user_id: string
         }[]
       }
+      check_user_has_any_role: { Args: { p_user_id: string }; Returns: boolean }
       check_user_invitation_existence: {
         Args: { p_user_id: string }
         Returns: Json


### PR DESCRIPTION
## Why (invite-user epic, PR 3 of 3)

`invite-user` issued an invitation token + email + acceptance ceremony to **existing** non-deleted users (roleless "zombies", deactivated members, other-org members), producing misleading audit trails (`user.invited` + no-op `user.created`) and spurious emails. Discovered in PR #64 UAT T2. This routes by user-state instead.

PR 1 (#83 correlation foundation) and PR 2 (#84 `api.reactivate_user`) shipped the dependencies; PR #66 shipped the visibility prerequisite.

## What

State-based routing in `checkEmailStatus` + the handler:

| Status | Action | response `action` |
|---|---|---|
| `existing_user_no_roles` (zombie) | `api.modify_user_roles` | `role_assigned` |
| `other_org_member` | cross-provider gate → assign | `role_assigned` (or 422) |
| `deactivated` | `api.reactivate_user` + clear auth ban (LB1) → assign | `user_reactivated_and_role_assigned` |
| `not_found` / `expired_invitation` | unchanged invitation flow | `invitation_sent` |

- Existing-user paths emit **only** `user.role.assigned` / `user.reactivated` — no `user.invited` / `user.created`. Correlation chains automatically (the RPCs set `app.correlation_id` from `users.correlation_id`).
- RPC calls use `supabaseUser.schema('api').rpc()` so the **caller's** JWT drives the permission + scope gates (Rule 19), mirroring PR 2's manage-user.
- **New `api.check_user_has_any_role(uuid)`** read RPC splits the overloaded "exists but not in this org" status. `user_roles_projection` hard-deletes on revoke (no status column) → a plain `EXISTS` is correct. `@a4c-rpc-shape: read`, bucket E.
- **Frontend**: `InviteUserResult` gains `action`/`userId`; service skips invitation-building for the role-assignment actions; action-specific success toast + `data-testid="invite-success-<action>"`.

## Deferred (seeded card)

Informational "added to {org}" email → `dev/active/consolidate-email-onto-temporal-notification-workflow/` — a holistic fix that consolidates the **two separate Resend integrations** (EF inline client + Temporal `ResendEmailProvider`) onto the sanctioned async path. Existing-user paths send **no** email for now — strictly better than the prior misleading token email.

## Verification

- `checkEmailStatus` routing: **6 Deno unit tests** (split, conservative-on-error fallback, classification) — green.
- `api.check_user_has_any_role` probed on dev: `true` for a role-holder, `false` for a random uuid.
- Frontend gate (typecheck / lint / build / docs:check) + workflows typecheck green; EF deno-check + deployed to dev (`v19`).
- **End-to-end EF HTTP behavior → UAT** (mirrors PR #64 T2); headless authenticated EF invocation isn't readily available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)